### PR TITLE
58 Move domain lifecycle methods to `Entity` class

### DIFF
--- a/src/protean/__init__.py
+++ b/src/protean/__init__.py
@@ -1,6 +1,3 @@
 """Primary Module to define version and expose packages"""
 
 __version__ = '0.0.6'
-
-
-from .core.entity import Entity

--- a/src/protean/core/entity.py
+++ b/src/protean/core/entity.py
@@ -296,7 +296,7 @@ class Entity(metaclass=EntityBase):
 
         return entity
 
-    def update(self, identifier: Any, data: dict) -> 'Entity':
+    def update(self, data: dict) -> 'Entity':
         """Update a Record in the repository
 
         :param identifier: The id of the record to be updated
@@ -305,29 +305,30 @@ class Entity(metaclass=EntityBase):
         from protean.core.repository import repo_factory  # FIXME
         logger.debug(
             f'Updating existing `{self.__class__.__name__}` object with id '
-            f'{identifier} using data {data}')
+            f'{self.id} using data {data}')
 
         # Fetch Model class and connected-adapter from Repository Factory
         model_cls = repo_factory.get_model(self.__class__.__name__)
         adapter = getattr(repo_factory, self.__class__.__name__)
 
-        # Get the entity and update it
-        entity = self.__class__.get(identifier)
-        entity.update_data(data)
+        # Update entity's data attributes
+        self.update_data(data)
 
         # Do unique checks, update the record and return the Entity
         self.validate_unique(create=False)
-        adapter._update_object(model_cls.from_entity(entity))
-        return entity
+        adapter._update_object(model_cls.from_entity(self))
+
+        return self
 
     def validate_unique(self, create=True):
         """ Validate the unique constraints for the entity """
         from protean.core.repository import repo_factory  # FIXME
         # Fetch Model class and connected-adapter from Repository Factory
         model_cls = repo_factory.get_model(self.__class__.__name__)
-        
+
         # Build the filters from the unique constraints
         filters, excludes = {}, {}
+
         for field_name, field_obj in self.meta_.unique_fields:
             lookup_value = getattr(self, field_name, None)
             # Ignore empty lookup values

--- a/src/protean/core/entity.py
+++ b/src/protean/core/entity.py
@@ -3,8 +3,10 @@ import logging
 
 from collections import OrderedDict
 
+from typing import Any
+
 from protean.core.field import Field, Auto
-from protean.core.exceptions import ValidationError
+from protean.core.exceptions import ValidationError, ObjectNotFoundError
 
 logger = logging.getLogger('protean.core.entity')
 
@@ -183,6 +185,87 @@ class Entity(metaclass=EntityBase):
                 for field_name in self.meta_.declared_fields}
 
     @classmethod
+    def get(cls, identifier: Any) -> 'Entity':
+        """Get a specific Record from the Repository
+
+        :param identifier: id of the record to be fetched from the repository.
+        """
+        logger.debug(f'Lookup `{cls.__name__}` object with identifier {identifier}')
+        # Get the ID field for the entity
+        filters = {
+            cls.meta_.id_field.field_name: identifier
+        }
+
+        # Find this item in the repository or raise Error
+        results = cls.filter(page=1, per_page=1, **filters)
+        if not results:
+            raise ObjectNotFoundError(
+                f'`{cls.__name__}` object with identifier {identifier} '
+                f'does not exist.')
+
+        # Return the first result
+        return results.first
+
+    @classmethod
+    def filter(cls, page: int = 1, per_page: int = 10, order_by: list = (),
+               excludes_: dict = None, **filters) -> 'Pagination':
+        """
+        Read Record(s) from the repository. Method must return a `Pagination`
+        object
+
+        :param page: The current page number of the records to be pulled
+        :param per_page: The size of each page of the records to be pulled
+        :param order_by: The list of parameters to be used for ordering the
+        results. Use a `-` before the parameter name to sort in descending
+        order and if not ascending order.
+        :param excludes_: Objects with these properties will be excluded
+        from the results
+
+        :return Returns a `Pagination` object that holds the filtered results
+        """
+        from protean.core.repository import repo_factory  # FIXME
+        logger.debug(
+            f'Query `{cls.__name__}` objects with filters {filters} and '
+            f'order results by {order_by}')
+
+        # Fetch Model class and connected-adapter from Repository Factory
+        model_cls = repo_factory.get_model(cls.__name__)
+        adapter = getattr(repo_factory, cls.__name__)
+
+        # order_by clause must be list of keys
+        order_by = model_cls.opts_.order_by if not order_by else order_by
+        if not isinstance(order_by, (list, tuple)):
+            order_by = [order_by]
+
+        # default excludes to a dictionary
+        excludes_ = excludes_ or {}
+
+        # Call the read method of the repository
+        results = adapter._filter_objects(page, per_page, order_by, excludes_, **filters)
+
+        # Convert the returned results to entity and return it
+        entity_items = []
+        for item in results.items:
+            entity_items.append(model_cls.to_entity(item))
+        results.items = entity_items
+
+        return results
+
+    @classmethod
+    def exists(cls, excludes_, **filters):
+        """ Return `True` if objects matching the provided filters and excludes
+        exist if not return false.
+
+        Call the filter query by default. Can be overridden for better and
+        quicker implementations.
+
+        :param excludes_: entities without this combination of field name and
+        values will be returned
+        """
+        results = cls.filter(page=1, per_page=1, excludes_=excludes_, **filters)
+        return bool(results)
+
+    @classmethod
     def create(cls, *args, **kwargs) -> 'Entity':
         """Create a new record in the repository"""
         from protean.core.repository import repo_factory  # FIXME
@@ -197,7 +280,7 @@ class Entity(metaclass=EntityBase):
         entity = cls(*args, **kwargs)
 
         # Do unique checks, create this object and return it
-        # self.validate_unique(entity)  # FIXME
+        entity.validate_unique()
 
         # Build the model object and create it
         model_obj = adapter._create_object(model_cls.from_entity(entity))
@@ -212,3 +295,70 @@ class Entity(metaclass=EntityBase):
                 setattr(entity, field_name, field_val)
 
         return entity
+
+    def update(self, identifier: Any, data: dict) -> 'Entity':
+        """Update a Record in the repository
+
+        :param identifier: The id of the record to be updated
+        :param data: A dictionary of record properties to be updated
+        """
+        from protean.core.repository import repo_factory  # FIXME
+        logger.debug(
+            f'Updating existing `{self.__class__.__name__}` object with id '
+            f'{identifier} using data {data}')
+
+        # Fetch Model class and connected-adapter from Repository Factory
+        model_cls = repo_factory.get_model(self.__class__.__name__)
+        adapter = getattr(repo_factory, self.__class__.__name__)
+
+        # Get the entity and update it
+        entity = self.__class__.get(identifier)
+        entity.update_data(data)
+
+        # Do unique checks, update the record and return the Entity
+        self.validate_unique(create=False)
+        adapter._update_object(model_cls.from_entity(entity))
+        return entity
+
+    def validate_unique(self, create=True):
+        """ Validate the unique constraints for the entity """
+        from protean.core.repository import repo_factory  # FIXME
+        # Fetch Model class and connected-adapter from Repository Factory
+        model_cls = repo_factory.get_model(self.__class__.__name__)
+        
+        # Build the filters from the unique constraints
+        filters, excludes = {}, {}
+        for field_name, field_obj in self.meta_.unique_fields:
+            lookup_value = getattr(self, field_name, None)
+            # Ignore empty lookup values
+            if lookup_value in Field.empty_values:
+                continue
+            # Ignore identifiers on updates
+            if not create and field_obj.identifier:
+                excludes[field_name] = lookup_value
+                continue
+            filters[field_name] = lookup_value
+
+        # Lookup the objects by the filters and raise error on results
+        for filter_key, lookup_value in filters.items():
+            if self.exists(excludes, **{filter_key: lookup_value}):
+                field_obj = self.meta_.declared_fields[filter_key]
+                field_obj.fail('unique',
+                               model_name=model_cls.opts_.model_name,
+                               field_name=filter_key)
+
+    def delete(self):
+        """Delete a Record from the Repository
+        
+        FIXME: Return True or False to indicate an object was deleted, 
+               rather than the count of records deleted
+        """
+        from protean.core.repository import repo_factory  # FIXME
+
+        # Fetch Model class and connected-adapter from Repository Factory
+        adapter = getattr(repo_factory, self.__class__.__name__)
+
+        filters = {
+            self.__class__.meta_.id_field.field_name: self.id
+        }
+        return adapter._delete_objects(**filters)

--- a/src/protean/core/entity.py
+++ b/src/protean/core/entity.py
@@ -155,7 +155,7 @@ class Entity(metaclass=EntityBase):
         except ValidationError as err:
             self.errors[field_name] = err.messages
 
-    def update(self, data):
+    def update_data(self, data):
         """
         Update the entity with the given set of values
 

--- a/src/protean/core/field/base.py
+++ b/src/protean/core/field/base.py
@@ -32,7 +32,7 @@ class Field(metaclass=ABCMeta):
     # Default error messages for various kinds of errors.
     default_error_messages = {
         'invalid': 'Value is not a valid type for this field.',
-        'unique': '`{schema_name:s}` with this `{field_name:s}` already exists.',
+        'unique': '`{model_name:s}` with this `{field_name:s}` already exists.',
         'required': 'This field is required.',
         'invalid_choice': 'Value `{value!r}` is not a valid choice. '
                           'Must be one of {choices!r}',

--- a/src/protean/core/repository/__init__.py
+++ b/src/protean/core/repository/__init__.py
@@ -1,10 +1,10 @@
 """Package for defining interfaces for Repository Implementations"""
 
-from .base import BaseRepository, BaseSchema, SchemaOptions, \
+from .base import BaseAdapter, BaseModel, ModelOptions, \
     BaseConnectionHandler
-from .factory import RepositoryFactory, repo
+from .factory import RepositoryFactory, repo_factory
 from .pagination import Pagination
 
-__all__ = ('BaseRepository', 'BaseSchema', 'SchemaOptions',
-           'BaseConnectionHandler', 'RepositoryFactory', 'repo',
+__all__ = ('BaseAdapter', 'BaseModel', 'ModelOptions',
+           'BaseConnectionHandler', 'RepositoryFactory', 'repo_factory',
            'Pagination')

--- a/src/protean/core/repository/base.py
+++ b/src/protean/core/repository/base.py
@@ -7,9 +7,8 @@ from abc import abstractmethod
 from typing import Any
 
 from protean.core.entity import Entity
-from protean.core.field import Field, Auto
-from protean.core.exceptions import ValidationError, ConfigurationError, \
-    ObjectNotFoundError
+from protean.core.field import Auto
+from protean.core.exceptions import ConfigurationError
 from protean.utils.meta import OptionsMeta
 from protean.utils import inflection
 
@@ -40,169 +39,17 @@ class BaseAdapter(metaclass=ABCMeta):
         object
         """
 
-    def get(self, identifier: Any) -> Entity:
-        """Get a specific Record from the Repository
-
-        :param identifier: id of the record to be fetched from the repository.
-
-        """
-        logger.debug(
-            f'Lookup `{self.model_name}` object with identifier {identifier}')
-        # Get the ID field for the entity
-        filters = {
-            self.entity_cls.meta_.id_field.field_name: identifier
-        }
-
-        # Find this item in the repository or raise Error
-        results = self.filter(page=1, per_page=1, **filters)
-        if not results:
-            raise ObjectNotFoundError(
-                f'`{self.model_name}` object with identifier {identifier} '
-                f'does not exist.')
-
-        # Return the first result
-        return results.first
-
-    def filter(self, page: int = 1, per_page: int = 10, order_by: list = (),
-               excludes_: dict = None, **filters) -> Pagination:
-        """
-        Read Record(s) from the repository. Method must return a `Pagination`
-        object
-
-        :param page: The current page number of the records to be pulled
-        :param per_page: The size of each page of the records to be pulled
-        :param order_by: The list of parameters to be used for ordering the
-        results. Use a `-` before the parameter name to sort in descending
-        order and if not ascending order.
-        :param excludes_: Objects with these properties will be excluded
-        from the results
-
-        :return Returns a `Pagination` object that holds the filtered results
-        """
-        logger.debug(
-            f'Query `{self.model_name}` objects with filters {filters} and '
-            f'order results by {order_by}')
-
-        # order_by clause must be list of keys
-        order_by = self.model_cls.opts_.order_by if not order_by else order_by
-        if not isinstance(order_by, (list, tuple)):
-            order_by = [order_by]
-
-        # default excludes to a dictionary
-        excludes_ = excludes_ or {}
-
-        # Call the read method of the repository
-        results = self._filter_objects(page, per_page, order_by, excludes_,
-                                       **filters)
-
-        # Convert the returned results to entity and return it
-        entity_items = []
-        for item in results.items:
-            entity_items.append(self.model_cls.to_entity(item))
-        results.items = entity_items
-
-        return results
-
-    def exists(self, excludes_, **filters):
-        """ Return `True` if objects matching the provided filters and excludes
-        exist if not return false.
-
-        Call the filter query by default. Can be overridden for better and
-        quicker implementations.
-
-        :param excludes_: entities without this combination of field name and
-        values will be returned
-        """
-        results = self.filter(page=1, per_page=1, excludes_=excludes_, **filters)
-        return bool(results)
-
     @abstractmethod
     def _create_object(self, model_obj: Any):
         """Create a new model object from the entity"""
-
-    def create(self, *args, **kwargs) -> Entity:
-        """Create a new record in the repository"""
-        logger.debug(
-            f'Creating new `{self.model_name}` object using data {kwargs}')
-
-        # Build the entity from the input arguments
-        entity = self.entity_cls(*args, **kwargs)
-
-        # Do unique checks, create this object and return it
-        self.validate_unique(entity)
-
-        # Build the model object and create it
-        model_obj = self._create_object(
-            self.model_cls.from_entity(entity))
-
-        # Update the auto fields of the entity
-        for field_name, field_obj in entity.meta_.declared_fields.items():
-            if isinstance(field_obj, Auto):
-                if isinstance(model_obj, dict):
-                    field_val = model_obj[field_name]
-                else:
-                    field_val = getattr(model_obj, field_name)
-                setattr(entity, field_name, field_val)
-
-        return entity
 
     @abstractmethod
     def _update_object(self, model_obj: Any):
         """Update a model object in the repository and return it"""
 
-    def update(self, identifier: Any, data: dict) -> Entity:
-        """Update a Record in the repository
-
-        :param identifier: The id of the record to be updated
-        :param data: A dictionary of record properties to be updated
-        """
-        logger.debug(
-            f'Updating existing `{self.model_name}` object with id '
-            f'{identifier} using data {data}')
-
-        # Get the entity and update it
-        entity = self.get(identifier)
-        entity.update_data(data)
-
-        # Do unique checks, update the record and return the Entity
-        self.validate_unique(entity, create=False)
-        self._update_object(
-            self.model_cls.from_entity(entity))
-        return entity
-
-    def validate_unique(self, entity, create=True):
-        """ Validate the unique constraints for the entity """
-        # Build the filters from the unique constraints
-        filters, excludes = {}, {}
-        for field_name, field_obj in entity.meta_.unique_fields:
-            lookup_value = getattr(entity, field_name, None)
-            # Ignore empty lookup values
-            if lookup_value in Field.empty_values:
-                continue
-            # Ignore identifiers on updates
-            if not create and field_obj.identifier:
-                excludes[field_name] = lookup_value
-                continue
-            filters[field_name] = lookup_value
-
-        # Lookup the objects by the filters and raise error on results
-        for filter_key, lookup_value in filters.items():
-            if self.exists(excludes, **{filter_key: lookup_value}):
-                field_obj = entity.meta_.declared_fields[filter_key]
-                field_obj.fail('unique',
-                               model_name=self.model_name,
-                               field_name=filter_key)
-
     @abstractmethod
     def _delete_objects(self, **filters):
         """Delete a Record from the Repository"""
-
-    def delete(self, identifier: Any):
-        """Delete a Record from the Repository"""
-        filters = {
-            self.entity_cls.meta_.id_field.field_name: identifier
-        }
-        return self._delete_objects(**filters)
 
 
 class ModelOptions(object):

--- a/src/protean/core/repository/base.py
+++ b/src/protean/core/repository/base.py
@@ -162,7 +162,7 @@ class BaseAdapter(metaclass=ABCMeta):
 
         # Get the entity and update it
         entity = self.get(identifier)
-        entity.update(data)
+        entity.update_data(data)
 
         # Do unique checks, update the record and return the Entity
         self.validate_unique(entity, create=False)

--- a/src/protean/core/repository/factory.py
+++ b/src/protean/core/repository/factory.py
@@ -13,7 +13,12 @@ logger = logging.getLogger('protean.repository')
 
 
 class RepositoryFactory:
-    """Repository Factory interface to retrieve Resource Objects from Repositories"""
+    """Repository Factory interface to retrieve Resource Objects from Repositories
+
+    FIXME RepositoryFactory should prepare adapter objects JIT, so that connections
+        are kept open only for the necessary duration. Once the request is handled, it should
+        be let go.
+    """
 
     def __init__(self):
         """"Initialize repository factory"""

--- a/src/protean/core/repository/factory.py
+++ b/src/protean/core/repository/factory.py
@@ -63,7 +63,8 @@ class RepositoryFactory:
 
         # Register the model if it does not exist
         model_name = model_cls.__name__
-        if not self._registry.get(model_name):
+        entity_name = model_cls.Meta.entity.__name__
+        if not self._registry.get(entity_name):
             # Lookup the connection details for the model
             try:
                 conn_info = self.repositories[model_cls.opts_.bind]
@@ -83,18 +84,18 @@ class RepositoryFactory:
                     conn_handler.get_connection()
 
             # Finally register the model against the provider repository
-            repo_cls = repo_cls or provider.Repository
-            self._registry[model_name] = \
+            repo_cls = repo_cls or provider.Adapter
+            self._registry[entity_name] = \
                 repo_cls(self.connections[model_cls.opts_.bind], model_cls)
             logger.debug(
-                f'Registered model {model_name} with repository provider '
+                f'Registered model {model_name} for entity {entity_name} with repository provider '
                 f'{conn_info["PROVIDER"]}.')
 
     def __getattr__(self, model_name):
         try:
             return self._registry[model_name]
         except KeyError:
-            raise AssertionError('Unregistered Model')
+            raise AssertionError('Unregistered Model {model_name}')
 
     def close_connections(self):
         """ Close all connections registered with the repository """

--- a/src/protean/core/repository/factory.py
+++ b/src/protean/core/repository/factory.py
@@ -18,6 +18,7 @@ class RepositoryFactory:
     def __init__(self):
         """"Initialize repository factory"""
         self._registry = {}
+        self._model_registry = {}
         self._connections = local()
         self._repositories = None
 
@@ -87,15 +88,23 @@ class RepositoryFactory:
             repo_cls = repo_cls or provider.Adapter
             self._registry[entity_name] = \
                 repo_cls(self.connections[model_cls.opts_.bind], model_cls)
+            self._model_registry[entity_name] = model_cls
             logger.debug(
                 f'Registered model {model_name} for entity {entity_name} with repository provider '
                 f'{conn_info["PROVIDER"]}.')
 
-    def __getattr__(self, model_name):
+    def get_model(self, entity_name):
+        """Retrieve Model class connected to Entity"""
         try:
-            return self._registry[model_name]
+            return self._model_registry[entity_name]
         except KeyError:
-            raise AssertionError('Unregistered Model {model_name}')
+            raise AssertionError('No Model registered for {entity_name}')
+
+    def __getattr__(self, entity_name):
+        try:
+            return self._registry[entity_name]
+        except KeyError:
+            raise AssertionError('No Model registered for {entity_name}')
 
     def close_connections(self):
         """ Close all connections registered with the repository """

--- a/src/protean/core/repository/factory.py
+++ b/src/protean/core/repository/factory.py
@@ -7,13 +7,13 @@ from threading import local
 from protean.core.exceptions import ConfigurationError
 from protean.conf import active_config
 
-from .base import BaseSchema, BaseRepository
+from .base import BaseModel, BaseAdapter
 
 logger = logging.getLogger('protean.repository')
 
 
 class RepositoryFactory:
-    """Repository Factory interface to retrieve resource repositories"""
+    """Repository Factory interface to retrieve Resource Objects from Repositories"""
 
     def __init__(self):
         """"Initialize repository factory"""
@@ -47,54 +47,54 @@ class RepositoryFactory:
             self._connections.connections = {}
             return self._connections.connections
 
-    def register(self, schema_cls, repo_cls=None):
-        """ Register the given schema with the factory
-        :param schema_cls: class of the schema to be registered
+    def register(self, model_cls, repo_cls=None):
+        """ Register the given model with the factory
+        :param model_cls: class of the model to be registered
         :param repo_cls: Optional repository class to use if not the
         `Repository` defined by the provider is userd
         """
-        if not issubclass(schema_cls, BaseSchema):
+        if not issubclass(model_cls, BaseModel):
             raise AssertionError(
-                f'Schema {schema_cls} must be subclass of `BaseSchema`')
+                f'Model {model_cls} must be subclass of `BaseModel`')
 
-        if repo_cls and not issubclass(repo_cls, BaseRepository):
+        if repo_cls and not issubclass(repo_cls, BaseAdapter):
             raise AssertionError(
-                f'Repository {repo_cls} must be subclass of `BaseRepository`')
+                f'Repository {repo_cls} must be subclass of `BaseAdapter`')
 
-        # Register the schema if it does not exist
-        schema_name = schema_cls.__name__
-        if not self._registry.get(schema_name):
-            # Lookup the connection details for the schema
+        # Register the model if it does not exist
+        model_name = model_cls.__name__
+        if not self._registry.get(model_name):
+            # Lookup the connection details for the model
             try:
-                conn_info = self.repositories[schema_cls.opts_.bind]
+                conn_info = self.repositories[model_cls.opts_.bind]
             except KeyError:
                 raise ConfigurationError(
-                    f"'{schema_cls.opts_.bind}' repository not found in "
+                    f"'{model_cls.opts_.bind}' repository not found in "
                     f"'REPOSITORIES'")
 
             # Load the repository provider
             provider = importlib.import_module(conn_info['PROVIDER'])
 
             # If no connection exists then build it
-            if schema_cls.opts_.bind not in self.connections:
+            if model_cls.opts_.bind not in self.connections:
                 conn_handler = provider.ConnectionHandler(
-                    schema_cls.opts_.bind, conn_info)
-                self._connections.connections[schema_cls.opts_.bind] = \
+                    model_cls.opts_.bind, conn_info)
+                self._connections.connections[model_cls.opts_.bind] = \
                     conn_handler.get_connection()
 
-            # Finally register the schema against the provider repository
+            # Finally register the model against the provider repository
             repo_cls = repo_cls or provider.Repository
-            self._registry[schema_name] = \
-                repo_cls(self.connections[schema_cls.opts_.bind], schema_cls)
+            self._registry[model_name] = \
+                repo_cls(self.connections[model_cls.opts_.bind], model_cls)
             logger.debug(
-                f'Registered schema {schema_name} with repository provider '
+                f'Registered model {model_name} with repository provider '
                 f'{conn_info["PROVIDER"]}.')
 
-    def __getattr__(self, schema):
+    def __getattr__(self, model_name):
         try:
-            return self._registry[schema]
+            return self._registry[model_name]
         except KeyError:
-            raise AssertionError('Unregistered Schema')
+            raise AssertionError('Unregistered Model')
 
     def close_connections(self):
         """ Close all connections registered with the repository """
@@ -105,4 +105,4 @@ class RepositoryFactory:
             conn_handler.close_connection(conn_obj)
 
 
-repo = RepositoryFactory()
+repo_factory = RepositoryFactory()

--- a/src/protean/core/tasklet.py
+++ b/src/protean/core/tasklet.py
@@ -7,13 +7,11 @@ class Tasklet:
     """Utility class to execute UseCases"""
 
     @classmethod
-    def perform(cls, repo_factory, entity_cls, usecase_cls, request_object_cls,
+    def perform(cls, entity_cls, usecase_cls, request_object_cls,
                 payload: dict, raise_error=False):
         """
         This method bundles all essential artifacts and initiates usecase
         execution.
-        :param repo_factory: The repository factory class for fetching the
-        repository
         :param entity_cls: The entity class to be used for running the usecase
         :param usecase_cls: The usecase class that will be executed by
         the tasklet.
@@ -26,13 +24,9 @@ class Tasklet:
         :type raise_error: bool
         """
 
-        # Get the Repository for the Current Model
-        repo = getattr(repo_factory, entity_cls.__name__)
-
         # Initialize the use case and request objects
-        use_case = usecase_cls(repo)
-        request_object = request_object_cls.\
-            from_dict(entity_cls, payload)
+        use_case = usecase_cls()
+        request_object = request_object_cls.from_dict(entity_cls, payload)
 
         # Run the use case and return the response
         resp = use_case.execute(request_object)

--- a/src/protean/core/tasklet.py
+++ b/src/protean/core/tasklet.py
@@ -26,7 +26,7 @@ class Tasklet:
         :type raise_error: bool
         """
 
-        # Get the Repository for the Current Schema
+        # Get the Repository for the Current Model
         repo = getattr(repo_factory, schema_cls.__name__)
 
         # Initialize the use case and request objects

--- a/src/protean/core/tasklet.py
+++ b/src/protean/core/tasklet.py
@@ -7,14 +7,14 @@ class Tasklet:
     """Utility class to execute UseCases"""
 
     @classmethod
-    def perform(cls, repo_factory, schema_cls, usecase_cls, request_object_cls,
+    def perform(cls, repo_factory, entity_cls, usecase_cls, request_object_cls,
                 payload: dict, raise_error=False):
         """
         This method bundles all essential artifacts and initiates usecase
         execution.
         :param repo_factory: The repository factory class for fetching the
         repository
-        :param schema_cls: The schema class to be used for running the usecase
+        :param entity_cls: The entity class to be used for running the usecase
         :param usecase_cls: The usecase class that will be executed by
         the tasklet.
         :param request_object_cls: The request object to be used as input to the
@@ -27,12 +27,12 @@ class Tasklet:
         """
 
         # Get the Repository for the Current Model
-        repo = getattr(repo_factory, schema_cls.__name__)
+        repo = getattr(repo_factory, entity_cls.__name__)
 
         # Initialize the use case and request objects
         use_case = usecase_cls(repo)
         request_object = request_object_cls.\
-            from_dict(schema_cls.opts_.entity_cls, payload)
+            from_dict(entity_cls, payload)
 
         # Run the use case and return the response
         resp = use_case.execute(request_object)

--- a/src/protean/core/usecase/base.py
+++ b/src/protean/core/usecase/base.py
@@ -5,7 +5,7 @@ import logging
 from abc import ABCMeta
 from abc import abstractmethod
 
-from protean.core.repository import BaseRepository
+from protean.core.repository import BaseAdapter
 from protean.core.exceptions import ObjectNotFoundError, ValidationError
 from protean.core.transport import ResponseFailure
 
@@ -15,7 +15,7 @@ logger = logging.getLogger('protean.usecase')
 class UseCase(metaclass=ABCMeta):
     """This is the base class for all UseCases"""
 
-    def __init__(self, repo: BaseRepository):
+    def __init__(self, repo: BaseAdapter):
         """Initialize UseCase with repository factory object
 
         :param repo: The repository associated with the use case

--- a/src/protean/core/usecase/base.py
+++ b/src/protean/core/usecase/base.py
@@ -5,7 +5,6 @@ import logging
 from abc import ABCMeta
 from abc import abstractmethod
 
-from protean.core.repository import BaseAdapter
 from protean.core.exceptions import ObjectNotFoundError, ValidationError
 from protean.core.transport import ResponseFailure
 
@@ -14,13 +13,6 @@ logger = logging.getLogger('protean.usecase')
 
 class UseCase(metaclass=ABCMeta):
     """This is the base class for all UseCases"""
-
-    def __init__(self, repo: BaseAdapter):
-        """Initialize UseCase with repository factory object
-
-        :param repo: The repository associated with the use case
-        """
-        self.repo = repo
 
     def execute(self, request_object):
         """Generic executor method of all UseCases"""

--- a/src/protean/core/usecase/generic.py
+++ b/src/protean/core/usecase/generic.py
@@ -46,7 +46,7 @@ class ShowUseCase(UseCase):
         identifier = request_object.identifier
 
         # Look for the object by its ID and return it
-        resource = self.repo.get(identifier)
+        resource = request_object.entity_cls.get(identifier)
         return ResponseSuccess(Status.SUCCESS, resource)
 
 
@@ -98,10 +98,10 @@ class ListUseCase(UseCase):
 
     def process_request(self, request_object):
         """Return a list of resources"""
-        resources = self.repo.filter(request_object.page,
-                                     request_object.per_page,
-                                     request_object.order_by,
-                                     **request_object.filters)
+        resources = request_object.entity_cls.filter(request_object.page,
+                                                     request_object.per_page,
+                                                     request_object.order_by,
+                                                     **request_object.filters)
         return ResponseSuccess(Status.SUCCESS, resources)
 
 
@@ -129,7 +129,7 @@ class CreateUseCase(UseCase):
     def process_request(self, request_object):
         """Process Create Resource Request"""
 
-        resource = self.repo.create(**request_object.data)
+        resource = request_object.entity_cls.create(**request_object.data)
         return ResponseSuccessCreated(resource)
 
 
@@ -169,10 +169,11 @@ class UpdateUseCase(UseCase):
     def process_request(self, request_object):
         """Process Update Resource Request"""
 
-        identifier = request_object.identifier
-
+        # Retrieve the object by its identifier
+        entity = request_object.entity_cls.get(request_object.identifier)
+    
         # Update the object and return the updated data
-        resource = self.repo.update(identifier, request_object.data)
+        resource = entity.update(data=request_object.data)
         return ResponseSuccess(Status.SUCCESS, resource)
 
 
@@ -209,8 +210,10 @@ class DeleteUseCase(UseCase):
         """Process the Delete Resource Request"""
 
         # Delete the object by its identifier
-        identifier = request_object.identifier
-        self.repo.delete(identifier)
+        entity = request_object.entity_cls.get(request_object.identifier)
+        entity.delete()
+
+        # FIXME Check for return value of `delete()`
 
         # We have successfully deleted the object.
         # Sending a 204 Response code.

--- a/src/protean/impl/repository/dict_repo.py
+++ b/src/protean/impl/repository/dict_repo.py
@@ -10,6 +10,7 @@ from operator import itemgetter
 from protean.core.field import Auto
 from protean.core.repository import BaseAdapter, BaseModel, \
     Pagination, BaseConnectionHandler
+from protean.core.exceptions import ObjectNotFoundError
 
 
 # Global in-memory store of dict data. Keyed by name, to provide
@@ -96,6 +97,12 @@ class Adapter(BaseAdapter):
         """ Update the entity record in the dictionary """
         identifier = model_obj[self.entity_cls.meta_.id_field.field_name]
         with self.conn['lock']:
+            # Check if object is present
+            if not identifier in self.conn['data'][self.model_name]:
+                raise ObjectNotFoundError(
+                    f'`{self.__class__.__name__}` object with identifier {identifier} '
+                    f'does not exist.')
+
             self.conn['data'][self.model_name][identifier] = model_obj
         return model_obj
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,24 @@
 """Module to setup Factories and other required artifacts for tests"""
 import os
+import pytest
+
+from protean.core.entity import Entity
+from protean.core import field
 
 os.environ['PROTEAN_CONFIG'] = 'tests.support.sample_config'
+
+
+@pytest.fixture(autouse=True)
+def run_around_tests():
+    """Initialize DogModel with Dict Repo"""
+    from protean.impl.repository.dict_repo import DictModel
+    from protean.core.repository import repo_factory
+
+    from tests.support.dog import DogModel
+
+    repo_factory.register(DogModel)
+
+    # A test function will be run at this point
+    yield
+
+    repo_factory.Dog.delete_all()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,18 +2,13 @@
 import os
 import pytest
 
-from protean.core.entity import Entity
-from protean.core import field
-
 os.environ['PROTEAN_CONFIG'] = 'tests.support.sample_config'
 
 
 @pytest.fixture(autouse=True)
 def run_around_tests():
     """Initialize DogModel with Dict Repo"""
-    from protean.impl.repository.dict_repo import DictModel
     from protean.core.repository import repo_factory
-
     from tests.support.dog import DogModel
 
     repo_factory.register(DogModel)

--- a/tests/core/test_cache.py
+++ b/tests/core/test_cache.py
@@ -2,7 +2,7 @@
 import time
 
 from protean.core.cache import cache
-from protean.core.repository import repo
+from protean.core.repository import repo_factory
 
 
 class TestCache:
@@ -10,7 +10,7 @@ class TestCache:
 
     @classmethod
     def teardown_class(cls):
-        repo.DogSchema.delete_all()
+        repo_factory.DogModel.delete_all()
 
     def test_init(self):
         """Test successful access to the Cache Wrapper"""
@@ -19,7 +19,7 @@ class TestCache:
     def test_add(self):
         """ Test adding and retrieving an entry to the cache """
         # Add an entity to the cache
-        dog = repo.DogSchema.create(id=1, name='Johnny', owner='John')
+        dog = repo_factory.DogModel.create(id=1, name='Johnny', owner='John')
         cache.provider.add(f'dog:{dog.id}', dog.to_dict())
 
         # Retrieve the entity
@@ -29,7 +29,7 @@ class TestCache:
     def test_set(self):
         """ Test setting an existing key and expiry of keys """
         # Set an entity to the cache
-        dog = repo.DogSchema.get(1)
+        dog = repo_factory.DogModel.get(1)
         cache.provider.set(f'dog:{dog.id}', dog.to_dict(), expiry=5)
 
         # Retrieve the entity
@@ -44,7 +44,7 @@ class TestCache:
     def test_touch(self):
         """ Test updating the expiry of key using touch """
         # Set an entity to the cache
-        dog = repo.DogSchema.get(1)
+        dog = repo_factory.DogModel.get(1)
         cache.provider.set(f'dog:{dog.id}', dog.to_dict(), expiry=1)
 
         # Retrieve the entity
@@ -60,7 +60,7 @@ class TestCache:
     def test_delete(self):
         """ Test deleting a key from the cache """
         # Set an entity to the cache
-        dog = repo.DogSchema.get(1)
+        dog = repo_factory.DogModel.get(1)
         cache.provider.set(f'dog:{dog.id}', dog.to_dict())
 
         # Retrieve the entity

--- a/tests/core/test_cache.py
+++ b/tests/core/test_cache.py
@@ -28,14 +28,14 @@ class TestCache:
 
         # Set an entity to the cache
         dog = repo_factory.Dog.get(1)
-        cache.provider.set(f'dog:{dog.id}', dog.to_dict(), expiry=5)
+        cache.provider.set(f'dog:{dog.id}', dog.to_dict(), expiry=1)
 
         # Retrieve the entity
         dog_d = cache.provider.get(f'dog:{dog.id}')
         assert dog_d == {'age': 5, 'id': 1, 'name': 'Johnny', 'owner': 'John'}
 
         # Sleep and wait for expiry
-        time.sleep(5)
+        time.sleep(2)
         dog_d = cache.provider.get(f'dog:{dog.id}')
         assert dog_d is None
 
@@ -53,7 +53,7 @@ class TestCache:
 
         # Touch and retrieve the entity again
         cache.provider.touch(f'dog:{dog.id}', expiry=10)
-        time.sleep(2)
+        time.sleep(1)
         dog_d = cache.provider.get(f'dog:{dog.id}')
         assert dog_d is not None
 

--- a/tests/core/test_cache.py
+++ b/tests/core/test_cache.py
@@ -8,10 +8,6 @@ from protean.core.repository import repo_factory
 class TestCache:
     """This class holds tests for Cache class"""
 
-    @classmethod
-    def teardown_class(cls):
-        repo_factory.DogModel.delete_all()
-
     def test_init(self):
         """Test successful access to the Cache Wrapper"""
         assert cache.provider is not None
@@ -19,7 +15,7 @@ class TestCache:
     def test_add(self):
         """ Test adding and retrieving an entry to the cache """
         # Add an entity to the cache
-        dog = repo_factory.DogModel.create(id=1, name='Johnny', owner='John')
+        dog = repo_factory.Dog.create(id=1, name='Johnny', owner='John')
         cache.provider.add(f'dog:{dog.id}', dog.to_dict())
 
         # Retrieve the entity
@@ -28,8 +24,10 @@ class TestCache:
 
     def test_set(self):
         """ Test setting an existing key and expiry of keys """
+        dog = repo_factory.Dog.create(id=1, name='Johnny', owner='John')
+
         # Set an entity to the cache
-        dog = repo_factory.DogModel.get(1)
+        dog = repo_factory.Dog.get(1)
         cache.provider.set(f'dog:{dog.id}', dog.to_dict(), expiry=5)
 
         # Retrieve the entity
@@ -43,8 +41,10 @@ class TestCache:
 
     def test_touch(self):
         """ Test updating the expiry of key using touch """
+        dog = repo_factory.Dog.create(id=1, name='Johnny', owner='John')
+
         # Set an entity to the cache
-        dog = repo_factory.DogModel.get(1)
+        dog = repo_factory.Dog.get(1)
         cache.provider.set(f'dog:{dog.id}', dog.to_dict(), expiry=1)
 
         # Retrieve the entity
@@ -59,8 +59,10 @@ class TestCache:
 
     def test_delete(self):
         """ Test deleting a key from the cache """
+        dog = repo_factory.Dog.create(id=1, name='Johnny', owner='John')
+
         # Set an entity to the cache
-        dog = repo_factory.DogModel.get(1)
+        dog = repo_factory.Dog.get(1)
         cache.provider.set(f'dog:{dog.id}', dog.to_dict())
 
         # Retrieve the entity
@@ -95,4 +97,3 @@ class TestCache:
         cache.provider.delete_many(['k1', 'k2', 'k3'])
         values = cache.provider.get_many(['k1', 'k2', 'k3'])
         assert values == {}
-

--- a/tests/core/test_cache.py
+++ b/tests/core/test_cache.py
@@ -4,6 +4,8 @@ import time
 from protean.core.cache import cache
 from protean.core.repository import repo_factory
 
+from tests.support.dog import Dog
+
 
 class TestCache:
     """This class holds tests for Cache class"""
@@ -15,7 +17,7 @@ class TestCache:
     def test_add(self):
         """ Test adding and retrieving an entry to the cache """
         # Add an entity to the cache
-        dog = repo_factory.Dog.create(id=1, name='Johnny', owner='John')
+        dog = Dog.create(id=1, name='Johnny', owner='John')
         cache.provider.add(f'dog:{dog.id}', dog.to_dict())
 
         # Retrieve the entity
@@ -24,10 +26,10 @@ class TestCache:
 
     def test_set(self):
         """ Test setting an existing key and expiry of keys """
-        dog = repo_factory.Dog.create(id=1, name='Johnny', owner='John')
+        dog = Dog.create(id=1, name='Johnny', owner='John')
 
         # Set an entity to the cache
-        dog = repo_factory.Dog.get(1)
+        dog = Dog.get(1)
         cache.provider.set(f'dog:{dog.id}', dog.to_dict(), expiry=1)
 
         # Retrieve the entity
@@ -41,10 +43,10 @@ class TestCache:
 
     def test_touch(self):
         """ Test updating the expiry of key using touch """
-        dog = repo_factory.Dog.create(id=1, name='Johnny', owner='John')
+        dog = Dog.create(id=1, name='Johnny', owner='John')
 
         # Set an entity to the cache
-        dog = repo_factory.Dog.get(1)
+        dog = Dog.get(1)
         cache.provider.set(f'dog:{dog.id}', dog.to_dict(), expiry=1)
 
         # Retrieve the entity
@@ -59,10 +61,10 @@ class TestCache:
 
     def test_delete(self):
         """ Test deleting a key from the cache """
-        dog = repo_factory.Dog.create(id=1, name='Johnny', owner='John')
+        dog = Dog.create(id=1, name='Johnny', owner='John')
 
         # Set an entity to the cache
-        dog = repo_factory.Dog.get(1)
+        dog = Dog.get(1)
         cache.provider.set(f'dog:{dog.id}', dog.to_dict())
 
         # Retrieve the entity

--- a/tests/core/test_entity.py
+++ b/tests/core/test_entity.py
@@ -137,13 +137,13 @@ class TestEntity:
         dog = Dog.create(id=11344234, name='Johnny', owner='John')
         dog.delete()
         with pytest.raises(ObjectNotFoundError):
-            dog.update(identifier=11344234, data=dict(age=10))
+            dog.update(data=dict(age=10))
 
     def test_update(self):
         """ Update an existing entity in the repository"""
         dog = Dog.create(id=2, name='Johnny', owner='Carey', age=2)
 
-        dog.update(identifier=2, data=dict(age=10))
+        dog.update(data=dict(age=10))
         u_dog = Dog.get(2)
         assert u_dog is not None
         assert u_dog.age == 10
@@ -153,7 +153,7 @@ class TestEntity:
         dog = Dog.create(id=1, name='Johnny', owner='Carey', age=2)
 
         with pytest.raises(ValidationError):
-            dog.update(identifier=1, data=dict(age='x'))
+            dog.update(data=dict(age='x'))
 
     def test_unique(self):
         """ Test the unique constraints for the entity """

--- a/tests/core/test_entity.py
+++ b/tests/core/test_entity.py
@@ -2,16 +2,11 @@
 
 import pytest
 
+from tests.support.dog import Dog
+
 from protean.core.entity import Entity
 from protean.core.exceptions import ValidationError
 from protean.core import field
-
-
-class Dog(Entity):
-    """This is a dummy Dog Entity class"""
-    name = field.String(required=True, max_length=50, min_length=5)
-    age = field.Integer(default=5)
-    owner = field.String(required=True, max_length=15)
 
 
 class TestEntity:
@@ -67,14 +62,14 @@ class TestEntity:
 
         # Test single error message
         try:
-            Dog(id=1, name='John Doe')
+            Dog(id=1, name='John Doe', owner='Jimmy')
         except ValidationError as err:
             assert err.normalized_messages == {
                 'owner': [Dog.owner.error_messages['required']]}
 
         # Test multiple error messages
         try:
-            Dog(id=1, name='Joh')
+            Dog(id=1, name='Joh', owner='Jimmy')
         except ValidationError as err:
             assert err.normalized_messages == {
                 'name': ['Ensure value has at least 5 characters.'],
@@ -118,3 +113,10 @@ class TestEntity:
         assert dog is not None
         assert dog.to_dict() == {
             'age': 10, 'id': 1, 'name': 'John Doe', 'owner': 'Jimmy'}
+
+    def test_create(self):
+        """Test create method of Entity"""
+
+        dog = Dog.create(name='John Doe', age=10, owner='Jimmy')
+        assert dog is not None
+        assert dog.id is not None

--- a/tests/core/test_entity.py
+++ b/tests/core/test_entity.py
@@ -5,7 +5,7 @@ import pytest
 from tests.support.dog import Dog
 
 from protean.core.entity import Entity
-from protean.core.exceptions import ValidationError
+from protean.core.exceptions import ValidationError, ObjectNotFoundError
 from protean.core import field
 
 
@@ -114,9 +114,103 @@ class TestEntity:
         assert dog.to_dict() == {
             'age': 10, 'id': 1, 'name': 'John Doe', 'owner': 'Jimmy'}
 
-    def test_create(self):
-        """Test create method of Entity"""
+    def test_create_error(self):
+        """ Add an entity to the repository missing a required attribute"""
+        with pytest.raises(ValidationError):
+            Dog.create(owner='John')
 
-        dog = Dog.create(name='John Doe', age=10, owner='Jimmy')
+    def test_create(self):
+        """ Add an entity to the repository"""
+        dog = Dog.create(id=11344234, name='Johnny', owner='John')
         assert dog is not None
-        assert dog.id is not None
+        assert dog.id == 11344234
+        assert dog.name == 'Johnny'
+        assert dog.age == 5
+        assert dog.owner == 'John'
+
+        dog = Dog.get(11344234)
+        assert dog is not None
+
+    def test_update_with_invalid_id(self):
+        """Try to update a non-existing entry"""
+
+        dog = Dog.create(id=11344234, name='Johnny', owner='John')
+        dog.delete()
+        with pytest.raises(ObjectNotFoundError):
+            dog.update(identifier=11344234, data=dict(age=10))
+
+    def test_update(self):
+        """ Update an existing entity in the repository"""
+        dog = Dog.create(id=2, name='Johnny', owner='Carey', age=2)
+
+        dog.update(identifier=2, data=dict(age=10))
+        u_dog = Dog.get(2)
+        assert u_dog is not None
+        assert u_dog.age == 10
+
+    def test_that_update_runs_validations(self):
+        """Try updating with invalid values"""
+        dog = Dog.create(id=1, name='Johnny', owner='Carey', age=2)
+
+        with pytest.raises(ValidationError):
+            dog.update(identifier=1, data=dict(age='x'))
+
+    def test_unique(self):
+        """ Test the unique constraints for the entity """
+        Dog.create(id=2, name='Johnny', owner='Carey')
+
+        with pytest.raises(ValidationError) as err:
+            Dog.create(
+                id=2, name='Johnny', owner='Carey')
+        assert err.value.normalized_messages == {
+            'name': ['`dogs` with this `name` already exists.']}
+
+    def test_filter(self):
+        """ Query the repository using filters """
+        # Add multiple entries to the DB
+        Dog.create(id=2, name='Murdock', age=7, owner='John')
+        Dog.create(id=3, name='Jean', age=3, owner='John')
+        Dog.create(id=4, name='Bart', age=6, owner='Carrie')
+
+        # Filter by the Owner
+        dogs = Dog.filter(owner='John')
+        assert dogs is not None
+        assert dogs.total == 2
+        assert len(dogs.items) == 2
+
+        # Order the results by age
+        dogs = Dog.filter(owner='John', order_by=['-age'])
+        assert dogs is not None
+        assert dogs.first.age == 7
+        assert dogs.first.name == 'Murdock'
+
+    def test_pagination(self):
+        """ Test the pagination of the filter results"""
+        for counter in range(1, 5):
+            Dog.create(id=counter, name=counter, owner='Owner Name')
+
+        dogs = Dog.filter(per_page=2, order_by=['id'])
+        assert dogs is not None
+        assert dogs.total == 4
+        assert len(dogs.items) == 2
+        assert dogs.first.id == 1
+        assert dogs.has_next
+        assert not dogs.has_prev
+
+        dogs = Dog.filter(page=2, per_page=2, order_by=['id'])
+        assert len(dogs.items) == 2
+        assert dogs.first.id == 3
+        assert not dogs.has_next
+        assert dogs.has_prev
+
+    def test_delete(self):
+        """ Delete an object in the reposoitory by ID"""
+        dog = Dog.create(id=3, name='Johnny', owner='Carey')
+        del_count = dog.delete()
+        assert del_count == 1
+
+        del_count = dog.delete()
+        assert del_count == 0
+
+        with pytest.raises(ObjectNotFoundError):
+            Dog.get(3)

--- a/tests/core/test_entity.py
+++ b/tests/core/test_entity.py
@@ -9,7 +9,6 @@ from protean.core import field
 
 class Dog(Entity):
     """This is a dummy Dog Entity class"""
-    id = field.Integer(identifier=True)
     name = field.String(required=True, max_length=50, min_length=5)
     age = field.Integer(default=5)
     owner = field.String(required=True, max_length=15)

--- a/tests/core/test_repository.py
+++ b/tests/core/test_repository.py
@@ -2,83 +2,66 @@
 
 import pytest
 
-from protean.core.entity import Entity
+from protean.impl.repository.dict_repo import _databases
 from protean.core.repository import repo_factory
 from protean.core.exceptions import ValidationError, ObjectNotFoundError
-from protean.core import field
-from protean.impl.repository.dict_repo import DictModel, _databases
-
-
-class Dog(Entity):
-    """This is a dummy Dog Entity class"""
-    id = field.Integer(identifier=True)
-    name = field.String(required=True, unique=True, max_length=50)
-    age = field.Integer(default=5)
-    owner = field.String(required=True, max_length=15)
-
-
-class DogModel(DictModel):
-    """ Model for the Dog Entity"""
-
-    class Meta:
-        """ Meta class for schema options"""
-        entity = Dog
-        model_name = 'dogs'
-
-
-repo_factory.register(DogModel)
 
 
 class TestRepository:
     """This class holds tests for Repository class"""
 
-    @classmethod
-    def teardown_class(cls):
-        repo_factory.DogModel.delete_all()
-
     def test_init(self):
         """Test successful access to the Dog repository"""
 
-        repo_factory.DogModel.filter()
-        current_db = dict(repo_factory.DogModel.conn)
+        repo_factory.Dog.filter()
+        current_db = dict(repo_factory.Dog.conn)
         assert current_db['data'] == {'dogs': {}}
+
+    def test_create_error(self):
+        """ Add an entity to the repository missing a required attribute"""
+        with pytest.raises(ValidationError):
+            repo_factory.Dog.create(owner='John')
 
     def test_create(self):
         """ Add an entity to the repository"""
-        with pytest.raises(ValidationError):
-            repo_factory.DogModel.create(name='Johnny', owner='John')
-
-        dog = repo_factory.DogModel.create(id=1, name='Johnny', owner='John')
+        dog = repo_factory.Dog.create(id=11344234, name='Johnny', owner='John')
         assert dog is not None
-        assert dog.id == 1
+        assert dog.id == 11344234
         assert dog.name == 'Johnny'
         assert dog.age == 5
         assert dog.owner == 'John'
 
-        dog = repo_factory.DogModel.get(1)
+        dog = repo_factory.Dog.get(11344234)
         assert dog is not None
+
+    def test_update_with_invalid_id(self):
+        """Try to update a non-existing entry"""
+
+        with pytest.raises(ObjectNotFoundError):
+            repo_factory.Dog.update(identifier=2, data=dict(age=10))
 
     def test_update(self):
         """ Update an existing entity in the repository"""
+        repo_factory.Dog.create(id=2, name='Johnny', owner='Carey', age=2)
 
-        # Using an invalid id should fail
-        with pytest.raises(ObjectNotFoundError):
-            repo_factory.DogModel.update(identifier=2, data=dict(age=10))
-
-        # Updates should run the validations
-        with pytest.raises(ValidationError):
-            repo_factory.DogModel.update(identifier=1, data=dict(age='x'))
-
-        repo_factory.DogModel.update(identifier=1, data=dict(age=10))
-        u_dog = repo_factory.DogModel.get(1)
+        repo_factory.Dog.update(identifier=2, data=dict(age=10))
+        u_dog = repo_factory.Dog.get(2)
         assert u_dog is not None
         assert u_dog.age == 10
 
+    def test_that_update_runs_validations(self):
+        """Try updating with invalid values"""
+        repo_factory.Dog.create(id=1, name='Johnny', owner='Carey', age=2)
+
+        with pytest.raises(ValidationError):
+            repo_factory.Dog.update(identifier=1, data=dict(age='x'))
+
     def test_unique(self):
         """ Test the unique constraints for the entity """
+        repo_factory.Dog.create(id=2, name='Johnny', owner='Carey')
 
         with pytest.raises(ValidationError) as err:
-            repo_factory.DogModel.create(
+            repo_factory.Dog.create(
                 id=2, name='Johnny', owner='Carey')
         assert err.value.normalized_messages == {
             'name': ['`dogs` with this `name` already exists.']}
@@ -86,25 +69,28 @@ class TestRepository:
     def test_filter(self):
         """ Query the repository using filters """
         # Add multiple entries to the DB
-        repo_factory.DogModel.create(id=2, name='Murdock', age=7, owner='John')
-        repo_factory.DogModel.create(id=3, name='Jean', age=3, owner='John')
-        repo_factory.DogModel.create(id=4, name='Bart', age=6, owner='Carrie')
+        repo_factory.Dog.create(id=2, name='Murdock', age=7, owner='John')
+        repo_factory.Dog.create(id=3, name='Jean', age=3, owner='John')
+        repo_factory.Dog.create(id=4, name='Bart', age=6, owner='Carrie')
 
         # Filter by the Owner
-        dogs = repo_factory.DogModel.filter(owner='John')
+        dogs = repo_factory.Dog.filter(owner='John')
         assert dogs is not None
-        assert dogs.total == 3
-        assert len(dogs.items) == 3
+        assert dogs.total == 2
+        assert len(dogs.items) == 2
 
         # Order the results by age
-        dogs = repo_factory.DogModel.filter(owner='John', order_by=['-age'])
+        dogs = repo_factory.Dog.filter(owner='John', order_by=['-age'])
         assert dogs is not None
-        assert dogs.first.age == 10
-        assert dogs.first.name == 'Johnny'
+        assert dogs.first.age == 7
+        assert dogs.first.name == 'Murdock'
 
     def test_pagination(self):
         """ Test the pagination of the filter results"""
-        dogs = repo_factory.DogModel.filter(per_page=2, order_by=['id'])
+        for counter in range(1, 5):
+            repo_factory.Dog.create(id=counter, name=counter, owner='Owner Name')
+
+        dogs = repo_factory.Dog.filter(per_page=2, order_by=['id'])
         assert dogs is not None
         assert dogs.total == 4
         assert len(dogs.items) == 2
@@ -112,7 +98,7 @@ class TestRepository:
         assert dogs.has_next
         assert not dogs.has_prev
 
-        dogs = repo_factory.DogModel.filter(page=2, per_page=2, order_by=['id'])
+        dogs = repo_factory.Dog.filter(page=2, per_page=2, order_by=['id'])
         assert len(dogs.items) == 2
         assert dogs.first.id == 3
         assert not dogs.has_next
@@ -120,14 +106,15 @@ class TestRepository:
 
     def test_delete(self):
         """ Delete an object in the reposoitory by ID"""
-        del_count = repo_factory.DogModel.delete(1)
+        repo_factory.Dog.create(id=3, name='Johnny', owner='Carey')
+        del_count = repo_factory.Dog.delete(3)
         assert del_count == 1
 
-        del_count = repo_factory.DogModel.delete(1)
+        del_count = repo_factory.Dog.delete(3)
         assert del_count == 0
 
         with pytest.raises(ObjectNotFoundError):
-            repo_factory.DogModel.get(1)
+            repo_factory.Dog.get(3)
 
     def test_close_connections(self):
         """ Test closing all connections to the repository"""

--- a/tests/core/test_repository.py
+++ b/tests/core/test_repository.py
@@ -6,6 +6,8 @@ from protean.impl.repository.dict_repo import _databases
 from protean.core.repository import repo_factory
 from protean.core.exceptions import ValidationError, ObjectNotFoundError
 
+from tests.support.dog import Dog
+
 
 class TestRepository:
     """This class holds tests for Repository class"""
@@ -13,55 +15,49 @@ class TestRepository:
     def test_init(self):
         """Test successful access to the Dog repository"""
 
-        repo_factory.Dog.filter()
+        Dog.filter()
         current_db = dict(repo_factory.Dog.conn)
         assert current_db['data'] == {'dogs': {}}
 
     def test_create_error(self):
         """ Add an entity to the repository missing a required attribute"""
         with pytest.raises(ValidationError):
-            repo_factory.Dog.create(owner='John')
+            Dog.create(owner='John')
 
     def test_create(self):
         """ Add an entity to the repository"""
-        dog = repo_factory.Dog.create(id=11344234, name='Johnny', owner='John')
+        dog = Dog.create(id=11344234, name='Johnny', owner='John')
         assert dog is not None
         assert dog.id == 11344234
         assert dog.name == 'Johnny'
         assert dog.age == 5
         assert dog.owner == 'John'
 
-        dog = repo_factory.Dog.get(11344234)
+        dog = Dog.get(11344234)
         assert dog is not None
-
-    def test_update_with_invalid_id(self):
-        """Try to update a non-existing entry"""
-
-        with pytest.raises(ObjectNotFoundError):
-            repo_factory.Dog.update(identifier=2, data=dict(age=10))
 
     def test_update(self):
         """ Update an existing entity in the repository"""
-        repo_factory.Dog.create(id=2, name='Johnny', owner='Carey', age=2)
+        dog = Dog.create(id=2, name='Johnny', owner='Carey', age=2)
 
-        repo_factory.Dog.update(identifier=2, data=dict(age=10))
-        u_dog = repo_factory.Dog.get(2)
+        dog.update(data=dict(age=10))
+        u_dog = Dog.get(2)
         assert u_dog is not None
         assert u_dog.age == 10
 
     def test_that_update_runs_validations(self):
         """Try updating with invalid values"""
-        repo_factory.Dog.create(id=1, name='Johnny', owner='Carey', age=2)
+        dog = Dog.create(id=1, name='Johnny', owner='Carey', age=2)
 
         with pytest.raises(ValidationError):
-            repo_factory.Dog.update(identifier=1, data=dict(age='x'))
+            dog.update(data=dict(age='x'))
 
     def test_unique(self):
         """ Test the unique constraints for the entity """
-        repo_factory.Dog.create(id=2, name='Johnny', owner='Carey')
+        Dog.create(id=2, name='Johnny', owner='Carey')
 
         with pytest.raises(ValidationError) as err:
-            repo_factory.Dog.create(
+            Dog.create(
                 id=2, name='Johnny', owner='Carey')
         assert err.value.normalized_messages == {
             'name': ['`dogs` with this `name` already exists.']}
@@ -69,18 +65,18 @@ class TestRepository:
     def test_filter(self):
         """ Query the repository using filters """
         # Add multiple entries to the DB
-        repo_factory.Dog.create(id=2, name='Murdock', age=7, owner='John')
-        repo_factory.Dog.create(id=3, name='Jean', age=3, owner='John')
-        repo_factory.Dog.create(id=4, name='Bart', age=6, owner='Carrie')
+        Dog.create(id=2, name='Murdock', age=7, owner='John')
+        Dog.create(id=3, name='Jean', age=3, owner='John')
+        Dog.create(id=4, name='Bart', age=6, owner='Carrie')
 
         # Filter by the Owner
-        dogs = repo_factory.Dog.filter(owner='John')
+        dogs = Dog.filter(owner='John')
         assert dogs is not None
         assert dogs.total == 2
         assert len(dogs.items) == 2
 
         # Order the results by age
-        dogs = repo_factory.Dog.filter(owner='John', order_by=['-age'])
+        dogs = Dog.filter(owner='John', order_by=['-age'])
         assert dogs is not None
         assert dogs.first.age == 7
         assert dogs.first.name == 'Murdock'
@@ -88,9 +84,9 @@ class TestRepository:
     def test_pagination(self):
         """ Test the pagination of the filter results"""
         for counter in range(1, 5):
-            repo_factory.Dog.create(id=counter, name=counter, owner='Owner Name')
+            Dog.create(id=counter, name=counter, owner='Owner Name')
 
-        dogs = repo_factory.Dog.filter(per_page=2, order_by=['id'])
+        dogs = Dog.filter(per_page=2, order_by=['id'])
         assert dogs is not None
         assert dogs.total == 4
         assert len(dogs.items) == 2
@@ -98,7 +94,7 @@ class TestRepository:
         assert dogs.has_next
         assert not dogs.has_prev
 
-        dogs = repo_factory.Dog.filter(page=2, per_page=2, order_by=['id'])
+        dogs = Dog.filter(page=2, per_page=2, order_by=['id'])
         assert len(dogs.items) == 2
         assert dogs.first.id == 3
         assert not dogs.has_next
@@ -106,15 +102,15 @@ class TestRepository:
 
     def test_delete(self):
         """ Delete an object in the reposoitory by ID"""
-        repo_factory.Dog.create(id=3, name='Johnny', owner='Carey')
-        del_count = repo_factory.Dog.delete(3)
+        dog = Dog.create(id=3, name='Johnny', owner='Carey')
+        del_count = dog.delete()
         assert del_count == 1
 
-        del_count = repo_factory.Dog.delete(3)
+        del_count = dog.delete()
         assert del_count == 0
 
         with pytest.raises(ObjectNotFoundError):
-            repo_factory.Dog.get(3)
+            Dog.get(3)
 
     def test_close_connections(self):
         """ Test closing all connections to the repository"""

--- a/tests/core/test_tasklet.py
+++ b/tests/core/test_tasklet.py
@@ -3,7 +3,6 @@ import pytest
 
 from protean.core.tasklet import Tasklet
 from protean.core.usecase import ShowRequestObject, ShowUseCase
-from protean.core.repository import repo_factory
 from protean.core.exceptions import UsecaseExecutionError
 from protean.core.transport import Status
 
@@ -15,12 +14,11 @@ class TestTasklet:
 
     def test_perform(self):
         """Test call to Tasklet's perform method"""
-        repo_factory.Dog.create(id=1, name='Murdock', owner='John')
+        Dog.create(id=1, name='Murdock', owner='John')
 
         # Perform a Show Usecase using Tasklet
         payload = {'identifier': 1}
-        response = Tasklet.perform(
-            repo_factory, Dog, ShowUseCase, ShowRequestObject, payload)
+        response = Tasklet.perform(Dog, ShowUseCase, ShowRequestObject, payload)
 
         # Validate the response received
         assert response is not None
@@ -31,9 +29,7 @@ class TestTasklet:
     def test_raise_error(self):
         """ Test raise error function of the Tasklet """
         with pytest.raises(UsecaseExecutionError) as exc_info:
-            Tasklet.perform(
-                repo_factory, Dog, ShowUseCase, ShowRequestObject, {},
-                raise_error=True)
+            Tasklet.perform(Dog, ShowUseCase, ShowRequestObject, {}, raise_error=True)
         assert exc_info.value.value[0] == Status.UNPROCESSABLE_ENTITY
         assert exc_info.value.value[1] ==  \
                {'code': 422, 'message': {'identifier': 'is required'}}

--- a/tests/core/test_tasklet.py
+++ b/tests/core/test_tasklet.py
@@ -7,24 +7,20 @@ from protean.core.repository import repo_factory
 from protean.core.exceptions import UsecaseExecutionError
 from protean.core.transport import Status
 
-from .test_repository import DogModel
+from tests.support.dog import Dog
 
 
 class TestTasklet:
     """Tests for Tasklet Utility Methods"""
 
-    @classmethod
-    def teardown_class(cls):
-        repo_factory.DogModel.delete_all()
-
     def test_perform(self):
         """Test call to Tasklet's perform method"""
-        repo_factory.DogModel.create(id=1, name='Murdock', owner='John')
+        repo_factory.Dog.create(id=1, name='Murdock', owner='John')
 
         # Perform a Show Usecase using Tasklet
         payload = {'identifier': 1}
         response = Tasklet.perform(
-            repo_factory, DogModel, ShowUseCase, ShowRequestObject, payload)
+            repo_factory, Dog, ShowUseCase, ShowRequestObject, payload)
 
         # Validate the response received
         assert response is not None
@@ -36,7 +32,7 @@ class TestTasklet:
         """ Test raise error function of the Tasklet """
         with pytest.raises(UsecaseExecutionError) as exc_info:
             Tasklet.perform(
-                repo_factory, DogModel, ShowUseCase, ShowRequestObject, {},
+                repo_factory, Dog, ShowUseCase, ShowRequestObject, {},
                 raise_error=True)
         assert exc_info.value.value[0] == Status.UNPROCESSABLE_ENTITY
         assert exc_info.value.value[1] ==  \

--- a/tests/core/test_tasklet.py
+++ b/tests/core/test_tasklet.py
@@ -3,11 +3,11 @@ import pytest
 
 from protean.core.tasklet import Tasklet
 from protean.core.usecase import ShowRequestObject, ShowUseCase
-from protean.core.repository import repo
+from protean.core.repository import repo_factory
 from protean.core.exceptions import UsecaseExecutionError
 from protean.core.transport import Status
 
-from .test_repository import DogSchema
+from .test_repository import DogModel
 
 
 class TestTasklet:
@@ -15,16 +15,16 @@ class TestTasklet:
 
     @classmethod
     def teardown_class(cls):
-        repo.DogSchema.delete_all()
+        repo_factory.DogModel.delete_all()
 
     def test_perform(self):
         """Test call to Tasklet's perform method"""
-        repo.DogSchema.create(id=1, name='Murdock', owner='John')
+        repo_factory.DogModel.create(id=1, name='Murdock', owner='John')
 
         # Perform a Show Usecase using Tasklet
         payload = {'identifier': 1}
         response = Tasklet.perform(
-            repo, DogSchema, ShowUseCase, ShowRequestObject, payload)
+            repo_factory, DogModel, ShowUseCase, ShowRequestObject, payload)
 
         # Validate the response received
         assert response is not None
@@ -36,7 +36,7 @@ class TestTasklet:
         """ Test raise error function of the Tasklet """
         with pytest.raises(UsecaseExecutionError) as exc_info:
             Tasklet.perform(
-                repo, DogSchema, ShowUseCase, ShowRequestObject, {},
+                repo_factory, DogModel, ShowUseCase, ShowRequestObject, {},
                 raise_error=True)
         assert exc_info.value.value[0] == Status.UNPROCESSABLE_ENTITY
         assert exc_info.value.value[1] ==  \

--- a/tests/core/test_usecase.py
+++ b/tests/core/test_usecase.py
@@ -98,7 +98,7 @@ class TestShowUseCase:
         """Test Show UseCase's `process_request` method"""
 
         # Add an object to the repository
-        repo_factory.Dog.create(name='Johnny', owner='John')
+        repo_factory.Dog.create(id=1, name='Johnny', owner='John')
 
         # Build the request object and run the usecase
         request_obj = ShowRequestObject.from_dict(Dog, {'identifier': 1})
@@ -154,7 +154,6 @@ class TestListUseCase:
         assert response.success
         assert response.value.page == 1
         assert response.value.total == 2
-        assert response.value.first.id == 3
         assert response.value.first.age == 3
 
 
@@ -172,7 +171,6 @@ class TestCreateUseCase:
 
         assert response is not None
         assert response.success
-        assert response.value.id == 5
         assert response.value.name == 'Barry'
 
     def test_unique_validation(self):

--- a/tests/core/test_usecase.py
+++ b/tests/core/test_usecase.py
@@ -6,7 +6,6 @@ from protean.core.usecase import (
     UseCase, ShowUseCase, ShowRequestObject, ListRequestObject, ListUseCase,
     CreateRequestObject, CreateUseCase, UpdateRequestObject, UpdateUseCase,
     DeleteRequestObject, DeleteUseCase)
-from protean.core.repository import repo_factory
 
 from tests.support.dog import Dog
 
@@ -17,7 +16,7 @@ class TestUseCase:
     def test_init(self):
         """Test Initialization of the generic UseCase class"""
         with pytest.raises(TypeError):
-            UseCase(repo_factory.Dog)
+            UseCase()
 
 
 class TestShowRequestObject:
@@ -98,11 +97,11 @@ class TestShowUseCase:
         """Test Show UseCase's `process_request` method"""
 
         # Add an object to the repository
-        repo_factory.Dog.create(id=1, name='Johnny', owner='John')
+        Dog.create(id=1, name='Johnny', owner='John')
 
         # Build the request object and run the usecase
         request_obj = ShowRequestObject.from_dict(Dog, {'identifier': 1})
-        use_case = ShowUseCase(repo_factory.Dog)
+        use_case = ShowUseCase()
         response = use_case.execute(request_obj)
         assert response is not None
         assert response.success
@@ -115,7 +114,7 @@ class TestShowUseCase:
 
         # Build the request object and run the usecase
         request_obj = ShowRequestObject.from_dict(Dog, {})
-        use_case = ShowUseCase(repo_factory.Dog)
+        use_case = ShowUseCase()
         response = use_case.execute(request_obj)
         assert response is not None
         assert not response.success
@@ -125,7 +124,7 @@ class TestShowUseCase:
 
         # Build the request object and run the usecase
         request_obj = ShowRequestObject.from_dict(Dog, {'identifier': 12})
-        use_case = ShowUseCase(repo_factory.Dog)
+        use_case = ShowUseCase()
         response = use_case.execute(request_obj)
         assert response is not None
         assert not response.success
@@ -137,16 +136,16 @@ class TestListUseCase:
     @classmethod
     def setup_class(cls):
         """ Setup instructions for this case """
-        repo_factory.Dog.create(name='Murdock', owner='John', age=7)
-        repo_factory.Dog.create(name='Jean', owner='John', age=3)
-        repo_factory.Dog.create(name='Bart', owner='Carrie', age=6)
+        Dog.create(name='Murdock', owner='John', age=7)
+        Dog.create(name='Jean', owner='John', age=3)
+        Dog.create(name='Bart', owner='Carrie', age=6)
 
     def test_process_request(self):
         """Test List UseCase's `process_request` method"""
         # Build the request object and run the usecase
         request_obj = ListRequestObject.from_dict(
             Dog, dict(order_by=['age'], owner='John'))
-        use_case = ListUseCase(repo_factory.Dog)
+        use_case = ListUseCase()
         response = use_case.execute(request_obj)
 
         # Validate the response received
@@ -166,7 +165,7 @@ class TestCreateUseCase:
         # Fix and rerun the usecase
         request_data = dict(name='Barry', age=10, owner='Jimmy')
         request_obj = CreateRequestObject.from_dict(Dog, request_data)
-        use_case = CreateUseCase(repo_factory.Dog)
+        use_case = CreateUseCase()
         response = use_case.execute(request_obj)
 
         assert response is not None
@@ -178,13 +177,13 @@ class TestCreateUseCase:
 
         request_data = dict(name='Drew', age=10, owner='Jimmy')
         request_obj = CreateRequestObject.from_dict(Dog, request_data)
-        use_case = CreateUseCase(repo_factory.Dog)
+        use_case = CreateUseCase()
         response = use_case.execute(request_obj)
 
         # Build the request object and run the usecase
         request_data = dict(id=response.value.id, name='Jerry', age=10, owner='Jimmy')
         request_obj = CreateRequestObject.from_dict(Dog, request_data)
-        use_case = CreateUseCase(repo_factory.Dog)
+        use_case = CreateUseCase()
         response = use_case.execute(request_obj)
 
         # Validate the response received
@@ -201,7 +200,7 @@ class TestUpdateUseCase:
     @pytest.fixture(scope="function")
     def dog_to_update(self):
         """ Setup instructions for this case """
-        dog = repo_factory.Dog.create(name='Johnny', owner='John')
+        dog = Dog.create(id=1, name='Johnny', owner='John')
         yield dog
 
     def test_process_request(self, dog_to_update):
@@ -210,7 +209,7 @@ class TestUpdateUseCase:
         # Build the request object and run the usecase
         request_obj = UpdateRequestObject.from_dict(
             Dog, {'identifier': dog_to_update.id, 'data': {'age': 13}})
-        use_case = UpdateUseCase(repo_factory.Dog)
+        use_case = UpdateUseCase()
         response = use_case.execute(request_obj)
 
         # Validate the response received
@@ -224,7 +223,7 @@ class TestUpdateUseCase:
         # Build the request object and run the usecase
         request_obj = UpdateRequestObject.from_dict(
             Dog, {'identifier': dog_to_update.id, 'data': {'age': 'x'}})
-        use_case = UpdateUseCase(repo_factory.Dog)
+        use_case = UpdateUseCase()
         response = use_case.execute(request_obj)
 
         # Validate the response received
@@ -236,12 +235,12 @@ class TestUpdateUseCase:
     def test_unique_validation(self, dog_to_update):
         """Test Update Usecase for unique validation"""
         # Create a dog with the same name
-        repo_factory.Dog.create(name='Barry', owner='John')
+        Dog.create(id=2, name='Barry', owner='John')
 
         # Build the request object and run the usecase
         request_obj = UpdateRequestObject.from_dict(
             Dog, {'identifier': dog_to_update.id, 'data': {'name': 'Barry'}})
-        use_case = UpdateUseCase(repo_factory.Dog)
+        use_case = UpdateUseCase()
         response = use_case.execute(request_obj)
 
         # Validate the response received
@@ -259,7 +258,7 @@ class TestDeleteUseCase:
     @classmethod
     def setup_class(cls):
         """ Setup instructions for this case """
-        cls.dog = repo_factory.Dog.create(name='Jimmy', owner='John')
+        cls.dog = Dog.create(name='Jimmy', owner='John')
 
     def test_process_request(self):
         """Test Delete UseCase's `process_request` method"""
@@ -267,7 +266,7 @@ class TestDeleteUseCase:
         # Build the request object and run the usecase
         request_obj = DeleteRequestObject.from_dict(
             Dog, {'identifier': self.dog.id})
-        use_case = DeleteUseCase(repo_factory.Dog)
+        use_case = DeleteUseCase()
         response = use_case.execute(request_obj)
 
         # Validate the response received
@@ -278,7 +277,7 @@ class TestDeleteUseCase:
         # Try to lookup the object again
         request_obj = ShowRequestObject.from_dict(
             Dog, {'identifier': self.dog.id})
-        use_case = ShowUseCase(repo_factory.Dog)
+        use_case = ShowUseCase()
         response = use_case.execute(request_obj)
         assert response is not None
         assert not response.success

--- a/tests/core/test_usecase.py
+++ b/tests/core/test_usecase.py
@@ -8,8 +8,8 @@ from protean.core.usecase import (
     UseCase, ShowUseCase, ShowRequestObject, ListRequestObject, ListUseCase,
     CreateRequestObject, CreateUseCase, UpdateRequestObject, UpdateUseCase,
     DeleteRequestObject, DeleteUseCase)
-from protean.core.repository import repo
-from protean.impl.repository.dict_repo import DictSchema
+from protean.core.repository import repo_factory
+from protean.impl.repository.dict_repo import DictModel
 
 
 class Dog(Entity):
@@ -19,17 +19,17 @@ class Dog(Entity):
     owner = field.String(required=True, max_length=15)
 
 
-class DogAutoSchema(DictSchema):
-    """ Schema for the Dog Entity"""
+class DogAutoModel(DictModel):
+    """Model for the Dog Entity"""
 
     class Meta:
-        """ Meta class for schema options"""
+        """ Meta class for model options"""
         entity = Dog
-        schema_name = 'dogs-auto'
+        model_name = 'dogs-auto'
 
 
-repo.register(DogAutoSchema)
-dog_repo = repo.DogAutoSchema
+repo_factory.register(DogAutoModel)
+dog_model = repo_factory.DogAutoModel
 
 
 class TestUseCase:
@@ -38,7 +38,7 @@ class TestUseCase:
     def test_init(self):
         """Test Initialization of the generic UseCase class"""
         with pytest.raises(TypeError):
-            UseCase(dog_repo)
+            UseCase(dog_model)
 
 
 class TestShowRequestObject:
@@ -119,11 +119,11 @@ class TestShowUseCase:
         """Test Show UseCase's `process_request` method"""
 
         # Add an object to the repository
-        dog_repo.create(name='Johnny', owner='John')
+        dog_model.create(name='Johnny', owner='John')
 
         # Build the request object and run the usecase
         request_obj = ShowRequestObject.from_dict(Dog, {'identifier': 1})
-        use_case = ShowUseCase(dog_repo)
+        use_case = ShowUseCase(dog_model)
         response = use_case.execute(request_obj)
         assert response is not None
         assert response.success
@@ -136,7 +136,7 @@ class TestShowUseCase:
 
         # Build the request object and run the usecase
         request_obj = ShowRequestObject.from_dict(Dog, {})
-        use_case = ShowUseCase(dog_repo)
+        use_case = ShowUseCase(dog_model)
         response = use_case.execute(request_obj)
         assert response is not None
         assert not response.success
@@ -146,7 +146,7 @@ class TestShowUseCase:
 
         # Build the request object and run the usecase
         request_obj = ShowRequestObject.from_dict(Dog, {'identifier': 12})
-        use_case = ShowUseCase(dog_repo)
+        use_case = ShowUseCase(dog_model)
         response = use_case.execute(request_obj)
         assert response is not None
         assert not response.success
@@ -158,21 +158,21 @@ class TestListUseCase:
     @classmethod
     def setup_class(cls):
         """ Setup instructions for this case """
-        dog_repo.create(name='Murdock', owner='John', age=7)
-        dog_repo.create(name='Jean', owner='John', age=3)
-        dog_repo.create(name='Bart', owner='Carrie', age=6)
+        dog_model.create(name='Murdock', owner='John', age=7)
+        dog_model.create(name='Jean', owner='John', age=3)
+        dog_model.create(name='Bart', owner='Carrie', age=6)
 
     @classmethod
     def teardown_class(cls):
         """ Teardown instructions for this case """
-        dog_repo.delete_all()
+        dog_model.delete_all()
 
     def test_process_request(self):
         """Test List UseCase's `process_request` method"""
         # Build the request object and run the usecase
         request_obj = ListRequestObject.from_dict(
             Dog, dict(order_by=['age'], owner='John'))
-        use_case = ListUseCase(dog_repo)
+        use_case = ListUseCase(dog_model)
         response = use_case.execute(request_obj)
 
         # Validate the response received
@@ -193,7 +193,7 @@ class TestCreateUseCase:
         # Fix and rerun the usecase
         request_data = dict(name='Barry', age=10, owner='Jimmy')
         request_obj = CreateRequestObject.from_dict(Dog, request_data)
-        use_case = CreateUseCase(dog_repo)
+        use_case = CreateUseCase(dog_model)
         response = use_case.execute(request_obj)
 
         assert response is not None
@@ -207,7 +207,7 @@ class TestCreateUseCase:
         # Build the request object and run the usecase
         request_data = dict(id=5, name='Jerry', age=10, owner='Jimmy')
         request_obj = CreateRequestObject.from_dict(Dog, request_data)
-        use_case = CreateUseCase(dog_repo)
+        use_case = CreateUseCase(dog_model)
         response = use_case.execute(request_obj)
 
         # Validate the response received
@@ -224,7 +224,7 @@ class TestUpdateUseCase:
     @classmethod
     def setup_class(cls):
         """ Setup instructions for this case """
-        cls.dog = dog_repo.create(name='Johnny', owner='John')
+        cls.dog = dog_model.create(name='Johnny', owner='John')
 
     def test_process_request(self):
         """Test Update UseCase's `process_request` method"""
@@ -232,7 +232,7 @@ class TestUpdateUseCase:
         # Build the request object and run the usecase
         request_obj = UpdateRequestObject.from_dict(
             Dog, {'identifier': self.dog.id, 'data': {'age': 13}})
-        use_case = UpdateUseCase(dog_repo)
+        use_case = UpdateUseCase(dog_model)
         response = use_case.execute(request_obj)
 
         # Validate the response received
@@ -246,7 +246,7 @@ class TestUpdateUseCase:
         # Build the request object and run the usecase
         request_obj = UpdateRequestObject.from_dict(
             Dog, {'identifier': self.dog.id, 'data': {'age': 'x'}})
-        use_case = UpdateUseCase(dog_repo)
+        use_case = UpdateUseCase(dog_model)
         response = use_case.execute(request_obj)
 
         # Validate the response received
@@ -260,7 +260,7 @@ class TestUpdateUseCase:
         # Build the request object and run the usecase
         request_obj = UpdateRequestObject.from_dict(
             Dog, {'identifier': self.dog.id, 'data': {'name': 'Barry'}})
-        use_case = UpdateUseCase(dog_repo)
+        use_case = UpdateUseCase(dog_model)
         response = use_case.execute(request_obj)
 
         # Validate the response received
@@ -278,7 +278,7 @@ class TestDeleteUseCase:
     @classmethod
     def setup_class(cls):
         """ Setup instructions for this case """
-        cls.dog = dog_repo.create(name='Jimmy', owner='John')
+        cls.dog = dog_model.create(name='Jimmy', owner='John')
 
     def test_process_request(self):
         """Test Delete UseCase's `process_request` method"""
@@ -286,7 +286,7 @@ class TestDeleteUseCase:
         # Build the request object and run the usecase
         request_obj = DeleteRequestObject.from_dict(
             Dog, {'identifier': self.dog.id})
-        use_case = DeleteUseCase(dog_repo)
+        use_case = DeleteUseCase(dog_model)
         response = use_case.execute(request_obj)
 
         # Validate the response received
@@ -297,7 +297,7 @@ class TestDeleteUseCase:
         # Try to lookup the object again
         request_obj = ShowRequestObject.from_dict(
             Dog, {'identifier': self.dog.id})
-        use_case = ShowUseCase(dog_repo)
+        use_case = ShowUseCase(dog_model)
         response = use_case.execute(request_obj)
         assert response is not None
         assert not response.success

--- a/tests/core/test_usecase.py
+++ b/tests/core/test_usecase.py
@@ -2,34 +2,13 @@
 
 import pytest
 
-from protean.core.entity import Entity
-from protean.core import field
 from protean.core.usecase import (
     UseCase, ShowUseCase, ShowRequestObject, ListRequestObject, ListUseCase,
     CreateRequestObject, CreateUseCase, UpdateRequestObject, UpdateUseCase,
     DeleteRequestObject, DeleteUseCase)
 from protean.core.repository import repo_factory
-from protean.impl.repository.dict_repo import DictModel
 
-
-class Dog(Entity):
-    """This is a dummy Dog Entity class"""
-    name = field.String(required=True, max_length=50, unique=True)
-    age = field.Integer(default=5)
-    owner = field.String(required=True, max_length=15)
-
-
-class DogAutoModel(DictModel):
-    """Model for the Dog Entity"""
-
-    class Meta:
-        """ Meta class for model options"""
-        entity = Dog
-        model_name = 'dogs-auto'
-
-
-repo_factory.register(DogAutoModel)
-dog_model = repo_factory.DogAutoModel
+from tests.support.dog import Dog
 
 
 class TestUseCase:
@@ -38,7 +17,7 @@ class TestUseCase:
     def test_init(self):
         """Test Initialization of the generic UseCase class"""
         with pytest.raises(TypeError):
-            UseCase(dog_model)
+            UseCase(repo_factory.Dog)
 
 
 class TestShowRequestObject:
@@ -119,11 +98,11 @@ class TestShowUseCase:
         """Test Show UseCase's `process_request` method"""
 
         # Add an object to the repository
-        dog_model.create(name='Johnny', owner='John')
+        repo_factory.Dog.create(name='Johnny', owner='John')
 
         # Build the request object and run the usecase
         request_obj = ShowRequestObject.from_dict(Dog, {'identifier': 1})
-        use_case = ShowUseCase(dog_model)
+        use_case = ShowUseCase(repo_factory.Dog)
         response = use_case.execute(request_obj)
         assert response is not None
         assert response.success
@@ -136,7 +115,7 @@ class TestShowUseCase:
 
         # Build the request object and run the usecase
         request_obj = ShowRequestObject.from_dict(Dog, {})
-        use_case = ShowUseCase(dog_model)
+        use_case = ShowUseCase(repo_factory.Dog)
         response = use_case.execute(request_obj)
         assert response is not None
         assert not response.success
@@ -146,7 +125,7 @@ class TestShowUseCase:
 
         # Build the request object and run the usecase
         request_obj = ShowRequestObject.from_dict(Dog, {'identifier': 12})
-        use_case = ShowUseCase(dog_model)
+        use_case = ShowUseCase(repo_factory.Dog)
         response = use_case.execute(request_obj)
         assert response is not None
         assert not response.success
@@ -158,28 +137,23 @@ class TestListUseCase:
     @classmethod
     def setup_class(cls):
         """ Setup instructions for this case """
-        dog_model.create(name='Murdock', owner='John', age=7)
-        dog_model.create(name='Jean', owner='John', age=3)
-        dog_model.create(name='Bart', owner='Carrie', age=6)
-
-    @classmethod
-    def teardown_class(cls):
-        """ Teardown instructions for this case """
-        dog_model.delete_all()
+        repo_factory.Dog.create(name='Murdock', owner='John', age=7)
+        repo_factory.Dog.create(name='Jean', owner='John', age=3)
+        repo_factory.Dog.create(name='Bart', owner='Carrie', age=6)
 
     def test_process_request(self):
         """Test List UseCase's `process_request` method"""
         # Build the request object and run the usecase
         request_obj = ListRequestObject.from_dict(
             Dog, dict(order_by=['age'], owner='John'))
-        use_case = ListUseCase(dog_model)
+        use_case = ListUseCase(repo_factory.Dog)
         response = use_case.execute(request_obj)
 
         # Validate the response received
         assert response is not None
         assert response.success
         assert response.value.page == 1
-        assert response.value.total == 3
+        assert response.value.total == 2
         assert response.value.first.id == 3
         assert response.value.first.age == 3
 
@@ -193,7 +167,7 @@ class TestCreateUseCase:
         # Fix and rerun the usecase
         request_data = dict(name='Barry', age=10, owner='Jimmy')
         request_obj = CreateRequestObject.from_dict(Dog, request_data)
-        use_case = CreateUseCase(dog_model)
+        use_case = CreateUseCase(repo_factory.Dog)
         response = use_case.execute(request_obj)
 
         assert response is not None
@@ -204,10 +178,15 @@ class TestCreateUseCase:
     def test_unique_validation(self):
         """Test unique validation for create usecase"""
 
-        # Build the request object and run the usecase
-        request_data = dict(id=5, name='Jerry', age=10, owner='Jimmy')
+        request_data = dict(name='Drew', age=10, owner='Jimmy')
         request_obj = CreateRequestObject.from_dict(Dog, request_data)
-        use_case = CreateUseCase(dog_model)
+        use_case = CreateUseCase(repo_factory.Dog)
+        response = use_case.execute(request_obj)
+
+        # Build the request object and run the usecase
+        request_data = dict(id=response.value.id, name='Jerry', age=10, owner='Jimmy')
+        request_obj = CreateRequestObject.from_dict(Dog, request_data)
+        use_case = CreateUseCase(repo_factory.Dog)
         response = use_case.execute(request_obj)
 
         # Validate the response received
@@ -215,38 +194,39 @@ class TestCreateUseCase:
         assert not response.success
         assert response.value == {
             'code': 422,
-            'message': {'id': ['`dogs-auto` with this `id` already exists.']}}
+            'message': {'id': ['`dogs` with this `id` already exists.']}}
 
 
 class TestUpdateUseCase:
     """Tests for the generic UpdateUseCase Class"""
 
-    @classmethod
-    def setup_class(cls):
+    @pytest.fixture(scope="function")
+    def dog_to_update(self):
         """ Setup instructions for this case """
-        cls.dog = dog_model.create(name='Johnny', owner='John')
+        dog = repo_factory.Dog.create(name='Johnny', owner='John')
+        yield dog
 
-    def test_process_request(self):
+    def test_process_request(self, dog_to_update):
         """Test Update UseCase's `process_request` method"""
 
         # Build the request object and run the usecase
         request_obj = UpdateRequestObject.from_dict(
-            Dog, {'identifier': self.dog.id, 'data': {'age': 13}})
-        use_case = UpdateUseCase(dog_model)
+            Dog, {'identifier': dog_to_update.id, 'data': {'age': 13}})
+        use_case = UpdateUseCase(repo_factory.Dog)
         response = use_case.execute(request_obj)
 
         # Validate the response received
         assert response is not None
         assert response.success
-        assert response.value.id == self.dog.id
+        assert response.value.id == dog_to_update.id
         assert response.value.age == 13
 
-    def test_validation_errors(self):
+    def test_validation_errors(self, dog_to_update):
         """Test Update Usecase for validation errors"""
         # Build the request object and run the usecase
         request_obj = UpdateRequestObject.from_dict(
-            Dog, {'identifier': self.dog.id, 'data': {'age': 'x'}})
-        use_case = UpdateUseCase(dog_model)
+            Dog, {'identifier': dog_to_update.id, 'data': {'age': 'x'}})
+        use_case = UpdateUseCase(repo_factory.Dog)
         response = use_case.execute(request_obj)
 
         # Validate the response received
@@ -255,12 +235,15 @@ class TestUpdateUseCase:
         assert response.value == {
             'code': 422, 'message': {'age': ['"x" value must be an integer.']}}
 
-    def test_unique_validation(self):
+    def test_unique_validation(self, dog_to_update):
         """Test Update Usecase for unique validation"""
+        # Create a dog with the same name
+        repo_factory.Dog.create(name='Barry', owner='John')
+
         # Build the request object and run the usecase
         request_obj = UpdateRequestObject.from_dict(
-            Dog, {'identifier': self.dog.id, 'data': {'name': 'Barry'}})
-        use_case = UpdateUseCase(dog_model)
+            Dog, {'identifier': dog_to_update.id, 'data': {'name': 'Barry'}})
+        use_case = UpdateUseCase(repo_factory.Dog)
         response = use_case.execute(request_obj)
 
         # Validate the response received
@@ -269,7 +252,7 @@ class TestUpdateUseCase:
         assert response.value == {
             'code': 422,
             'message': {
-                'name': ['`dogs-auto` with this `name` already exists.']}}
+                'name': ['`dogs` with this `name` already exists.']}}
 
 
 class TestDeleteUseCase:
@@ -278,7 +261,7 @@ class TestDeleteUseCase:
     @classmethod
     def setup_class(cls):
         """ Setup instructions for this case """
-        cls.dog = dog_model.create(name='Jimmy', owner='John')
+        cls.dog = repo_factory.Dog.create(name='Jimmy', owner='John')
 
     def test_process_request(self):
         """Test Delete UseCase's `process_request` method"""
@@ -286,7 +269,7 @@ class TestDeleteUseCase:
         # Build the request object and run the usecase
         request_obj = DeleteRequestObject.from_dict(
             Dog, {'identifier': self.dog.id})
-        use_case = DeleteUseCase(dog_model)
+        use_case = DeleteUseCase(repo_factory.Dog)
         response = use_case.execute(request_obj)
 
         # Validate the response received
@@ -297,7 +280,7 @@ class TestDeleteUseCase:
         # Try to lookup the object again
         request_obj = ShowRequestObject.from_dict(
             Dog, {'identifier': self.dog.id})
-        use_case = ShowUseCase(dog_model)
+        use_case = ShowUseCase(repo_factory.Dog)
         response = use_case.execute(request_obj)
         assert response is not None
         assert not response.success

--- a/tests/support/dog.py
+++ b/tests/support/dog.py
@@ -1,0 +1,21 @@
+"""Support Classes for Test Cases"""
+
+from protean.core.entity import Entity
+from protean.core import field
+from protean.impl.repository.dict_repo import DictModel
+
+
+class Dog(Entity):
+    """This is a dummy Dog Entity class"""
+    name = field.String(required=True, unique=True, max_length=50)
+    age = field.Integer(default=5)
+    owner = field.String(required=True, max_length=15)
+
+
+class DogModel(DictModel):
+    """ Model for the Dog Entity"""
+
+    class Meta:
+        """ Meta class for model options"""
+        entity = Dog
+        model_name = 'dogs'

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -4,12 +4,12 @@ import threading
 import time
 
 from protean.core.usecase import CreateUseCase, CreateRequestObject
-from protean.core.repository import repo
+from protean.core.repository import repo_factory
 from protean.core.entity import Entity
 from protean.core.tasklet import Tasklet
 from protean.context import context
 from protean.core import field
-from protean.impl.repository.dict_repo import DictSchema
+from protean.impl.repository.dict_repo import DictModel
 
 
 class CreateUseCase2(CreateUseCase):
@@ -28,16 +28,16 @@ class ThreadedDog(Entity):
     created_by = field.String(required=True, max_length=15)
 
 
-class ThreadedDogSchema(DictSchema):
-    """ Schema for the ThreadedDog Entity"""
+class ThreadedDogModel(DictModel):
+    """ Model for the ThreadedDog Entity"""
 
     class Meta:
         """ Meta class for schema options"""
         entity = ThreadedDog
-        schema_name = 'threaded_dogs'
+        model_name = 'threaded_dogs'
 
 
-repo.register(ThreadedDogSchema)
+repo_factory.register(ThreadedDogModel)
 
 
 def test_context_with_threads():
@@ -51,7 +51,7 @@ def test_context_with_threads():
         # move forward
         time.sleep(sleep)
         Tasklet.perform(
-            repo, ThreadedDogSchema, CreateUseCase2, CreateRequestObject,
+            repo_factory, ThreadedDogModel, CreateUseCase2, CreateRequestObject,
             {'name': name})
 
     # Run 5 threads and create multiple objects
@@ -76,7 +76,7 @@ def test_context_with_threads():
         t.join()
 
     # Get the list of dogs and validate the results
-    dogs = repo.ThreadedDogSchema.filter(per_page=-1)
+    dogs = repo_factory.ThreadedDogModel.filter(per_page=-1)
     assert dogs.total == 5
     for dog in dogs.items:
         if dog.name == 'Johnny':
@@ -91,4 +91,4 @@ def test_context_with_threads():
             assert dog.created_by == 'thread_5'
 
     # Cleanup the database
-    repo.ThreadedDogSchema.delete_all()
+    repo_factory.ThreadedDogModel.delete_all()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -50,8 +50,9 @@ def test_context_with_threads():
         # Sleep for some determinate time to allow other threads to
         # move forward
         time.sleep(sleep)
+
         Tasklet.perform(
-            repo_factory, ThreadedDogModel, CreateUseCase2, CreateRequestObject,
+            repo_factory, ThreadedDog, CreateUseCase2, CreateRequestObject,
             {'name': name})
 
     # Run 5 threads and create multiple objects
@@ -76,7 +77,7 @@ def test_context_with_threads():
         t.join()
 
     # Get the list of dogs and validate the results
-    dogs = repo_factory.ThreadedDogModel.filter(per_page=-1)
+    dogs = repo_factory.ThreadedDog.filter(per_page=10)
     assert dogs.total == 5
     for dog in dogs.items:
         if dog.name == 'Johnny':
@@ -91,4 +92,4 @@ def test_context_with_threads():
             assert dog.created_by == 'thread_5'
 
     # Cleanup the database
-    repo_factory.ThreadedDogModel.delete_all()
+    repo_factory.ThreadedDog.delete_all()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -51,9 +51,7 @@ def test_context_with_threads():
         # move forward
         time.sleep(sleep)
 
-        Tasklet.perform(
-            repo_factory, ThreadedDog, CreateUseCase2, CreateRequestObject,
-            {'name': name})
+        Tasklet.perform(ThreadedDog, CreateUseCase2, CreateRequestObject, {'name': name})
 
     # Run 5 threads and create multiple objects
     threads = [
@@ -77,7 +75,7 @@ def test_context_with_threads():
         t.join()
 
     # Get the list of dogs and validate the results
-    dogs = repo_factory.ThreadedDog.filter(per_page=10)
+    dogs = ThreadedDog.filter(per_page=10)
     assert dogs.total == 5
     for dog in dogs.items:
         if dog.name == 'Johnny':


### PR DESCRIPTION
Closes #58 (Also includes changes for #57 and #56)

With this change, we move to a Domain Model centric application as shown below:

**Core Application:**
```
class Dog(Entity):
    """This is a dummy Dog Entity class"""
    name = field.String(required=True, unique=True, max_length=50)
    age = field.Integer(default=5)
    owner = field.String(required=True, max_length=15)

Dog.create(name='Johnny', owner='John')
```

**Database-aware Implementation:**
```
class DogModel(DictModel):
    """ Model for the Dog Entity"""

    class Meta:
        """ Meta class for model options"""
        entity = Dog
        model_name = 'dogs'

repo_factory.register(DogModel)
```