### PR TITLE
60 Allow `Entity` to accept keyword arguments for `update` method

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,6 +45,10 @@ The User Guide
 
 This part of the documentation introduces some background information about protean, then focuses on step-by-step instructions for getting the most out of Protean.
 
+.. note:: Protean's test code is littered with usage of a certain `Dog` class. If you find that discomforting, replace `Dog` with `CuteLittlePuppyDog` everywhere.
+
+    **Disclosure**: No real dog was harmed in the process of building this framework.
+
 .. toctree::
    :maxdepth: 2
    :caption: User Guide

--- a/src/protean/core/entity.py
+++ b/src/protean/core/entity.py
@@ -341,9 +341,9 @@ class Entity(metaclass=EntityBase):
 
         Supports both dictionary and keyword argument updates to the entity::
 
-            Dog.update({'age': 10})
+            dog.update({'age': 10})
 
-            Dog.update(age=10)
+            dog.update(age=10)
 
         :param data: Dictionary of values to be updated for the entity
         :param kwargs: keyword arguments with key-value pairs to be updated

--- a/src/protean/core/usecase/generic.py
+++ b/src/protean/core/usecase/generic.py
@@ -176,7 +176,7 @@ class UpdateUseCase(UseCase):
         entity = request_object.entity_cls.get(request_object.identifier)
 
         # Update the object and return the updated data
-        resource = entity.update(data=request_object.data)
+        resource = entity.update(request_object.data)
         return ResponseSuccess(Status.SUCCESS, resource)
 
 

--- a/tests/core/test_entity.py
+++ b/tests/core/test_entity.py
@@ -157,6 +157,16 @@ class TestEntity:
         assert u_dog is not None
         assert u_dog.age == 10
 
+    def test_update_with_dict_and_kwargs(self):
+        """ Update an existing entity in the repository"""
+        dog = Dog.create(id=2, name='Johnny', owner='Carey', age=2)
+
+        dog.update({'owner': 'Stephen'}, age=10)
+        u_dog = Dog.get(2)
+        assert u_dog is not None
+        assert u_dog.age == 10
+        assert u_dog.owner == 'Stephen'
+
     def test_that_update_runs_validations(self):
         """Try updating with invalid values"""
         dog = Dog.create(id=1, name='Johnny', owner='Carey', age=2)

--- a/tests/core/test_entity.py
+++ b/tests/core/test_entity.py
@@ -137,13 +137,22 @@ class TestEntity:
         dog = Dog.create(id=11344234, name='Johnny', owner='John')
         dog.delete()
         with pytest.raises(ObjectNotFoundError):
-            dog.update(data=dict(age=10))
+            dog.update({'age': 10})
 
-    def test_update(self):
+    def test_update_with_dict(self):
         """ Update an existing entity in the repository"""
         dog = Dog.create(id=2, name='Johnny', owner='Carey', age=2)
 
-        dog.update(data=dict(age=10))
+        dog.update({'age':10})
+        u_dog = Dog.get(2)
+        assert u_dog is not None
+        assert u_dog.age == 10
+
+    def test_update_with_kwargs(self):
+        """ Update an existing entity in the repository"""
+        dog = Dog.create(id=2, name='Johnny', owner='Carey', age=2)
+
+        dog.update(age=10)
         u_dog = Dog.get(2)
         assert u_dog is not None
         assert u_dog.age == 10
@@ -153,7 +162,7 @@ class TestEntity:
         dog = Dog.create(id=1, name='Johnny', owner='Carey', age=2)
 
         with pytest.raises(ValidationError):
-            dog.update(data=dict(age='x'))
+            dog.update(age='x')
 
     def test_unique(self):
         """ Test the unique constraints for the entity """

--- a/tests/core/test_repository.py
+++ b/tests/core/test_repository.py
@@ -40,7 +40,7 @@ class TestRepository:
         """ Update an existing entity in the repository"""
         dog = Dog.create(id=2, name='Johnny', owner='Carey', age=2)
 
-        dog.update(data=dict(age=10))
+        dog.update(age=10)
         u_dog = Dog.get(2)
         assert u_dog is not None
         assert u_dog.age == 10
@@ -50,7 +50,7 @@ class TestRepository:
         dog = Dog.create(id=1, name='Johnny', owner='Carey', age=2)
 
         with pytest.raises(ValidationError):
-            dog.update(data=dict(age='x'))
+            dog.update(age='x')
 
     def test_unique(self):
         """ Test the unique constraints for the entity """


### PR DESCRIPTION
Now we can do both:
```
dog.update({'age': 10})
```

as well as:
```
dog.update(age=10)
```

AND:
```
dog.update({'owner': 'Stephen'}, age=10)
```
Closes #60 