### PR TITLE
#63 Add `find_by` method to Entity

### DIFF
--- a/src/protean/core/entity.py
+++ b/src/protean/core/entity.py
@@ -235,6 +235,29 @@ class Entity(metaclass=EntityBase):
         return results.first
 
     @classmethod
+    def find_by(cls, **kwargs) -> 'Entity':
+        """Find a specific entity record that matches one or more criteria.
+
+        :param kwargs: named arguments consisting of attr_name and attr_value pairs to search on
+        """
+        logger.debug(f'Lookup `{cls.__name__}` object with values '
+                     f'{[item for item in kwargs.items()]}')
+
+        filters = {}
+        for item in kwargs.items():
+            filters[item[0]] = item[1]
+
+        # Find this item in the repository or raise Error
+        results = cls.filter(page=1, per_page=1, **filters)
+        if not results:
+            raise ObjectNotFoundError(
+                f'`{cls.__name__}` object with values {[item for item in kwargs.items()]} '
+                f'does not exist.')
+
+        # Return the first result
+        return results.first
+
+    @classmethod
     def _retrieve_model(cls):
         """Retrieve model details associated with this Entity"""
         from protean.core.repository import repo_factory  # FIXME Move to a better placement

--- a/tests/core/test_entity.py
+++ b/tests/core/test_entity.py
@@ -114,6 +114,57 @@ class TestEntity:
         assert dog.to_dict() == {
             'age': 10, 'id': 1, 'name': 'John Doe', 'owner': 'Jimmy'}
 
+    def test_get(self):
+        """Test Entity Retrieval by its primary key"""
+        Dog.create(id=1234, name='Johnny', owner='John')
+
+        dog = Dog.get(1234)
+        assert dog is not None
+        assert dog.id == 1234
+
+    def test_get_object_not_found_error(self):
+        """Test failed Entity Retrieval by its primary key"""
+        Dog.create(id=1234, name='Johnny', owner='John')
+
+        with pytest.raises(ObjectNotFoundError):
+            Dog.get(1235)
+
+    def test_find_by(self):
+        """Test Entity retrieval by a specific column's value"""
+
+        Dog.create(id=2345, name='Johnny', owner='John')
+
+        dog = Dog.find_by(name='Johnny')
+        assert dog is not None
+        assert dog.id == 2345
+
+    def test_find_by_object_not_found_error(self):
+        """Test Entity retrieval by specific column value(s)"""
+
+        Dog.create(id=2345, name='Johnny', owner='John')
+
+        with pytest.raises(ObjectNotFoundError):
+            Dog.find_by(name='JohnnyChase')
+
+    def test_find_by_multiple_attributes(self):
+        """Test Entity retrieval by multiple column value(s)"""
+
+        Dog.create(id=2346, name='Johnny1', age=8, owner='John')
+        Dog.create(id=2347, name='Johnny2', age=6, owner='John')
+
+        dog = Dog.find_by(name='Johnny1', age=8)
+        assert dog is not None
+        assert dog.id == 2346
+
+    def test_find_by_multiple_attributes_object_not_found_error(self):
+        """Test Entity retrieval by multiple column value(s)"""
+
+        Dog.create(id=2346, name='Johnny1', age=8, owner='John')
+        Dog.create(id=2347, name='Johnny2', age=6, owner='John')
+
+        with pytest.raises(ObjectNotFoundError):
+            Dog.find_by(name='Johnny1', age=6)
+
     def test_create_error(self):
         """ Add an entity to the repository missing a required attribute"""
         with pytest.raises(ValidationError):


### PR DESCRIPTION
`find_by` will allow search by one or more attributes for a given Entity.

If no results are found, `find_by` raises `ObjectNotFoundError`.

Closes #63 