### PR TITLE
#70 Cache Results after the QuerySet is evaluated

### DIFF
--- a/src/protean/core/repository/pagination.py
+++ b/src/protean/core/repository/pagination.py
@@ -30,7 +30,7 @@ class Pagination(object):
     @property
     def has_prev(self):
         """True if a previous page exists"""
-        return self.page > 1
+        return bool(self.items) and self.page > 1
 
     @property
     def has_next(self):

--- a/tests/core/test_entity.py
+++ b/tests/core/test_entity.py
@@ -481,7 +481,7 @@ class TestQuerySet:
         query = Dog.query.filter(owner='John').order_by('age')
         assert repr(query) == ("<QuerySet: {'_entity_cls_name': 'Dog', '_page': 1, "
                                "'_per_page': 10, '_order_by': {'age'}, '_excludes': {}, "
-                               "'_filters': {'owner': 'John'}}>")
+                               "'_filters': {'owner': 'John'}, '_result_cache': None}>")
 
     def test_bool_false(self):
         """Test that `bool` returns `False` on no records"""
@@ -523,6 +523,26 @@ class TestQuerySet:
         sliced = query[1:]
         assert len(sliced) == 4
 
+    def test_caching(self):
+        """Test that results are cached after query is evaluated"""
+        # Add multiple entries to the DB
+        Dog.create(id=2, name='Murdock', age=7, owner='John')
+        Dog.create(id=3, name='Jean', age=3, owner='John')
+        Dog.create(id=4, name='Bart', age=6, owner='Carrie')
+
+        # Filter by Dog attributes
+        query = Dog.query.filter(owner='John').order_by('age')
+
+        # Result cache is empty to begin with
+        assert query._result_cache is None
+
+        # Total invokes an evaluation and a query
+        assert query.total == 2
+
+        # Result cache is now populated
+        assert query._result_cache is not None
+        assert query._result_cache.total == 2
+
     def test_total(self):
         """Test value of `total` results"""
         # Add multiple entries to the DB
@@ -533,6 +553,27 @@ class TestQuerySet:
         # Filter by Dog attributes
         query = Dog.query.filter(owner='John').order_by('age')
         assert query.total == 2
+
+    def test_total_with_cache(self):
+        """Test value of `total` results without refresh"""
+        # Add multiple entries to the DB
+        Dog.create(id=2, name='Murdock', age=7, owner='John')
+        Dog.create(id=3, name='Jean', age=3, owner='John')
+        Dog.create(id=4, name='Bart', age=6, owner='Carrie')
+
+        # Filter by Dog attributes
+        query = Dog.query.filter(owner='John').order_by('age')
+        assert query.total == 2
+
+        Dog.create(id=5, name='Berry', age=1, owner='John')
+        assert query.total == 2
+        assert query._result_cache.total == 2
+
+        # Force a refresh
+        assert query.all().total == 3
+
+        # Result cache is now populated
+        assert query._result_cache.total == 3
 
     def test_items(self):
         """Test that items is retrieved from Pagination results"""
@@ -545,6 +586,22 @@ class TestQuerySet:
         query = Dog.query.filter(owner='John').order_by('age')
         assert query.items[0].id == query.all().items[0].id
 
+    def test_items_with_cache(self):
+        """Test that items is retrieved from Pagination results"""
+        # Add multiple entries to the DB
+        Dog.create(id=2, name='Murdock', age=7, owner='John')
+        Dog.create(id=3, name='Jean', age=3, owner='John')
+        Dog.create(id=4, name='Bart', age=6, owner='Carrie')
+
+        # Filter by Dog attributes
+        query = Dog.query.filter(owner='John').order_by('age')
+        assert query.items[0].id == 3
+
+        Dog.create(id=5, name='Berry', age=1, owner='John')
+        assert query.items[0].id == 3
+
+        assert query.all().items[0].id == 5
+
     def test_has_next(self):
         """Test if there are results after the current set"""
         # Add multiple entries to the DB
@@ -555,6 +612,22 @@ class TestQuerySet:
         # Filter by Dog attributes
         query = Dog.query.paginate(page=1, per_page=2)
         assert query.has_next is True
+
+    def test_has_next_with_cache(self):
+        """Test if there are results after the current set"""
+        # Add multiple entries to the DB
+        Dog.create(id=2, name='Murdock', age=7, owner='John')
+        Dog.create(id=3, name='Jean', age=3, owner='John')
+        dog = Dog.create(id=4, name='Bart', age=6, owner='Carrie')
+
+        # Filter by Dog attributes
+        query = Dog.query.paginate(page=1, per_page=2)
+        assert query.has_next is True
+
+        dog.delete()
+
+        assert query.has_next is True
+        assert query.all().has_next is False
 
     def test_has_prev(self):
         """Test if there are results before the current set"""
@@ -567,6 +640,22 @@ class TestQuerySet:
         query = Dog.query.paginate(page=2, per_page=2)
         assert query.has_prev is True
 
+    def test_has_prev_with_cache(self):
+        """Test if there are results before the current set"""
+        # Add multiple entries to the DB
+        Dog.create(id=2, name='Murdock', age=7, owner='John')
+        Dog.create(id=3, name='Jean', age=3, owner='John')
+        dog = Dog.create(id=4, name='Bart', age=6, owner='Carrie')
+
+        # Filter by Dog attributes
+        query = Dog.query.paginate(page=2, per_page=2)
+        assert query.has_prev is True
+
+        dog.delete()
+
+        assert query.has_prev is True
+        assert query.all().has_prev is False
+
     def test_first(self):
         """Test that the first item is retrieved correctly from the resultset"""
         # Add multiple entries to the DB
@@ -577,3 +666,18 @@ class TestQuerySet:
         # Filter by Dog attributes
         query = Dog.query.order_by('-age')
         assert query.first.id == 2
+
+    def test_first_with_cache(self):
+        """Test that the first item is retrieved correctly from the resultset"""
+        # Add multiple entries to the DB
+        Dog.create(id=2, name='Murdock', age=7, owner='John')
+        Dog.create(id=3, name='Jean', age=3, owner='John')
+        Dog.create(id=4, name='Bart', age=6, owner='Carrie')
+
+        # Filter by Dog attributes
+        query = Dog.query.order_by('-age')
+        assert query.first.id == 2
+
+        Dog.create(id=5, name='Berry', age=8, owner='John')
+        assert query.first.id == 2
+        assert query.all().first.id == 5

--- a/tests/core/test_entity.py
+++ b/tests/core/test_entity.py
@@ -543,6 +543,23 @@ class TestQuerySet:
         assert query._result_cache is not None
         assert query._result_cache.total == 2
 
+    def test_cache_reset(self):
+        """Test that results are cached after query is evaluated"""
+        # Add multiple entries to the DB
+        Dog.create(id=2, name='Murdock', age=7, owner='John')
+        Dog.create(id=3, name='Jean', age=3, owner='John')
+        Dog.create(id=4, name='Bart', age=6, owner='Carrie')
+
+        # Filter by Dog attributes
+        query = Dog.query.filter(owner='John').order_by('age')
+
+        # Total invokes an evaluation and a query
+        assert query.total == 2
+        assert query._result_cache.total == 2
+
+        query_dup = query.paginate(per_page=25)
+        assert query_dup._result_cache is None
+
     def test_total(self):
         """Test value of `total` results"""
         # Add multiple entries to the DB


### PR DESCRIPTION
A `QuerySet` will cache its results once evaluated. If the data in the database might have changed,
we can get updated results for the same query by calling `all()` on a previously evaluated `QuerySet`.

Closes #70 