### PR TITLE
68 Support Query Operators for Entities

### DIFF
--- a/src/protean/core/entity.py
+++ b/src/protean/core/entity.py
@@ -73,7 +73,7 @@ class EntityBase(type):
 class EntityMeta:
     """ Metadata information for the entity including any options defined."""
 
-    def __init__(self, meta, entity_cls):
+    def __init__(self, meta, entity_cls):  # FIXME Remote `meta`?
         self.entity_cls = entity_cls
         self.declared_fields = {}
         self.id_field = None
@@ -226,21 +226,21 @@ class QuerySet:
                 parts = key.split('__')
 
                 if len(parts) == 1:
-                    self._restructured_filters[key] = (self._filters[key], 'exact')
+                    self._restructured_filters[key] = ('exact', self._filters[key])
                 else:
                     # Ensure that the key structure is sane and contains exactly one operator
                     assert len(parts) == 2
-                    self._restructured_filters[parts[0]] = (self._filters[key], parts[1])
+                    self._restructured_filters[parts[0]] = (parts[1], self._filters[key])
 
             for key in self._excludes:
                 parts = key.split('__')
 
                 if len(parts) == 1:
-                    self._restructured_excludes[key] = (self._excludes[key], 'exact')
+                    self._restructured_excludes[key] = ('exact', self._excludes[key])
                 else:
                     # Ensure that the key structure is sane and contains exactly one operator
                     assert len(parts) == 2
-                    self._restructured_excludes[parts[0]] = (self._excludes[key], parts[1])
+                    self._restructured_excludes[parts[0]] = (parts[1], self._excludes[key])
 
             self.evaluated = True
 
@@ -586,7 +586,6 @@ class Entity(metaclass=EntityBase):
             values[item[0]] = getattr(self, item[0])
 
         return self.__class__.create(**values)
-
 
     def update(self, *data, **kwargs) -> 'Entity':
         """Update a Record in the repository.

--- a/src/protean/core/repository/__init__.py
+++ b/src/protean/core/repository/__init__.py
@@ -3,11 +3,12 @@
 from .base import BaseAdapter
 from .base import BaseConnectionHandler
 from .base import BaseModel
+from .base import Lookup
 from .base import ModelOptions
 from .factory import RepositoryFactory
 from .factory import repo_factory
 from .pagination import Pagination
 
-__all__ = ('BaseAdapter', 'BaseModel', 'ModelOptions',
+__all__ = ('BaseAdapter', 'BaseModel', 'Lookup', 'ModelOptions',
            'BaseConnectionHandler', 'RepositoryFactory', 'repo_factory',
            'Pagination')

--- a/src/protean/core/repository/base.py
+++ b/src/protean/core/repository/base.py
@@ -123,6 +123,14 @@ class Lookup(metaclass=ABCMeta):
         """Source is LHS and Target is RHS of a comparsion"""
         self.source, self.target = source, target
 
+    def process_source(self):
+        """Blank implementation; returns source"""
+        return self.source
+
+    def process_target(self):
+        """Blank implementation; returns target"""
+        return self.target
+
     @abstractmethod
     def as_expression(self):
         """To be implemented in each Adapter for its Lookups"""

--- a/src/protean/core/repository/base.py
+++ b/src/protean/core/repository/base.py
@@ -8,13 +8,14 @@ from protean.core.entity import Entity
 from protean.core.exceptions import ConfigurationError
 from protean.utils import inflection
 from protean.utils.meta import OptionsMeta
+from protean.utils.query import RegisterLookupMixin
 
 from .pagination import Pagination
 
 logger = logging.getLogger('protean.repository')
 
 
-class BaseAdapter(metaclass=ABCMeta):
+class BaseAdapter(RegisterLookupMixin, metaclass=ABCMeta):
     """Adapter interface to interact with databases
 
     :param conn: A connection/session to the data source of the model
@@ -112,3 +113,17 @@ class BaseConnectionHandler(metaclass=ABCMeta):
     @abstractmethod
     def close_connection(self, conn):
         """ Close the connection object for the repository"""
+
+
+class Lookup(metaclass=ABCMeta):
+    """Base Lookup class to implement in Adapters"""
+    lookup_name = None
+
+    def __init__(self, source, target):
+        """Source is LHS and Target is RHS of a comparsion"""
+        self.source, self.target = source, target
+
+    @abstractmethod
+    def as_expression(self):
+        """To be implemented in each Adapter for its Lookups"""
+        raise NotImplementedError

--- a/src/protean/impl/repository/dict_repo.py
+++ b/src/protean/impl/repository/dict_repo.py
@@ -60,15 +60,13 @@ class Adapter(BaseAdapter):
             match = True
 
             # Add objects that match the given filters
-            for fk, fv in filters.items():
-                lookup_class = self.get_lookup(fv[0])
-                lookup = lookup_class(item[fk], fv[1])
+            for key, (lookup_class, value) in filters.items():
+                lookup = lookup_class(item[key], value)
                 match &= eval(lookup.as_expression())
 
             # Add objects that do not match excludes
-            for fk, fv in excludes.items():
-                lookup_class = self.get_lookup(fv[0])
-                lookup = lookup_class(item[fk], fv[1])
+            for key, (lookup_class, value) in excludes.items():
+                lookup = lookup_class(item[key], value)
                 match &= not eval(lookup.as_expression())
 
             if match:

--- a/src/protean/utils/query.py
+++ b/src/protean/utils/query.py
@@ -1,0 +1,74 @@
+"""Utility classes and methods for DB Adapters and Query Constructors"""
+import functools
+import inspect
+
+
+def subclasses(cls):
+    """Iterator utilty to loop and clear registered Lookups against a class"""
+    yield cls
+    for subclass in cls.__subclasses__():
+        yield from subclasses(subclass)
+
+
+class RegisterLookupMixin:
+    """Helper Mixin to register Lookups to an Adapter"""
+    @classmethod
+    def _get_lookup(cls, lookup_name):
+        return cls.get_lookups().get(lookup_name, None)
+
+    @classmethod
+    @functools.lru_cache(maxsize=None)
+    def get_lookups(cls):
+        """Fetch all Lookups"""
+        class_lookups = [parent.__dict__.get('class_lookups', {}) for parent in inspect.getmro(cls)]
+        return cls.merge_dicts(class_lookups)
+
+    def get_lookup(self, lookup_name):
+        """Fetch Lookup by name"""
+        from protean.core.repository import Lookup
+        lookup = self._get_lookup(lookup_name)
+
+        # If unable to find Lookup, or if Lookup is the wrong class, raise Error
+        if lookup is None or (lookup is not None and not issubclass(lookup, Lookup)):
+            raise NotImplementedError
+
+        return lookup
+
+    @staticmethod
+    def merge_dicts(dicts):
+        """
+        Merge dicts in reverse to preference the order of the original list. e.g.,
+        merge_dicts([a, b]) will preference the keys in 'a' over those in 'b'.
+        """
+        merged = {}
+        for d in reversed(dicts):
+            merged.update(d)
+        return merged
+
+    @classmethod
+    def _clear_cached_lookups(cls):
+        for subclass in subclasses(cls):
+            subclass.get_lookups.cache_clear()
+
+    @classmethod
+    def register_lookup(cls, lookup, lookup_name=None):
+        """Register a Lookup to a class"""
+        if lookup_name is None:
+            lookup_name = lookup.lookup_name
+        if 'class_lookups' not in cls.__dict__:
+            cls.class_lookups = {}
+
+        cls.class_lookups[lookup_name] = lookup
+        cls._clear_cached_lookups()
+
+        return lookup
+
+    @classmethod
+    def _unregister_lookup(cls, lookup, lookup_name=None):
+        """
+        Remove given lookup from cls lookups. For use in tests only as it's
+        not thread-safe.
+        """
+        if lookup_name is None:
+            lookup_name = lookup.lookup_name
+        del cls.class_lookups[lookup_name]

--- a/tests/core/test_entity.py
+++ b/tests/core/test_entity.py
@@ -446,6 +446,17 @@ class TestEntity:
         assert dogs_contains.total == 1
         assert dogs_icontains.total == 2
 
+    def test_invalid_comparison_on_query_evaluation(self):
+        """Query with an invalid/unimplemented comparison"""
+        # Add multiple entries to the DB
+        Dog.create(id=2, name='Murdock', age=7, owner='John')
+        Dog.create(id=3, name='Jean', age=3, owner='john')
+        Dog.create(id=4, name='Bart', age=6, owner='Carrie')
+
+        # Filter by the Owner
+        with pytest.raises(NotImplementedError):
+            dogs_notexact = Dog.query.filter(age__notexact=3).all()
+
     def test_pagination(self):
         """ Test the pagination of the filter results"""
         for counter in range(1, 5):

--- a/tests/core/test_repository.py
+++ b/tests/core/test_repository.py
@@ -116,3 +116,31 @@ class TestRepository:
         """ Test closing all connections to the repository"""
         assert 'default' in _databases
         repo_factory.close_connections()
+
+
+class TestLookup:
+    """This class holds tests for Lookup Class"""
+
+    from protean.core.repository import Lookup
+    from protean.impl.repository.dict_repo import Adapter
+
+    @Adapter.register_lookup
+    class SampleLookup(Lookup):
+        """A simple implementation of lookup class"""
+        lookup_name = "sample"
+        def as_expression(self):
+            return '%s %s %s' % (self.process_source(),
+                                 '<<<>>>',
+                                 self.process_target())
+
+    def test_init(self):
+        """Test initialization of a Lookup Object"""
+
+        lookup = self.SampleLookup("src", "trg")
+        assert lookup.as_expression() == "src <<<>>> trg"
+
+    def test_registration(self):
+        """Test registering a lookup to an adapter"""
+        from protean.impl.repository.dict_repo import Adapter
+
+        assert Adapter.get_lookups().get('sample') == self.SampleLookup


### PR DESCRIPTION
Supported filtering/query operators are:

- `exact` - Default operator, equivalent to eq for all objects
- `iexact` - case-insensitive match, if String. Will throw error for non-character types
- `contains`
- `icontains`
- `in` - Applicable to iterable types
- `gte`
- `gt`
- `lte`
- `lt`

**Notes:**

- Negation is supported by `exclude()`: Criteria are ANDed and then negated
- All criteria specified in `.filter()` are ANDed
- Multiple filter clauses get collapsed together as part of a single AND clause

**Examples:**
* _Example 1_: `Account.query.filter(first_name__iexact='Subhash', last_name__iexact=='Bhushan')
* _Example 2_: `Account.query.filter(first_name__iexact='Subhash').filter(last_name__iexact=='Bhushan')
* _Example 3_: `Account.query.filter(first_name__iexact='Subhash', last_name__iexact=='Bhushan').exclude(full_name__iexact='Subhash Bhushan)
* _Example 4_: `Account.query.filter(first_name__iexact='Subhash', last_name__contains='Bhushan').order_by('email')`

The Sample Dict repository implementation has been updated to support these operations.