### PR TITLE
#78 Add support for customizable `bind_to_entity`

### DIFF
--- a/src/protean/core/field/base.py
+++ b/src/protean/core/field/base.py
@@ -114,7 +114,7 @@ class Field(metaclass=ABCMeta):
 
         self.entity_cls = entity_cls
         self.set_attributes_from_name(field_name)
-        entity_cls.meta_.add_field(field_name, self)
+        entity_cls._meta.add_field(field_name, self)
 
     def fail(self, key, **kwargs):
         """A helper method that simply raises a `ValidationError`.

--- a/src/protean/core/field/base.py
+++ b/src/protean/core/field/base.py
@@ -114,7 +114,7 @@ class Field(metaclass=ABCMeta):
 
         self.entity_cls = entity_cls
         self.set_attributes_from_name(field_name)
-        entity_cls._meta.add_field(field_name, self)
+        entity_cls.add_field(field_name, self)
 
     def fail(self, key, **kwargs):
         """A helper method that simply raises a `ValidationError`.

--- a/src/protean/core/field/base.py
+++ b/src/protean/core/field/base.py
@@ -77,6 +77,7 @@ class Field(metaclass=ABCMeta):
         # the entity
         self.entity_cls = None
         self.field_name = None
+        self.attribute_name = None
 
         # Collect default error message from self and parent classes
         messages = {}
@@ -84,6 +85,23 @@ class Field(metaclass=ABCMeta):
             messages.update(getattr(cls, 'default_error_messages', {}))
         messages.update(error_messages or {})
         self.error_messages = messages
+
+    def set_attributes_from_name(self, field_name):
+        """Set attributes of field from name"""
+        self.field_name = self.field_name or field_name
+        self.attribute_name = self.get_attribute_name()
+
+        # `self.label` should default to being based on the field name.
+        if self.label is None:
+            self.label = field_name.replace('_', ' ').capitalize()
+
+    def get_attribute_name(self):
+        """Return Attribute name for the attribute.
+
+        Defaults to the field name in this base class, but can be overridden.
+        Handy when defining complex objects with backing attributes, like Foreign keys.
+        """
+        return self.field_name
 
     def bind_to_entity(self, entity_cls, field_name):
         """
@@ -95,11 +113,8 @@ class Field(metaclass=ABCMeta):
         """
 
         self.entity_cls = entity_cls
-        self.field_name = field_name
-
-        # `self.label` should default to being based on the field name.
-        if self.label is None:
-            self.label = field_name.replace('_', ' ').capitalize()
+        self.set_attributes_from_name(field_name)
+        entity_cls.meta_.add_field(field_name, self)
 
     def fail(self, key, **kwargs):
         """A helper method that simply raises a `ValidationError`.

--- a/src/protean/impl/repository/dict_repo.py
+++ b/src/protean/impl/repository/dict_repo.py
@@ -26,7 +26,7 @@ class Adapter(BaseAdapter):
     def _set_auto_fields(self, model_obj):
         """ Set the values of the auto field using counter"""
         for field_name, field_obj in \
-                self.entity_cls._meta.declared_fields.items():
+                self.entity_cls.auto_fields:
             counter_key = f'{self.model_name}_{field_name}'
             if isinstance(field_obj, Auto) and not (field_name in model_obj and
                                                     model_obj[field_name] is not None):
@@ -44,7 +44,7 @@ class Adapter(BaseAdapter):
         model_obj = self._set_auto_fields(model_obj)
 
         # Add the entity to the repository
-        identifier = model_obj[self.entity_cls._meta.id_field.field_name]
+        identifier = model_obj[self.entity_cls.id_field.field_name]
         with self.conn['lock']:
             self.conn['data'][self.model_name][identifier] = model_obj
 
@@ -129,7 +129,7 @@ class Adapter(BaseAdapter):
 
     def _update_object(self, model_obj):
         """ Update the entity record in the dictionary """
-        identifier = model_obj[self.entity_cls._meta.id_field.field_name]
+        identifier = model_obj[self.entity_cls.id_field.field_name]
         with self.conn['lock']:
             # Check if object is present
             if identifier not in self.conn['data'][self.model_name]:
@@ -297,7 +297,7 @@ class DictModel(BaseModel):
     def from_entity(cls, entity):
         """ Convert the entity to a dictionary record """
         dict_obj = {}
-        for field_name in entity._meta.declared_fields:
+        for field_name in entity.__class__.declared_fields():
             dict_obj[field_name] = getattr(entity, field_name)
         return dict_obj
 

--- a/src/protean/impl/repository/dict_repo.py
+++ b/src/protean/impl/repository/dict_repo.py
@@ -26,7 +26,7 @@ class Adapter(BaseAdapter):
     def _set_auto_fields(self, model_obj):
         """ Set the values of the auto field using counter"""
         for field_name, field_obj in \
-                self.entity_cls.meta_.declared_fields.items():
+                self.entity_cls._meta.declared_fields.items():
             counter_key = f'{self.model_name}_{field_name}'
             if isinstance(field_obj, Auto) and not (field_name in model_obj and
                                                     model_obj[field_name] is not None):
@@ -44,7 +44,7 @@ class Adapter(BaseAdapter):
         model_obj = self._set_auto_fields(model_obj)
 
         # Add the entity to the repository
-        identifier = model_obj[self.entity_cls.meta_.id_field.field_name]
+        identifier = model_obj[self.entity_cls._meta.id_field.field_name]
         with self.conn['lock']:
             self.conn['data'][self.model_name][identifier] = model_obj
 
@@ -129,7 +129,7 @@ class Adapter(BaseAdapter):
 
     def _update_object(self, model_obj):
         """ Update the entity record in the dictionary """
-        identifier = model_obj[self.entity_cls.meta_.id_field.field_name]
+        identifier = model_obj[self.entity_cls._meta.id_field.field_name]
         with self.conn['lock']:
             # Check if object is present
             if identifier not in self.conn['data'][self.model_name]:
@@ -297,7 +297,7 @@ class DictModel(BaseModel):
     def from_entity(cls, entity):
         """ Convert the entity to a dictionary record """
         dict_obj = {}
-        for field_name in entity.meta_.declared_fields:
+        for field_name in entity._meta.declared_fields:
             dict_obj[field_name] = getattr(entity, field_name)
         return dict_obj
 

--- a/src/protean/impl/repository/dict_repo.py
+++ b/src/protean/impl/repository/dict_repo.py
@@ -28,8 +28,7 @@ class Adapter(BaseAdapter):
         for field_name, field_obj in \
                 self.entity_cls.auto_fields:
             counter_key = f'{self.model_name}_{field_name}'
-            if isinstance(field_obj, Auto) and not (field_name in model_obj and
-                                                    model_obj[field_name] is not None):
+            if not (field_name in model_obj and model_obj[field_name] is not None):
                 # Increment the counter and it should start from 1
                 counter = next(self.conn['counters'][counter_key])
                 if not counter:
@@ -297,7 +296,7 @@ class DictModel(BaseModel):
     def from_entity(cls, entity):
         """ Convert the entity to a dictionary record """
         dict_obj = {}
-        for field_name in entity.__class__.declared_fields():
+        for field_name in entity.__class__.declared_fields:
             dict_obj[field_name] = getattr(entity, field_name)
         return dict_obj
 

--- a/src/protean/utils/generic.py
+++ b/src/protean/utils/generic.py
@@ -1,0 +1,10 @@
+"""Generic Utilities for Protean functionality"""
+
+
+class classproperty(object):
+
+    def __init__(self, fget):
+        self.fget = fget
+
+    def __get__(self, owner_self, owner_cls):
+        return self.fget(owner_cls)

--- a/tests/core/test_entity.py
+++ b/tests/core/test_entity.py
@@ -23,6 +23,18 @@ class TestEntity:
         assert dog.age == 10
         assert dog.owner == 'Jimmy'
 
+    def test_individuality(self):
+        """Test successful Account Entity initialization"""
+
+        dog1 = Dog(id=1, name='John Doe', age=10, owner='Jimmy')
+        dog2 = Dog(id=2, name='Jimmy Kane', age=3, owner='John')
+        assert dog1.name == 'John Doe'
+        assert dog1.age == 10
+        assert dog1.owner == 'Jimmy'
+        assert dog2.name == 'Jimmy Kane'
+        assert dog2.age == 3
+        assert dog2.owner == 'John'
+
     def test_required_fields(self):
         """Test errors if mandatory fields are missing"""
 
@@ -199,7 +211,15 @@ class TestEntity:
         dog = Dog(name='Johnny', owner='John')
 
         with pytest.raises(ValidationError):
-            del dog.name  # Simulate an error by force-deleting an attribute
+            dog.name = ""  # Simulate an error by force-resetting an attribute
+            dog.save()
+
+    def test_save_invalid_value(self):
+        """Initialize an entity and save it to repository"""
+        dog = Dog(name='Johnny', owner='John')
+
+        with pytest.raises(ValidationError):
+            dog.age = 'abcd'
             dog.save()
 
     def test_update_with_invalid_id(self):


### PR DESCRIPTION
All Entity attributes should implement a `bind_to_entity` to define how they will contribute to the Entity class. Some attributes, like Linked fields (Related objects), could have custom implementations that dynamically add a shadow attribute to the Entity, to represent a primary key of the target object.

Closes #78 