### PR TITLE
75 HasOne and HasMany Associations

### DIFF
--- a/src/protean/core/entity.py
+++ b/src/protean/core/entity.py
@@ -6,6 +6,7 @@ from protean.core.exceptions import ObjectNotFoundError
 from protean.core.exceptions import ValidationError
 from protean.core.field import Auto
 from protean.core.field import Field, Reference
+from protean.core.field.association import HasOne
 from protean.utils.generic import classproperty
 from protean.utils.query import Q
 
@@ -81,7 +82,7 @@ class EntityBase(type):
         is set up in this method, while `parent_id` is set up in `_set_up_reference_fields()`.
         """
         for attr_name, attr_obj in attrs.items():
-            if isinstance(attr_obj, (Field, Reference)):
+            if isinstance(attr_obj, (Field, Reference)) and not isinstance(attr_obj, HasOne):
                 setattr(new_class, attr_name, attr_obj)
                 new_class._meta.declared_fields[attr_name] = attr_obj
 
@@ -458,7 +459,7 @@ class Entity(metaclass=EntityBase):
         # Now load the remaining fields with a None value, which will fail
         # for required fields
         for field_name, field_obj in self._meta.declared_fields.items():
-            if field_name not in loaded_fields:
+            if field_name not in loaded_fields and not isinstance(field_obj, HasOne):
                 # Check that the field is not set already, which would happen if we are
                 #   dealing with reference fields
                 if getattr(self, field_name, None) is None:

--- a/src/protean/core/entity.py
+++ b/src/protean/core/entity.py
@@ -48,11 +48,11 @@ class EntityBase(type):
         # Load declared fields from Base class, in case this Entity is subclassing another
         new_class._load_base_class_fields(bases, attrs)
 
-        # Set up Relation Fields
-        new_class._set_up_reference_fields()
-
         # Lookup an already defined ID field or create an `Auto` field
         new_class._set_id_field()
+
+        # Set up Relation Fields
+        new_class._set_up_reference_fields()
 
         # Load list of Attributes from declared fields, depending on type of fields
         new_class._load_attributes()

--- a/src/protean/core/entity.py
+++ b/src/protean/core/entity.py
@@ -6,7 +6,6 @@ from protean.core.exceptions import ObjectNotFoundError
 from protean.core.exceptions import ValidationError
 from protean.core.field import Auto
 from protean.core.field import Field, Reference
-from protean.core.field.association import HasOne, HasMany
 from protean.utils.generic import classproperty
 from protean.utils.query import Q
 
@@ -85,8 +84,7 @@ class EntityBase(type):
         is set up in this method, while `parent_id` is set up in `_set_up_reference_fields()`.
         """
         for attr_name, attr_obj in attrs.items():
-            if (isinstance(attr_obj, (Field, Reference)) and
-                    not isinstance(attr_obj, (HasOne, HasMany))):
+            if isinstance(attr_obj, (Field, Reference)):
                 setattr(new_class, attr_name, attr_obj)
                 new_class._meta.declared_fields[attr_name] = attr_obj
 
@@ -469,7 +467,7 @@ class Entity(metaclass=EntityBase):
         # Now load the remaining fields with a None value, which will fail
         # for required fields
         for field_name, field_obj in self._meta.declared_fields.items():
-            if field_name not in loaded_fields and not isinstance(field_obj, (HasOne, HasMany)):
+            if field_name not in loaded_fields:
                 # Check that the field is not set already, which would happen if we are
                 #   dealing with reference fields
                 if getattr(self, field_name, None) is None:

--- a/src/protean/core/entity.py
+++ b/src/protean/core/entity.py
@@ -54,6 +54,9 @@ class EntityBase(type):
         # Lookup an already defined ID field or create an `Auto` field
         new_class._set_id_field()
 
+        # Load list of Attributes from declared fields, depending on type of fields
+        new_class._load_attributes()
+
         # Construct an empty QuerySet associated with this Entity class
         new_class.query = QuerySet(name)
 
@@ -119,6 +122,11 @@ class EntityBase(type):
         new_class._meta.declared_fields['id'] = id_field
         new_class._meta.id_field = id_field
 
+    def _load_attributes(new_class):
+        """Load list of attributes from declared fields"""
+        for field_name, field_obj in new_class._meta.declared_fields.items():
+            new_class._meta.attributes[field_obj.get_attribute_name()] = field_obj
+
 
 class EntityMeta:
     """ Metadata information for the entity including any options defined."""
@@ -129,6 +137,7 @@ class EntityMeta:
         # Initialize Options
         self.entity_cls = None
         self.declared_fields = {}
+        self.attributes = {}
         self.id_field = None
 
     @property
@@ -522,6 +531,11 @@ class Entity(metaclass=EntityBase):
     def declared_fields(cls):
         """Pass through method to retrieve declared fields defined for entity"""
         return cls._meta.declared_fields
+
+    @classproperty
+    def attributes(cls):
+        """Pass through method to retrieve attributes defined for entity"""
+        return cls._meta.attributes
 
     @classproperty
     def auto_fields(cls):

--- a/src/protean/core/entity.py
+++ b/src/protean/core/entity.py
@@ -6,7 +6,7 @@ from typing import Any, Union
 from protean.core.exceptions import ObjectNotFoundError
 from protean.core.exceptions import ValidationError
 from protean.core.field import Auto
-from protean.core.field import Field, Reference
+from protean.core.field import Field, Reference, ReferenceField
 from protean.utils.generic import classproperty
 from protean.utils.query import Q
 
@@ -497,9 +497,7 @@ class Entity(metaclass=EntityBase):
         # for required fields
         for field_name, field_obj in self._meta.declared_fields.items():
             if field_name not in loaded_fields:
-                # Check that the field is not set already, which would happen if we are
-                #   dealing with reference fields
-                if getattr(self, field_name, None) is None:
+                if not isinstance(field_obj, (Reference, ReferenceField)):
                     setattr(self, field_name, None)
 
         # Raise any errors found during load

--- a/src/protean/core/entity.py
+++ b/src/protean/core/entity.py
@@ -6,7 +6,7 @@ from protean.core.exceptions import ObjectNotFoundError
 from protean.core.exceptions import ValidationError
 from protean.core.field import Auto
 from protean.core.field import Field, Reference
-from protean.core.field.association import HasOne
+from protean.core.field.association import HasOne, HasMany
 from protean.utils.generic import classproperty
 from protean.utils.query import Q
 
@@ -85,7 +85,8 @@ class EntityBase(type):
         is set up in this method, while `parent_id` is set up in `_set_up_reference_fields()`.
         """
         for attr_name, attr_obj in attrs.items():
-            if isinstance(attr_obj, (Field, Reference)) and not isinstance(attr_obj, HasOne):
+            if (isinstance(attr_obj, (Field, Reference)) and
+                    not isinstance(attr_obj, (HasOne, HasMany))):
                 setattr(new_class, attr_name, attr_obj)
                 new_class._meta.declared_fields[attr_name] = attr_obj
 
@@ -468,7 +469,7 @@ class Entity(metaclass=EntityBase):
         # Now load the remaining fields with a None value, which will fail
         # for required fields
         for field_name, field_obj in self._meta.declared_fields.items():
-            if field_name not in loaded_fields and not isinstance(field_obj, HasOne):
+            if field_name not in loaded_fields and not isinstance(field_obj, (HasOne, HasMany)):
                 # Check that the field is not set already, which would happen if we are
                 #   dealing with reference fields
                 if getattr(self, field_name, None) is None:

--- a/src/protean/core/exceptions.py
+++ b/src/protean/core/exceptions.py
@@ -11,8 +11,8 @@ class ObjectNotFoundError(Exception):
     """Object was not found, can raise 404"""
 
 
-class ValueError(Exception):
-    """Object of incorrect type, or with invalid state was assigned"""
+class NotSupportedError(Exception):
+    """Object does not support the operation being performed"""
 
 
 class ValidationError(Exception):

--- a/src/protean/core/field/__init__.py
+++ b/src/protean/core/field/__init__.py
@@ -1,6 +1,6 @@
 """Package for defining Field type and its implementations"""
 
-from .association import Reference
+from .association import Reference, ReferenceField
 from .base import Field
 from .basic import Auto
 from .basic import Boolean
@@ -18,4 +18,4 @@ from .ext import StringShort
 
 __all__ = ('Field', 'String', 'Boolean', 'Integer', 'Float', 'List', 'Dict',
            'Auto', 'Date', 'DateTime', 'Text', 'StringShort', 'StringMedium',
-           'StringLong', 'Reference')
+           'StringLong', 'Reference', 'ReferenceField')

--- a/src/protean/core/field/association.py
+++ b/src/protean/core/field/association.py
@@ -1,7 +1,7 @@
 from abc import abstractmethod
 
 from .base import Field
-from .mixins import FieldCacheMixin
+from .mixins import FieldCacheMixin, FieldDescriptorMixin
 
 from protean.core import exceptions
 from protean.utils import inflection
@@ -155,11 +155,12 @@ class Reference(FieldCacheMixin, Field):
         return value
 
 
-class Association(FieldCacheMixin, Field):
+class Association(FieldDescriptorMixin, FieldCacheMixin):
     """Base class for all association classes"""
 
     def __init__(self, to_cls, via=None, **kwargs):
         super().__init__(**kwargs)
+
         self.to_cls = to_cls
         self.via = via
 
@@ -220,14 +221,14 @@ class Association(FieldCacheMixin, Field):
         raise NotImplementedError
 
     def __set__(self, instance, value):
-        """Cannot set values through the HasOne association"""
+        """Cannot set values through an association"""
         raise exceptions.NotSupportedError(
             "Object does not support the operation being performed",
             self.field_name
         )
 
     def __delete__(self, instance):
-        """Cannot pop values for a HasOne association"""
+        """Cannot pop values for an association"""
         raise exceptions.NotSupportedError(
             "Object does not support the operation being performed",
             self.field_name

--- a/src/protean/core/field/association.py
+++ b/src/protean/core/field/association.py
@@ -166,6 +166,7 @@ class HasOne(FieldCacheMixin, Field):
         reference_obj = self.to_cls.find_by(**{self._linked_attribute(owner): id_value})
         if reference_obj:
             self.value = reference_obj
+            return reference_obj
         else:
             # No Objects were found in the remote entity with this Entity's ID
-            pass
+            return None

--- a/src/protean/core/field/association.py
+++ b/src/protean/core/field/association.py
@@ -233,3 +233,85 @@ class HasOne(FieldCacheMixin, Field):
 
     def get_cache_name(self):
         return self.field_name
+
+
+class HasMany(FieldCacheMixin, Field):
+    """
+    Provide a HasMany relation to a remote entity.
+
+    By default, the query will lookup an attribute of the form `<current_entity>_id`
+    to fetch and populate. This behavior can be changed by using the `via` argument.
+    """
+
+    def __init__(self, to_cls, via=None, **kwargs):
+        super().__init__(**kwargs)
+        self.to_cls = to_cls
+        self.via = via
+
+    def _cast_to_type(self, value):
+        """Verify type of value assigned to the association field"""
+        # FIXME Verify that the value being assigned is compatible with the associated Entity
+        return value
+
+    def _linked_attribute(self, owner):
+        """Choose the Linkage attribute between `via` and own entity's `id_field`
+
+           FIXME Explore converting this method into an attribute, and treating it
+           uniformly at `association` level.
+        """
+        return self.via or (inflection.underscore(owner.__name__) + '_id')
+
+    def _fetch_to_cls_from_registry(self, entity):
+        """Private Method to fetch an Entity class from an entity's name"""
+        # Defensive check to ensure we only process if `to_cls` is a string
+        if isinstance(entity, str):
+            from protean.core.repository import repo_factory  # FIXME Move to a better placement
+
+            try:
+                return repo_factory.get_entity(self.to_cls)
+            except AssertionError:
+                # Entity has not been registered (yet)
+                # FIXME print a helpful debug message
+                raise
+        else:
+            return self.to_cls
+
+    def __get__(self, instance, owner):
+        """Retrieve associated objects"""
+
+        # If `to_cls` was specified as a string, take this opportunity to fetch
+        #   and update the correct entity class against it, if not already done
+        if isinstance(self.to_cls, str):
+            self.to_cls = self._fetch_to_cls_from_registry(self.to_cls)
+
+        try:
+            reference_obj = self.get_cached_value(instance)
+        except KeyError:
+            # Fetch target object by own Identifier
+            id_value = getattr(instance, instance.id_field.field_name)
+            reference_obj = self.to_cls.query.filter(**{self._linked_attribute(owner): id_value})
+            if reference_obj:
+                self.value = reference_obj
+                self.set_cached_value(instance, reference_obj)
+            else:
+                # No Objects were found in the remote entity with this Entity's ID
+                reference_obj = None
+
+        return reference_obj
+
+    def __set__(self, instance, value):
+        """Cannot set values through the HasMany association"""
+        raise exceptions.NotSupportedError(
+            "Object does not support the operation being performed",
+            self.field_name
+        )
+
+    def __delete__(self, instance):
+        """Cannot pop values for a HasMany association"""
+        raise exceptions.NotSupportedError(
+            "Object does not support the operation being performed",
+            self.field_name
+        )
+
+    def get_cache_name(self):
+        return self.field_name

--- a/src/protean/core/field/association.py
+++ b/src/protean/core/field/association.py
@@ -4,7 +4,7 @@ from .base import Field
 from .mixins import FieldCacheMixin, FieldDescriptorMixin
 
 from protean.core import exceptions
-from protean.utils import inflection
+from protean import utils
 
 
 class ReferenceField(Field):
@@ -89,31 +89,13 @@ class Reference(FieldCacheMixin, Field):
         else:
             return self.via or self.to_cls.id_field.attribute_name
 
-    def _fetch_to_cls_from_registry(self, entity):
-        """Private Method to fetch an Entity class from an entity's name
-
-           FIXME Move this method into utils
-        """
-        # Defensive check to ensure we only process if `to_cls` is a string
-        if isinstance(entity, str):
-            from protean.core.repository import repo_factory  # FIXME Move to a better placement
-
-            try:
-                return repo_factory.get_entity(self.to_cls)
-            except AssertionError:
-                # Entity has not been registered (yet)
-                # FIXME print a helpful debug message
-                raise
-        else:
-            return self.to_cls
-
     def __get__(self, instance, owner):
         """Retrieve associated objects"""
 
         # If `to_cls` was specified as a string, take this opportunity to fetch
         #   and update the correct entity class against it, if not already done
         if isinstance(self.to_cls, str):
-            self.to_cls = self._fetch_to_cls_from_registry(self.to_cls)
+            self.to_cls = utils.fetch_entity_cls_from_registry(self.to_cls)
 
             # Refresh attribute name, now that we know `to_cls` Entity and it has been
             #   initialized with `id_field`
@@ -144,7 +126,7 @@ class Reference(FieldCacheMixin, Field):
         """Override `__set__` to coordinate between relation field and its shadow attribute"""
         if value:
             if isinstance(self.to_cls, str):
-                self.to_cls = self._fetch_to_cls_from_registry(self.to_cls)
+                self.to_cls = utils.fetch_entity_cls_from_registry(self.to_cls)
 
                 # Refresh attribute name, now that we know `to_cls` Entity and it has been
                 #   initialized with `id_field`
@@ -214,7 +196,7 @@ class Association(FieldDescriptorMixin, FieldCacheMixin):
            FIXME Explore converting this method into an attribute, and treating it
            uniformly at `association` level.
         """
-        return self.via or (inflection.underscore(owner.__name__) + '_id')
+        return self.via or (utils.inflection.underscore(owner.__name__) + '_id')
 
     def _fetch_to_cls_from_registry(self, entity):
         """Private Method to fetch an Entity class from an entity's name"""

--- a/src/protean/core/field/base.py
+++ b/src/protean/core/field/base.py
@@ -92,7 +92,10 @@ class Field(FieldDescriptorMixin, metaclass=ABCMeta):
         self.error_messages = messages
 
     def __get__(self, instance, owner):
-        return instance.__dict__.get(self.field_name, self.value)
+        if hasattr(instance, '__dict__'):
+            return instance.__dict__.get(self.field_name, self.value)
+        else:
+            return None
 
     def __set__(self, instance, value):
         value = self._load(value)

--- a/src/protean/core/field/base.py
+++ b/src/protean/core/field/base.py
@@ -76,6 +76,9 @@ class Field(metaclass=ABCMeta):
         # Value holder
         self._value = value
 
+        # Hold a reference to Entity registering the field
+        self._entity_cls = None
+
         # These are set up when the owner (Entity class) adds the field to itself
         self.field_name = None
         self.attribute_name = None
@@ -90,6 +93,9 @@ class Field(metaclass=ABCMeta):
     def __set_name__(self, entity_cls, name):
         self.field_name = name
         self.attribute_name = self.get_attribute_name()
+
+        # Record Entity setting up the field
+        self._entity_cls = entity_cls
 
         # `self.label` should default to being based on the field name.
         if self.label is None:

--- a/src/protean/core/field/base.py
+++ b/src/protean/core/field/base.py
@@ -222,3 +222,6 @@ class Field(metaclass=ABCMeta):
         self._run_validators(value)
 
         return value
+
+    def get_cache_name(self):
+        return self.field_name

--- a/src/protean/core/field/base.py
+++ b/src/protean/core/field/base.py
@@ -139,7 +139,6 @@ class Field(metaclass=ABCMeta):
             raise AssertionError(msg)
         if isinstance(msg, str):
             msg = msg.format(**kwargs)
-
         raise exceptions.ValidationError(msg, self.field_name)
 
     @property

--- a/src/protean/core/field/mixins.py
+++ b/src/protean/core/field/mixins.py
@@ -2,7 +2,7 @@ NOT_PROVIDED = object()
 
 
 class FieldCacheMixin:
-    """Provide an API for working with the model's fields value cache."""
+    """Provide an API for working with the entity's fields value cache."""
 
     def get_cache_name(self):
         raise NotImplementedError
@@ -24,3 +24,45 @@ class FieldCacheMixin:
 
     def delete_cached_value(self, instance):
         del instance._state.fields_cache[self.get_cache_name()]
+
+
+class FieldDescriptorMixin:
+    """Provide basic implementation to treat the Field as a descriptor"""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize common Field Attributes"""
+        # These are set up when the owner (Entity class) adds the field to itself
+        self.field_name = None
+        self.attribute_name = None
+        self.label = None
+
+    def __set_name__(self, entity_cls, name):
+        self.field_name = name
+        self.attribute_name = self.get_attribute_name()
+
+        # Record Entity setting up the field
+        self._entity_cls = entity_cls
+
+        # `self.label` should default to being based on the field name.
+        if self.label is None:
+            self.label = self.field_name.replace('_', ' ').capitalize()
+
+    def get_attribute_name(self):
+        """Return Attribute name for the attribute.
+
+        Defaults to the field name in this base class, but can be overridden.
+        Handy when defining complex objects with shadow attributes, like Foreign keys.
+        """
+        return self.field_name
+
+    def __get__(self, instance, owner):
+        """Placeholder for handling `getattr` operations on attributes"""
+        raise NotImplementedError
+
+    def __set__(self, instance, value):
+        """Placeholder for handling `setattr` operations on attributes"""
+        raise NotImplementedError
+
+    def __delete__(self, instance):
+        """Placeholder for handling `del` operations on attributes"""
+        raise NotImplementedError

--- a/src/protean/core/field/mixins.py
+++ b/src/protean/core/field/mixins.py
@@ -23,7 +23,8 @@ class FieldCacheMixin:
         instance._state.fields_cache[self.get_cache_name()] = value
 
     def delete_cached_value(self, instance):
-        del instance._state.fields_cache[self.get_cache_name()]
+        if self.get_cache_name() in instance._state.fields_cache:
+            del instance._state.fields_cache[self.get_cache_name()]
 
 
 class FieldDescriptorMixin:

--- a/src/protean/core/repository/factory.py
+++ b/src/protean/core/repository/factory.py
@@ -23,6 +23,7 @@ class RepositoryFactory:
     def __init__(self):
         """"Initialize repository factory"""
         self._registry = {}
+        self._entity_registry = {}
         self._model_registry = {}
         self._connections = local()
         self._repositories = None
@@ -94,6 +95,7 @@ class RepositoryFactory:
             self._registry[entity_name] = \
                 repo_cls(self.connections[model_cls.opts_.bind], model_cls)
             self._model_registry[entity_name] = model_cls
+            self._entity_registry[entity_name] = model_cls.Meta.entity
             logger.debug(
                 f'Registered model {model_name} for entity {entity_name} with repository provider '
                 f'{conn_info["PROVIDER"]}.')
@@ -103,13 +105,20 @@ class RepositoryFactory:
         try:
             return self._model_registry[entity_name]
         except KeyError:
-            raise AssertionError('No Model registered for {entity_name}')
+            raise AssertionError('No Model registered for {entity_name}'.format(entity_name))
+
+    def get_entity(self, entity_name):
+        """Retrieve Entity class registered by `entity_name`"""
+        try:
+            return self._entity_registry[entity_name]
+        except KeyError:
+            raise AssertionError('No Entity registered with name {entity_name}'.format(entity_name))
 
     def __getattr__(self, entity_name):
         try:
             return self._registry[entity_name]
         except KeyError:
-            raise AssertionError('No Model registered for {entity_name}')
+            raise AssertionError('No Model registered for {entity_name}'.format(entity_name))
 
     def close_connections(self):
         """ Close all connections registered with the repository """

--- a/src/protean/impl/repository/dict_repo.py
+++ b/src/protean/impl/repository/dict_repo.py
@@ -298,7 +298,7 @@ class DictModel(BaseModel):
     def from_entity(cls, entity):
         """ Convert the entity to a dictionary record """
         dict_obj = {}
-        for field_name in entity.__class__.declared_fields:
+        for field_name in entity.__class__.attributes:
             dict_obj[field_name] = getattr(entity, field_name)
         return dict_obj
 

--- a/src/protean/impl/repository/dict_repo.py
+++ b/src/protean/impl/repository/dict_repo.py
@@ -7,7 +7,6 @@ from threading import Lock
 
 from protean.core.entity import Q
 from protean.core.exceptions import ObjectNotFoundError
-from protean.core.field import Auto
 from protean.core.repository import BaseAdapter
 from protean.core.repository import BaseConnectionHandler
 from protean.core.repository import BaseModel

--- a/src/protean/utils/__init__.py
+++ b/src/protean/utils/__init__.py
@@ -1,0 +1,14 @@
+def fetch_entity_cls_from_registry(entity):
+        """Util Method to fetch an Entity class from an entity's name"""
+        # Defensive check to ensure we only process if `to_cls` is a string
+        if isinstance(entity, str):
+            from protean.core.repository import repo_factory  # FIXME Move to a better placement
+
+            try:
+                return repo_factory.get_entity(entity)
+            except AssertionError:
+                # Entity has not been registered (yet)
+                # FIXME print a helpful debug message
+                raise
+        else:
+            return entity

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,9 +11,12 @@ def run_around_tests():
     """Initialize DogModel with Dict Repo"""
     from protean.core.repository import repo_factory
     from tests.support.dog import (DogModel, RelatedDogModel, DogRelatedByEmailModel,
-                                   HasOneDog1Model, HasOneDog2Model, HasOneDog3Model)
+                                   HasOneDog1Model, HasOneDog2Model, HasOneDog3Model,
+                                   HasManyDog1Model, HasManyDog2Model, HasManyDog3Model)
     from tests.support.human import (HumanModel, HasOneHuman1Model,
-                                     HasOneHuman2Model, HasOneHuman3Model)
+                                     HasOneHuman2Model, HasOneHuman3Model,
+                                     HasManyHuman1Model, HasManyHuman2Model,
+                                     HasManyHuman3Model)
 
     repo_factory.register(DogModel)
     repo_factory.register(RelatedDogModel)
@@ -21,10 +24,16 @@ def run_around_tests():
     repo_factory.register(HasOneDog1Model)
     repo_factory.register(HasOneDog2Model)
     repo_factory.register(HasOneDog3Model)
+    repo_factory.register(HasManyDog1Model)
+    repo_factory.register(HasManyDog2Model)
+    repo_factory.register(HasManyDog3Model)
     repo_factory.register(HumanModel)
     repo_factory.register(HasOneHuman1Model)
     repo_factory.register(HasOneHuman2Model)
     repo_factory.register(HasOneHuman3Model)
+    repo_factory.register(HasManyHuman1Model)
+    repo_factory.register(HasManyHuman2Model)
+    repo_factory.register(HasManyHuman3Model)
 
     # A test function will be run at this point
     yield
@@ -35,7 +44,13 @@ def run_around_tests():
     repo_factory.HasOneDog1.delete_all()
     repo_factory.HasOneDog2.delete_all()
     repo_factory.HasOneDog3.delete_all()
+    repo_factory.HasManyDog1.delete_all()
+    repo_factory.HasManyDog2.delete_all()
+    repo_factory.HasManyDog3.delete_all()
     repo_factory.Human.delete_all()
     repo_factory.HasOneHuman1.delete_all()
     repo_factory.HasOneHuman2.delete_all()
     repo_factory.HasOneHuman3.delete_all()
+    repo_factory.HasManyHuman1.delete_all()
+    repo_factory.HasManyHuman2.delete_all()
+    repo_factory.HasManyHuman3.delete_all()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,13 +10,19 @@ os.environ['PROTEAN_CONFIG'] = 'tests.support.sample_config'
 def run_around_tests():
     """Initialize DogModel with Dict Repo"""
     from protean.core.repository import repo_factory
-    from tests.support.dog import DogModel, RelatedDogModel, DogRelatedByEmailModel
-    from tests.support.human import HumanModel
+    from tests.support.dog import (DogModel, RelatedDogModel, DogRelatedByEmailModel,
+                                   HasOneDog1Model, HasOneDog2Model, HasOneDog3Model)
+    from tests.support.human import HumanModel, HasOneHuman1Model, HasOneHuman2Model
 
     repo_factory.register(DogModel)
     repo_factory.register(RelatedDogModel)
     repo_factory.register(DogRelatedByEmailModel)
+    repo_factory.register(HasOneDog1Model)
+    repo_factory.register(HasOneDog2Model)
+    repo_factory.register(HasOneDog3Model)
     repo_factory.register(HumanModel)
+    repo_factory.register(HasOneHuman1Model)
+    repo_factory.register(HasOneHuman2Model)
 
     # A test function will be run at this point
     yield
@@ -24,4 +30,10 @@ def run_around_tests():
     repo_factory.Dog.delete_all()
     repo_factory.RelatedDog.delete_all()
     repo_factory.DogRelatedByEmail.delete_all()
+    repo_factory.HasOneDog1.delete_all()
+    repo_factory.HasOneDog2.delete_all()
+    repo_factory.HasOneDog3.delete_all()
     repo_factory.Human.delete_all()
+    repo_factory.HasOneHuman1.delete_all()
+    repo_factory.HasOneHuman2.delete_all()
+    

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,8 @@ def run_around_tests():
     from protean.core.repository import repo_factory
     from tests.support.dog import (DogModel, RelatedDogModel, DogRelatedByEmailModel,
                                    HasOneDog1Model, HasOneDog2Model, HasOneDog3Model)
-    from tests.support.human import HumanModel, HasOneHuman1Model, HasOneHuman2Model
+    from tests.support.human import (HumanModel, HasOneHuman1Model,
+                                     HasOneHuman2Model, HasOneHuman3Model)
 
     repo_factory.register(DogModel)
     repo_factory.register(RelatedDogModel)
@@ -23,6 +24,7 @@ def run_around_tests():
     repo_factory.register(HumanModel)
     repo_factory.register(HasOneHuman1Model)
     repo_factory.register(HasOneHuman2Model)
+    repo_factory.register(HasOneHuman3Model)
 
     # A test function will be run at this point
     yield
@@ -36,4 +38,4 @@ def run_around_tests():
     repo_factory.Human.delete_all()
     repo_factory.HasOneHuman1.delete_all()
     repo_factory.HasOneHuman2.delete_all()
-    
+    repo_factory.HasOneHuman3.delete_all()

--- a/tests/core/test_entity.py
+++ b/tests/core/test_entity.py
@@ -1,13 +1,14 @@
 """Tests for Entity Functionality and Base Classes"""
 
 import pytest
-from tests.support.dog import Dog, RelatedDog, DogRelatedByEmail
-from tests.support.human import Human
+from tests.support.dog import (Dog, RelatedDog, DogRelatedByEmail,
+                               HasOneDog1, HasOneDog2, HasOneDog3)
+from tests.support.human import Human, HasOneHuman1, HasOneHuman2
 
 from protean.core import field
 from protean.core.entity import Entity, QuerySet
 from protean.core.exceptions import ObjectNotFoundError
-from protean.core.exceptions import ValidationError, ValueError
+from protean.core.exceptions import ValidationError
 from protean.utils.query import Q
 
 
@@ -1327,3 +1328,15 @@ class TestAssociations:
             dog.save()
             assert hasattr(dog, 'owner_email')
             assert dog.owner_email == human.email
+
+    class TestHasOne:
+        """Class to test HasOne Association"""
+
+        def test_init(self):
+            """Test successful HasOne initialization"""
+            human = HasOneHuman1.create(
+                first_name='Jeff', last_name='Kennedy',
+                email='jeff.kennedy@presidents.com')
+            dog = HasOneDog1.create(id=1, name='John Doe', age=10, has_one_human1=human)
+            assert dog.has_one_human1 == human
+            assert human.dog == dog

--- a/tests/core/test_entity.py
+++ b/tests/core/test_entity.py
@@ -3,7 +3,7 @@
 from collections import OrderedDict
 
 import pytest
-from tests.support.dog import (Dog, RelatedDog, DogRelatedByEmail,
+from tests.support.dog import (Dog, RelatedDog, RelatedDog2, DogRelatedByEmail,
                                HasOneDog1, HasOneDog2, HasOneDog3)
 from tests.support.human import Human, HasOneHuman1, HasOneHuman2, HasOneHuman3
 
@@ -1233,6 +1233,13 @@ class TestAssociations:
             human = Human.create(first_name='Jeff', last_name='Kennedy',
                                  email='jeff.kennedy@presidents.com')
             dog = RelatedDog(id=1, name='John Doe', age=10, owner=human)
+            assert dog.owner == human
+
+        def test_init_with_string_reference(self):
+            """Test successful RelatedDog initialization"""
+            human = Human.create(first_name='Jeff', last_name='Kennedy',
+                                 email='jeff.kennedy@presidents.com')
+            dog = RelatedDog2(id=1, name='John Doe', age=10, owner=human)
             assert dog.owner == human
 
         def test_save(self):

--- a/tests/core/test_entity.py
+++ b/tests/core/test_entity.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 import pytest
 from tests.support.dog import (Dog, RelatedDog, DogRelatedByEmail,
                                HasOneDog1, HasOneDog2, HasOneDog3)
-from tests.support.human import Human, HasOneHuman1, HasOneHuman2
+from tests.support.human import Human, HasOneHuman1, HasOneHuman2, HasOneHuman3
 
 from protean.core import field
 from protean.core.entity import Entity, QuerySet
@@ -1375,4 +1375,23 @@ class TestAssociations:
                 email='jeff.kennedy@presidents.com')
             dog = HasOneDog1.create(id=101, name='John Doe', age=10, has_one_human1=human)
             assert dog.has_one_human1 == human
+            assert human.dog.id == dog.id
+
+        def test_init_with_via(self):
+            """Test successful HasOne initialization with a class containing via"""
+            human = HasOneHuman2.create(
+                first_name='Jeff', last_name='Kennedy',
+                email='jeff.kennedy@presidents.com')
+            dog = HasOneDog2.create(id=101, name='John Doe', age=10, human=human)
+            assert dog.human == human
+            assert human.dog.id == dog.id
+
+        def test_init_with_no_reference(self):
+            """Test successful HasOne initialization with a class containing via"""
+            human = HasOneHuman3.create(
+                first_name='Jeff', last_name='Kennedy',
+                email='jeff.kennedy@presidents.com')
+            dog = HasOneDog3.create(id=101, name='John Doe', age=10, human_id=human.id)
+            assert dog.human_id == human.id
+            assert not hasattr(dog, 'human')
             assert human.dog.id == dog.id

--- a/tests/support/dog.py
+++ b/tests/support/dog.py
@@ -1,6 +1,6 @@
 """Support Classes for Test Cases"""
 
-from tests.support.human import Human, HasOneHuman1, HasOneHuman2
+from tests.support.human import Human, HasOneHuman1, HasOneHuman2, HasManyHuman1, HasManyHuman2
 
 from protean.core import field
 from protean.core.entity import Entity
@@ -90,7 +90,9 @@ class HasOneDog1Model(DictModel):
 
 
 class HasOneDog2(Entity):
-    """This is a dummy Dog Entity class to test HasOne Association"""
+    """This is a dummy Dog Entity class to test HasOne Association, where the associated
+       has defined a `via` attribute to finetune linkage
+    """
     name = field.String(required=True, unique=True, max_length=50)
     age = field.Integer(default=5)
     human = field.Reference(HasOneHuman2)
@@ -119,3 +121,53 @@ class HasOneDog3Model(DictModel):
         """ Meta class for model options"""
         entity = HasOneDog3
         model_name = 'has_one_dogs3'
+
+
+class HasManyDog1(Entity):
+    """This is a dummy Dog Entity class to test HasMany Association"""
+    name = field.String(required=True, unique=True, max_length=50)
+    age = field.Integer(default=5)
+    has_many_human1 = field.Reference(HasManyHuman1)
+
+
+class HasManyDog1Model(DictModel):
+    """ Model for the HasManyDog1 Entity"""
+
+    class Meta:
+        """ Meta class for model options"""
+        entity = HasManyDog1
+        model_name = 'has_many_dogs1'
+
+
+class HasManyDog2(Entity):
+    """This is a dummy Dog Entity class to test HasMany Association, where the associated
+       has defined a `via` attribute to finetune linkage
+    """
+    name = field.String(required=True, unique=True, max_length=50)
+    age = field.Integer(default=5)
+    human = field.Reference(HasManyHuman2)
+
+
+class HasManyDog2Model(DictModel):
+    """ Model for the HasManyDog2 Entity"""
+
+    class Meta:
+        """ Meta class for model options"""
+        entity = HasManyDog2
+        model_name = 'has_many_dogs2'
+
+
+class HasManyDog3(Entity):
+    """This is a dummy Dog Entity class to test HasMany Association"""
+    name = field.String(required=True, unique=True, max_length=50)
+    age = field.Integer(default=5)
+    human_id = field.Integer()
+
+
+class HasManyDog3Model(DictModel):
+    """ Model for the HasManyDog3 Entity"""
+
+    class Meta:
+        """ Meta class for model options"""
+        entity = HasManyDog3
+        model_name = 'has_many_dogs3'

--- a/tests/support/dog.py
+++ b/tests/support/dog.py
@@ -1,6 +1,6 @@
 """Support Classes for Test Cases"""
 
-from tests.support.human import Human
+from tests.support.human import Human, HasOneHuman1, HasOneHuman2
 
 from protean.core import field
 from protean.core.entity import Entity
@@ -53,3 +53,51 @@ class DogRelatedByEmailModel(DictModel):
         """ Meta class for model options"""
         entity = DogRelatedByEmail
         model_name = 'related_dogs_by_email'
+
+
+class HasOneDog1(Entity):
+    """This is a dummy Dog Entity class to test HasOne Association"""
+    name = field.String(required=True, unique=True, max_length=50)
+    age = field.Integer(default=5)
+    has_one_human1 = field.Reference(HasOneHuman1)
+
+
+class HasOneDog1Model(DictModel):
+    """ Model for the HasOneDog1 Entity"""
+
+    class Meta:
+        """ Meta class for model options"""
+        entity = HasOneDog1
+        model_name = 'has_one_dogs1'
+
+
+class HasOneDog2(Entity):
+    """This is a dummy Dog Entity class to test HasOne Association"""
+    name = field.String(required=True, unique=True, max_length=50)
+    age = field.Integer(default=5)
+    human = field.Reference(HasOneHuman2)
+
+
+class HasOneDog2Model(DictModel):
+    """ Model for the HasOneDog2 Entity"""
+
+    class Meta:
+        """ Meta class for model options"""
+        entity = HasOneDog2
+        model_name = 'has_one_dogs2'
+
+
+class HasOneDog3(Entity):
+    """This is a dummy Dog Entity class to test HasOne Association"""
+    name = field.String(required=True, unique=True, max_length=50)
+    age = field.Integer(default=5)
+    human_id = field.Integer()
+
+
+class HasOneDog3Model(DictModel):
+    """ Model for the HasOneDog3 Entity"""
+
+    class Meta:
+        """ Meta class for model options"""
+        entity = HasOneDog3
+        model_name = 'has_one_dogs3'

--- a/tests/support/dog.py
+++ b/tests/support/dog.py
@@ -39,6 +39,24 @@ class RelatedDogModel(DictModel):
         model_name = 'related_dogs'
 
 
+class RelatedDog2(Entity):
+    """This is a dummy RelatedDog2 Entity class with reference definition
+       containing the target class name as string
+    """
+    name = field.String(required=True, unique=True, max_length=50)
+    age = field.Integer(default=5)
+    owner = field.Reference('Human')
+
+
+class RelatedDog2Model(DictModel):
+    """ Model for the RelatedDog2 Entity"""
+
+    class Meta:
+        """ Meta class for model options"""
+        entity = RelatedDog2
+        model_name = 'related_dogs2'
+
+
 class DogRelatedByEmail(Entity):
     """This is a dummy Dog Entity class with an association"""
     name = field.String(required=True, unique=True, max_length=50)

--- a/tests/support/human.py
+++ b/tests/support/human.py
@@ -75,3 +75,58 @@ class HasOneHuman3Model(DictModel):
         """ Meta class for model options"""
         entity = HasOneHuman3
         model_name = 'has_one_humans3'
+
+
+class HasManyHuman1(Entity):
+    """This is a dummy Human Entity class to test HasMany association"""
+    first_name = field.String(required=True, unique=True, max_length=50)
+    last_name = field.String(required=True, unique=True, max_length=50)
+    email = field.String(required=True, unique=True, max_length=50)
+    dogs = association.HasMany('HasManyDog1')
+
+
+class HasManyHuman1Model(DictModel):
+    """ Model for the HasManyHuman1 Entity"""
+
+    class Meta:
+        """ Meta class for model options"""
+        entity = HasManyHuman1
+        model_name = 'has_many_humans1'
+
+
+class HasManyHuman2(Entity):
+    """This is a dummy Human Entity class to test HasMany association
+       with a custom attribute defined in `via` argument to field
+    """
+    first_name = field.String(required=True, unique=True, max_length=50)
+    last_name = field.String(required=True, unique=True, max_length=50)
+    email = field.String(required=True, unique=True, max_length=50)
+    dogs = association.HasMany('HasManyDog2', via='human_id')
+
+
+class HasManyHuman2Model(DictModel):
+    """ Model for the HasManyHuman2 Entity"""
+
+    class Meta:
+        """ Meta class for model options"""
+        entity = HasManyHuman2
+        model_name = 'has_many_humans2'
+
+
+class HasManyHuman3(Entity):
+    """This is a dummy Human Entity class to test HasMany association
+       when there is no corresponding Reference defined in the target class
+    """
+    first_name = field.String(required=True, unique=True, max_length=50)
+    last_name = field.String(required=True, unique=True, max_length=50)
+    email = field.String(required=True, unique=True, max_length=50)
+    dogs = association.HasMany('HasManyDog3', via='human_id')
+
+
+class HasManyHuman3Model(DictModel):
+    """ Model for the HasManyHuman3 Entity"""
+
+    class Meta:
+        """ Meta class for model options"""
+        entity = HasManyHuman3
+        model_name = 'has_many_humans3'

--- a/tests/support/human.py
+++ b/tests/support/human.py
@@ -40,7 +40,9 @@ class HasOneHuman1Model(DictModel):
 
 
 class HasOneHuman2(Entity):
-    """This is a dummy Human Entity class to test HasOne association"""
+    """This is a dummy Human Entity class to test HasOne association
+       with a custom attribute defined in `via` argument to field
+    """
     first_name = field.String(required=True, unique=True, max_length=50)
     last_name = field.String(required=True, unique=True, max_length=50)
     email = field.String(required=True, unique=True, max_length=50)
@@ -53,4 +55,23 @@ class HasOneHuman2Model(DictModel):
     class Meta:
         """ Meta class for model options"""
         entity = HasOneHuman2
-        model_name = 'has_one_humans1'
+        model_name = 'has_one_humans2'
+
+
+class HasOneHuman3(Entity):
+    """This is a dummy Human Entity class to test HasOne association
+       when there is no corresponding Reference defined in the target class
+    """
+    first_name = field.String(required=True, unique=True, max_length=50)
+    last_name = field.String(required=True, unique=True, max_length=50)
+    email = field.String(required=True, unique=True, max_length=50)
+    dog = association.HasOne('HasOneDog3', via='human_id')
+
+
+class HasOneHuman3Model(DictModel):
+    """ Model for the HasOneHuman3 Entity"""
+
+    class Meta:
+        """ Meta class for model options"""
+        entity = HasOneHuman3
+        model_name = 'has_one_humans3'

--- a/tests/support/human.py
+++ b/tests/support/human.py
@@ -1,6 +1,7 @@
 """Human Support Class for Test Cases"""
 
 from protean.core import field
+from protean.core.field import association
 from protean.core.entity import Entity
 from protean.impl.repository.dict_repo import DictModel
 
@@ -19,3 +20,37 @@ class HumanModel(DictModel):
         """ Meta class for model options"""
         entity = Human
         model_name = 'humans'
+
+
+class HasOneHuman1(Entity):
+    """This is a dummy Human Entity class to test HasOne association"""
+    first_name = field.String(required=True, unique=True, max_length=50)
+    last_name = field.String(required=True, unique=True, max_length=50)
+    email = field.String(required=True, unique=True, max_length=50)
+    dog = association.HasOne('HasOneDog1')
+
+
+class HasOneHuman1Model(DictModel):
+    """ Model for the HasOneHuman1 Entity"""
+
+    class Meta:
+        """ Meta class for model options"""
+        entity = HasOneHuman1
+        model_name = 'has_one_humans1'
+
+
+class HasOneHuman2(Entity):
+    """This is a dummy Human Entity class to test HasOne association"""
+    first_name = field.String(required=True, unique=True, max_length=50)
+    last_name = field.String(required=True, unique=True, max_length=50)
+    email = field.String(required=True, unique=True, max_length=50)
+    dog = association.HasOne('HasOneDog2', via='human_id')
+
+
+class HasOneHuman2Model(DictModel):
+    """ Model for the HasOneHuman2 Entity"""
+
+    class Meta:
+        """ Meta class for model options"""
+        entity = HasOneHuman2
+        model_name = 'has_one_humans1'


### PR DESCRIPTION
This PR provides the underlying implementation for HasOne and HasMany associations.

Note that there is no support for HABTM (Has and Belongs to Many) yet. HasOne and HasMany should suffice for Reference Support for the next release of Protean. 

Closes #75 