### PR TITLE
Bug 107 - Prevent Automatic Model registrations

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,9 +20,6 @@ Release v\ |version|. (:ref:`Changelog <changelog>`)
 .. image:: https://img.shields.io/pypi/pyversions/protean.svg
     :target: https://pypi.org/project/protean/
 
-.. image:: https://img.shields.io/pypi/implementation/protean.svg
-    :target: https://pypi.org/project/protean/
-
 .. image:: https://codecov.io/gh/proteanhq/protean/branch/master/graph/badge.svg
     :target: https://codecov.io/gh/proteanhq/protean
 

--- a/src/protean/core/entity.py
+++ b/src/protean/core/entity.py
@@ -11,7 +11,6 @@ from protean.core.field import Field
 from protean.core.field import Reference
 from protean.core.field import ReferenceField
 from protean.core.repository import repo_factory
-from protean.utils.generic import classproperty
 from protean.utils.query import Q
 
 logger = logging.getLogger('protean.core.entity')

--- a/src/protean/core/exceptions.py
+++ b/src/protean/core/exceptions.py
@@ -4,7 +4,11 @@ Custom Protean exception classes
 
 
 class ConfigurationError(Exception):
-    """An important configuration variable is missing"""
+    """Improper Configuration encountered like:
+        * An important configuration variable is missing
+        * Re-registration of Models
+        * Incorrect associations
+    """
 
 
 class ObjectNotFoundError(Exception):

--- a/src/protean/core/repository/base.py
+++ b/src/protean/core/repository/base.py
@@ -105,8 +105,6 @@ class BaseModelMeta(ABCMeta):
         if not is_base:
             # Set klass.opts by initializing the `options_cls` with the meta
             klass.opts_ = klass.options_cls(meta, klass)
-            # Register this model with the factory
-            repo_factory.register(klass)
 
         return klass
 

--- a/src/protean/core/repository/factory.py
+++ b/src/protean/core/repository/factory.py
@@ -73,7 +73,12 @@ class RepositoryFactory:
         model_name = model_cls.__name__
         entity_name = model_cls.opts_.entity_cls.__name__
 
-        if not self._registry.get(entity_name):
+        if self._registry.get(entity_name):
+            # This probably is an accidental re-registration of the entity
+            #   and we should warn the user of a possible repository confusion
+            raise ConfigurationError(
+                f'Entity {entity_name} has already been registered')
+        else:
             # Lookup the connection details for the model
             try:
                 conn_info = self.repositories[model_cls.opts_.bind]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,40 @@ import pytest
 os.environ['PROTEAN_CONFIG'] = 'tests.support.sample_config'
 
 
+@pytest.fixture(scope="session", autouse=True)
+def register_models():
+    """Register Test Models with Dict Repo
+
+       Run only once for the entire test suite
+    """
+    from protean.core.repository import repo_factory
+    from tests.support.dog import (DogModel, RelatedDogModel, DogRelatedByEmailModel,
+                                   HasOneDog1Model, HasOneDog2Model, HasOneDog3Model,
+                                   HasManyDog1Model, HasManyDog2Model, HasManyDog3Model)
+    from tests.support.human import (HumanModel, HasOneHuman1Model,
+                                     HasOneHuman2Model, HasOneHuman3Model,
+                                     HasManyHuman1Model, HasManyHuman2Model,
+                                     HasManyHuman3Model)
+
+    repo_factory.register(DogModel)
+    repo_factory.register(RelatedDogModel)
+    repo_factory.register(DogRelatedByEmailModel)
+    repo_factory.register(HasOneDog1Model)
+    repo_factory.register(HasOneDog2Model)
+    repo_factory.register(HasOneDog3Model)
+    repo_factory.register(HasManyDog1Model)
+    repo_factory.register(HasManyDog2Model)
+    repo_factory.register(HasManyDog3Model)
+    repo_factory.register(HumanModel)
+    repo_factory.register(HasOneHuman1Model)
+    repo_factory.register(HasOneHuman2Model)
+    repo_factory.register(HasOneHuman3Model)
+    repo_factory.register(HasManyHuman1Model)
+    repo_factory.register(HasManyHuman2Model)
+    repo_factory.register(HasManyHuman3Model)
+
+
+
 @pytest.fixture(autouse=True)
 def run_around_tests():
     """Initialize DogModel with Dict Repo"""


### PR DESCRIPTION
Attempting to re-register an entity model will now raise an error. All models will need to be registered explicitly.