### PR TITLE
115 Support Entity Namespacing

### DIFF
--- a/src/protean/core/entity.py
+++ b/src/protean/core/entity.py
@@ -71,7 +71,7 @@ class EntityBase(type):
         when invoked like `Dog.query.all()` directly. A new query, and a corresponding `Pagination`
         result would be created every time.
         """
-        return QuerySet(cls.__name__)
+        return QuerySet(cls)
 
     def _load_base_class_fields(new_class, bases, attrs):
         """If this class is subclassing another Entity, add that Entity's
@@ -163,318 +163,6 @@ class EntityMeta:
         return [(field_name, field_obj)
                 for field_name, field_obj in self.declared_fields.items()
                 if isinstance(field_obj, Auto)]
-
-
-class QuerySet:
-    """A chainable class to gather a bunch of criteria and preferences (page size, order etc.)
-    before execution.
-
-    Internally, a QuerySet can be constructed, filtered, sliced, and generally passed around
-    without actually fetching data. No data fetch actually occurs until you do something
-    to evaluate the queryset.
-
-    Once evaluated, a `QuerySet` typically caches its results. If the data in the database
-    might have changed, you can get updated results for the same query by calling `all()` on a
-    previously evaluated `QuerySet`.
-
-    Attributes:
-        page: The current page number of the records to be pulled
-        per_page: The size of each page of the records to be pulled
-        order_by: The list of parameters to be used for ordering the results.
-            Use a `-` before the parameter name to sort in descending order
-            and if not ascending order.
-        excludes_: Objects with these properties will be excluded from the results
-        filters: Filter criteria
-
-    :return Returns a `Pagination` object that holds the query results
-    """
-
-    def __init__(self, entity_cls_name: str, criteria=None, page: int = 1, per_page: int = 10,
-                 order_by: set = None):
-        """Initialize either with empty preferences (when invoked on an Entity)
-            or carry forward filters and preferences when chained
-        """
-
-        self._entity_cls_name = entity_cls_name
-        self._criteria = criteria or Q()
-        self._result_cache = None
-        self._page = page or 1
-        self._per_page = per_page or 10
-
-        # `order_by` could be empty, or a string or a set.
-        #   Intialize empty set if `order_by` is None
-        #   Convert string to set if `order_by` is a String
-        #   Safe-cast set to a set if `order_by` is already a set
-        if order_by:
-            self._order_by = set([order_by]) if isinstance(order_by, str) else set(order_by)
-        else:
-            self._order_by = set()
-
-    def _clone(self):
-        """
-        Return a copy of the current QuerySet.
-        """
-        clone = self.__class__(self._entity_cls_name, criteria=self._criteria,
-                               page=self._page, per_page=self._per_page,
-                               order_by=self._order_by)
-        return clone
-
-    def _add_q(self, q_object):
-        """Add a Q-object to the current filter."""
-        self._criteria = self._criteria._combine(q_object, q_object.connector)
-
-    def filter(self, *args, **kwargs):
-        """
-        Return a new QuerySet instance with the args ANDed to the existing
-        set.
-        """
-        return self._filter_or_exclude(False, *args, **kwargs)
-
-    def exclude(self, *args, **kwargs):
-        """
-        Return a new QuerySet instance with NOT (args) ANDed to the existing
-        set.
-        """
-        return self._filter_or_exclude(True, *args, **kwargs)
-
-    def _filter_or_exclude(self, negate, *args, **kwargs):
-        clone = self._clone()
-        if negate:
-            clone._add_q(~Q(*args, **kwargs))
-        else:
-            clone._add_q(Q(*args, **kwargs))
-        return clone
-
-    def paginate(self, **page_args):
-        """Update page preferences for query"""
-        clone = self._clone()
-        if 'page' in page_args and isinstance(page_args['page'], int):
-            clone._page = page_args['page']
-        if 'per_page' in page_args and isinstance(page_args['per_page'], int):
-            clone._per_page = page_args['per_page']
-
-        return clone
-
-    def order_by(self, order_by: Union[set, str]):
-        """Update page setting for filter set"""
-        clone = self._clone()
-        if isinstance(order_by, str):
-            order_by = {order_by}
-
-        clone._order_by = clone._order_by.union(order_by)
-
-        return clone
-
-    def _retrieve_model(self):
-        """Retrieve model details associated with this Entity"""
-        # Fetch Model class and connected repository from Repository Factory
-        model_cls = repo_factory.get_model(self._entity_cls_name)
-        repository = getattr(repo_factory, self._entity_cls_name)
-
-        return (model_cls, repository)
-
-    def all(self):
-        """Primary method to fetch data based on filters
-
-        Also trigged when the QuerySet is evaluated by calling one of the following methods:
-            * len()
-            * bool()
-            * list()
-            * Iteration
-            * Slicing
-        """
-        logger.debug(f'Query `{self.__class__.__name__}` objects with filters {self}')
-
-        # Destroy any cached results
-        self._result_cache = None
-
-        # Fetch Model class and connected repository from Repository Factory
-        model_cls, repository = self._retrieve_model()
-
-        # order_by clause must be list of keys
-        order_by = model_cls.opts_.order_by if not self._order_by else self._order_by
-
-        # Call the read method of the repository
-        results = repository._filter_objects(self._criteria, self._page, self._per_page, order_by)
-
-        # Convert the returned results to entity and return it
-        entity_items = []
-        for item in results.items:
-            entity = model_cls.to_entity(item)
-            entity.state_.mark_retrieved()
-            entity_items.append(entity)
-        results.items = entity_items
-
-        # Cache results
-        self._result_cache = results
-
-        return results
-
-    def update(self, *data, **kwargs):
-        """Updates all objects with details given if they match a set of conditions supplied.
-
-        This method updates each object individually, to fire callback methods and ensure
-        validations are run.
-
-        Returns the number of objects matched (which may not be equal to the number of objects
-            updated if objects rows already have the new value).
-        """
-        updated_item_count = 0
-        try:
-            items = self.all()
-
-            for item in items:
-                item.update(*data, **kwargs)
-                updated_item_count += 1
-        except Exception as exc:
-            # FIXME Log Exception
-            raise
-
-        return updated_item_count
-
-    def delete(self):
-        """Deletes matching objects from the Repository
-
-        Does not throw error if no objects are matched.
-
-        Returns the number of objects matched (which may not be equal to the number of objects
-            deleted if objects rows already have the new value).
-        """
-        # Fetch Model class and connected repository from Repository Factory
-        deleted_item_count = 0
-        try:
-            items = self.all()
-
-            for item in items:
-                item.delete()
-                deleted_item_count += 1
-        except Exception as exc:
-            # FIXME Log Exception
-            raise
-
-        return deleted_item_count
-
-    def update_all(self, *args, **kwargs):
-        """Updates all objects with details given if they match a set of conditions supplied.
-
-        This method forwards filters and updates directly to the repository. It does not
-        instantiate entities and it does not trigger Entity callbacks or validations.
-
-        Update values can be specified either as a dict, or keyword arguments.
-
-        Returns the number of objects matched (which may not be equal to the number of objects
-            updated if objects rows already have the new value).
-        """
-        updated_item_count = 0
-        _, repository = self._retrieve_model()
-        try:
-            updated_item_count = repository._update_all_objects(self._criteria, *args, **kwargs)
-        except Exception as exc:
-            # FIXME Log Exception
-            raise
-
-        return updated_item_count
-
-    def delete_all(self, *args, **kwargs):
-        """Deletes objects that match a set of conditions supplied.
-
-        This method forwards filters directly to the repository. It does not instantiate entities and
-        it does not trigger Entity callbacks or validations.
-
-        Returns the number of objects matched and deleted.
-        """
-        deleted_item_count = 0
-        _, repository = self._retrieve_model()
-        try:
-            deleted_item_count = repository._delete_all_objects(self._criteria)
-        except Exception as exc:
-            # FIXME Log Exception
-            raise
-
-        return deleted_item_count
-
-    ###############################
-    # Python Magic method support #
-    ###############################
-
-    def __iter__(self):
-        """Return results on iteration"""
-        if self._result_cache:
-            return iter(self._result_cache)
-
-        return iter(self.all())
-
-    def __len__(self):
-        """Return length of results"""
-        if self._result_cache:
-            return self._result_cache.total
-
-        return self.all().total
-
-    def __bool__(self):
-        """Return True if query results have items"""
-        if self._result_cache:
-            return bool(self._result_cache)
-
-        return bool(self.all())
-
-    def __repr__(self):
-        """Support friendly print of query criteria"""
-        return ("<%s: entity: %s, criteria: %s, page: %s, per_page: %s, order_by: %s>" %
-                (self.__class__.__name__, self._entity_cls_name,
-                 self._criteria.deconstruct(),
-                 self._page, self._per_page, self._order_by))
-
-    def __getitem__(self, k):
-        """Support slicing of results"""
-        if self._result_cache:
-            return self._result_cache.items[k]
-
-        return self.all().items[k]
-
-    #########################
-    # Pagination properties #
-    #########################
-
-    @property
-    def total(self):
-        """Return the total number of records"""
-        if self._result_cache:
-            return self._result_cache.total
-
-        return self.all().total
-
-    @property
-    def items(self):
-        """Return result values"""
-        if self._result_cache:
-            return self._result_cache.items
-
-        return self.all().items
-
-    @property
-    def first(self):
-        """Return the first result"""
-        if self._result_cache:
-            return self._result_cache.first
-
-        return self.all().first
-
-    @property
-    def has_next(self):
-        """Return True if there are more values present"""
-        if self._result_cache:
-            return self._result_cache.has_next
-
-        return self.all().has_next
-
-    @property
-    def has_prev(self):
-        """Return True if there are previous values present"""
-        if self._result_cache:
-            return self._result_cache.has_prev
-
-        return self.all().has_prev
 
 
 class EntityStateFieldsCacheDescriptor:
@@ -640,8 +328,8 @@ class Entity(metaclass=EntityBase):
         from protean.core.repository import repo_factory  # FIXME Move to a better placement
 
         # Fetch Model class and connected repository from Repository Factory
-        model_cls = repo_factory.get_model(cls.__name__)
-        repository = getattr(repo_factory, cls.__name__)
+        model_cls = repo_factory.get_model(cls)
+        repository = repo_factory.get_repository(cls)
 
         return (model_cls, repository)
 
@@ -873,3 +561,315 @@ class Entity(metaclass=EntityBase):
         except Exception as exc:
             # FIXME Log Exception
             raise
+
+
+class QuerySet:
+    """A chainable class to gather a bunch of criteria and preferences (page size, order etc.)
+    before execution.
+
+    Internally, a QuerySet can be constructed, filtered, sliced, and generally passed around
+    without actually fetching data. No data fetch actually occurs until you do something
+    to evaluate the queryset.
+
+    Once evaluated, a `QuerySet` typically caches its results. If the data in the database
+    might have changed, you can get updated results for the same query by calling `all()` on a
+    previously evaluated `QuerySet`.
+
+    Attributes:
+        page: The current page number of the records to be pulled
+        per_page: The size of each page of the records to be pulled
+        order_by: The list of parameters to be used for ordering the results.
+            Use a `-` before the parameter name to sort in descending order
+            and if not ascending order.
+        excludes_: Objects with these properties will be excluded from the results
+        filters: Filter criteria
+
+    :return Returns a `Pagination` object that holds the query results
+    """
+
+    def __init__(self, entity_cls: Entity, criteria=None, page: int = 1, per_page: int = 10,
+                 order_by: set = None):
+        """Initialize either with empty preferences (when invoked on an Entity)
+            or carry forward filters and preferences when chained
+        """
+
+        self._entity_cls = entity_cls
+        self._criteria = criteria or Q()
+        self._result_cache = None
+        self._page = page or 1
+        self._per_page = per_page or 10
+
+        # `order_by` could be empty, or a string or a set.
+        #   Intialize empty set if `order_by` is None
+        #   Convert string to set if `order_by` is a String
+        #   Safe-cast set to a set if `order_by` is already a set
+        if order_by:
+            self._order_by = set([order_by]) if isinstance(order_by, str) else set(order_by)
+        else:
+            self._order_by = set()
+
+    def _clone(self):
+        """
+        Return a copy of the current QuerySet.
+        """
+        clone = self.__class__(self._entity_cls, criteria=self._criteria,
+                               page=self._page, per_page=self._per_page,
+                               order_by=self._order_by)
+        return clone
+
+    def _add_q(self, q_object):
+        """Add a Q-object to the current filter."""
+        self._criteria = self._criteria._combine(q_object, q_object.connector)
+
+    def filter(self, *args, **kwargs):
+        """
+        Return a new QuerySet instance with the args ANDed to the existing
+        set.
+        """
+        return self._filter_or_exclude(False, *args, **kwargs)
+
+    def exclude(self, *args, **kwargs):
+        """
+        Return a new QuerySet instance with NOT (args) ANDed to the existing
+        set.
+        """
+        return self._filter_or_exclude(True, *args, **kwargs)
+
+    def _filter_or_exclude(self, negate, *args, **kwargs):
+        clone = self._clone()
+        if negate:
+            clone._add_q(~Q(*args, **kwargs))
+        else:
+            clone._add_q(Q(*args, **kwargs))
+        return clone
+
+    def paginate(self, **page_args):
+        """Update page preferences for query"""
+        clone = self._clone()
+        if 'page' in page_args and isinstance(page_args['page'], int):
+            clone._page = page_args['page']
+        if 'per_page' in page_args and isinstance(page_args['per_page'], int):
+            clone._per_page = page_args['per_page']
+
+        return clone
+
+    def order_by(self, order_by: Union[set, str]):
+        """Update page setting for filter set"""
+        clone = self._clone()
+        if isinstance(order_by, str):
+            order_by = {order_by}
+
+        clone._order_by = clone._order_by.union(order_by)
+
+        return clone
+
+    def _retrieve_model(self):
+        """Retrieve model details associated with this Entity"""
+        # Fetch Model class and connected repository from Repository Factory
+        model_cls = repo_factory.get_model(self._entity_cls)
+        repository = repo_factory.get_repository(self._entity_cls)
+
+        return (model_cls, repository)
+
+    def all(self):
+        """Primary method to fetch data based on filters
+
+        Also trigged when the QuerySet is evaluated by calling one of the following methods:
+            * len()
+            * bool()
+            * list()
+            * Iteration
+            * Slicing
+        """
+        logger.debug(f'Query `{self.__class__.__name__}` objects with filters {self}')
+
+        # Destroy any cached results
+        self._result_cache = None
+
+        # Fetch Model class and connected repository from Repository Factory
+        model_cls, repository = self._retrieve_model()
+
+        # order_by clause must be list of keys
+        order_by = model_cls.opts_.order_by if not self._order_by else self._order_by
+
+        # Call the read method of the repository
+        results = repository._filter_objects(self._criteria, self._page, self._per_page, order_by)
+
+        # Convert the returned results to entity and return it
+        entity_items = []
+        for item in results.items:
+            entity = model_cls.to_entity(item)
+            entity.state_.mark_retrieved()
+            entity_items.append(entity)
+        results.items = entity_items
+
+        # Cache results
+        self._result_cache = results
+
+        return results
+
+    def update(self, *data, **kwargs):
+        """Updates all objects with details given if they match a set of conditions supplied.
+
+        This method updates each object individually, to fire callback methods and ensure
+        validations are run.
+
+        Returns the number of objects matched (which may not be equal to the number of objects
+            updated if objects rows already have the new value).
+        """
+        updated_item_count = 0
+        try:
+            items = self.all()
+
+            for item in items:
+                item.update(*data, **kwargs)
+                updated_item_count += 1
+        except Exception as exc:
+            # FIXME Log Exception
+            raise
+
+        return updated_item_count
+
+    def delete(self):
+        """Deletes matching objects from the Repository
+
+        Does not throw error if no objects are matched.
+
+        Returns the number of objects matched (which may not be equal to the number of objects
+            deleted if objects rows already have the new value).
+        """
+        # Fetch Model class and connected repository from Repository Factory
+        deleted_item_count = 0
+        try:
+            items = self.all()
+
+            for item in items:
+                item.delete()
+                deleted_item_count += 1
+        except Exception as exc:
+            # FIXME Log Exception
+            raise
+
+        return deleted_item_count
+
+    def update_all(self, *args, **kwargs):
+        """Updates all objects with details given if they match a set of conditions supplied.
+
+        This method forwards filters and updates directly to the repository. It does not
+        instantiate entities and it does not trigger Entity callbacks or validations.
+
+        Update values can be specified either as a dict, or keyword arguments.
+
+        Returns the number of objects matched (which may not be equal to the number of objects
+            updated if objects rows already have the new value).
+        """
+        updated_item_count = 0
+        _, repository = self._retrieve_model()
+        try:
+            updated_item_count = repository._update_all_objects(self._criteria, *args, **kwargs)
+        except Exception as exc:
+            # FIXME Log Exception
+            raise
+
+        return updated_item_count
+
+    def delete_all(self, *args, **kwargs):
+        """Deletes objects that match a set of conditions supplied.
+
+        This method forwards filters directly to the repository. It does not instantiate entities and
+        it does not trigger Entity callbacks or validations.
+
+        Returns the number of objects matched and deleted.
+        """
+        deleted_item_count = 0
+        _, repository = self._retrieve_model()
+        try:
+            deleted_item_count = repository._delete_all_objects(self._criteria)
+        except Exception as exc:
+            # FIXME Log Exception
+            raise
+
+        return deleted_item_count
+
+    ###############################
+    # Python Magic method support #
+    ###############################
+
+    def __iter__(self):
+        """Return results on iteration"""
+        if self._result_cache:
+            return iter(self._result_cache)
+
+        return iter(self.all())
+
+    def __len__(self):
+        """Return length of results"""
+        if self._result_cache:
+            return self._result_cache.total
+
+        return self.all().total
+
+    def __bool__(self):
+        """Return True if query results have items"""
+        if self._result_cache:
+            return bool(self._result_cache)
+
+        return bool(self.all())
+
+    def __repr__(self):
+        """Support friendly print of query criteria"""
+        return ("<%s: entity: %s, criteria: %s, page: %s, per_page: %s, order_by: %s>" %
+                (self.__class__.__name__, self._entity_cls,
+                 self._criteria.deconstruct(),
+                 self._page, self._per_page, self._order_by))
+
+    def __getitem__(self, k):
+        """Support slicing of results"""
+        if self._result_cache:
+            return self._result_cache.items[k]
+
+        return self.all().items[k]
+
+    #########################
+    # Pagination properties #
+    #########################
+
+    @property
+    def total(self):
+        """Return the total number of records"""
+        if self._result_cache:
+            return self._result_cache.total
+
+        return self.all().total
+
+    @property
+    def items(self):
+        """Return result values"""
+        if self._result_cache:
+            return self._result_cache.items
+
+        return self.all().items
+
+    @property
+    def first(self):
+        """Return the first result"""
+        if self._result_cache:
+            return self._result_cache.first
+
+        return self.all().first
+
+    @property
+    def has_next(self):
+        """Return True if there are more values present"""
+        if self._result_cache:
+            return self._result_cache.has_next
+
+        return self.all().has_next
+
+    @property
+    def has_prev(self):
+        """Return True if there are previous values present"""
+        if self._result_cache:
+            return self._result_cache.has_prev
+
+        return self.all().has_prev

--- a/src/protean/utils/generic.py
+++ b/src/protean/utils/generic.py
@@ -8,3 +8,8 @@ class classproperty(object):
 
     def __get__(self, owner_self, owner_cls):
         return self.fget(owner_cls)
+
+
+def fully_qualified_name(cls):
+    """Return Fully Qualified name along with module"""
+    return '.'.join([cls.__module__, cls.__qualname__])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,24 +45,29 @@ def register_models():
 def run_around_tests():
     """Cleanup Database after each test run"""
     from protean.core.repository import repo_factory
+    from tests.support.dog import (Dog, RelatedDog, DogRelatedByEmail, HasOneDog1,
+                                   HasOneDog2, HasOneDog3, HasManyDog1, HasManyDog2,
+                                   HasManyDog3, ThreadedDog)
+    from tests.support.human import (Human, HasOneHuman1, HasOneHuman2, HasOneHuman3,
+                                     HasManyHuman1, HasManyHuman2, HasManyHuman3)
 
     # A test function will be run at this point
     yield
 
-    repo_factory.Dog.delete_all()
-    repo_factory.RelatedDog.delete_all()
-    repo_factory.DogRelatedByEmail.delete_all()
-    repo_factory.HasOneDog1.delete_all()
-    repo_factory.HasOneDog2.delete_all()
-    repo_factory.HasOneDog3.delete_all()
-    repo_factory.HasManyDog1.delete_all()
-    repo_factory.HasManyDog2.delete_all()
-    repo_factory.HasManyDog3.delete_all()
-    repo_factory.Human.delete_all()
-    repo_factory.HasOneHuman1.delete_all()
-    repo_factory.HasOneHuman2.delete_all()
-    repo_factory.HasOneHuman3.delete_all()
-    repo_factory.HasManyHuman1.delete_all()
-    repo_factory.HasManyHuman2.delete_all()
-    repo_factory.HasManyHuman3.delete_all()
-    repo_factory.ThreadedDog.delete_all()
+    repo_factory.get_repository(Dog).delete_all()
+    repo_factory.get_repository(RelatedDog).delete_all()
+    repo_factory.get_repository(DogRelatedByEmail).delete_all()
+    repo_factory.get_repository(HasOneDog1).delete_all()
+    repo_factory.get_repository(HasOneDog2).delete_all()
+    repo_factory.get_repository(HasOneDog3).delete_all()
+    repo_factory.get_repository(HasManyDog1).delete_all()
+    repo_factory.get_repository(HasManyDog2).delete_all()
+    repo_factory.get_repository(HasManyDog3).delete_all()
+    repo_factory.get_repository(Human).delete_all()
+    repo_factory.get_repository(HasOneHuman1).delete_all()
+    repo_factory.get_repository(HasOneHuman2).delete_all()
+    repo_factory.get_repository(HasOneHuman3).delete_all()
+    repo_factory.get_repository(HasManyHuman1).delete_all()
+    repo_factory.get_repository(HasManyHuman2).delete_all()
+    repo_factory.get_repository(HasManyHuman3).delete_all()
+    repo_factory.get_repository(ThreadedDog).delete_all()

--- a/tests/core/test_entity.py
+++ b/tests/core/test_entity.py
@@ -353,7 +353,7 @@ class TestEntity:
 
         assert query is not None
         assert isinstance(query, QuerySet)
-        assert vars(query) == vars(QuerySet('Dog'))
+        assert vars(query) == vars(QuerySet(Dog))
 
     def test_filter_chain_initialization_from_entity(self):
         """ Test that chaining returns a QuerySet for further chaining """

--- a/tests/core/test_queryset.py
+++ b/tests/core/test_queryset.py
@@ -31,7 +31,7 @@ class TestQuerySet:
     def test_repr(self):
         """Test that filter is evaluted on calling `list()`"""
         query = Dog.query.filter(owner='John').order_by('age')
-        assert repr(query) == ("<QuerySet: entity: Dog, "
+        assert repr(query) == ("<QuerySet: entity: <class 'tests.support.dog.Dog'>, "
                                "criteria: ('protean.utils.query.Q', (), {'owner': 'John'}), "
                                "page: 1, "
                                "per_page: 10, order_by: {'age'}>")

--- a/tests/core/test_repository.py
+++ b/tests/core/test_repository.py
@@ -15,7 +15,7 @@ class TestRepository:
         """Test successful access to the Dog repository"""
 
         Dog.query.all()
-        current_db = dict(repo_factory.Dog.conn)
+        current_db = dict(repo_factory.get_repository(Dog).conn)
         assert current_db['data'] == {'dogs': {}}
 
     def test_create_error(self):

--- a/tests/support/dog.py
+++ b/tests/support/dog.py
@@ -49,7 +49,7 @@ class RelatedDog2(Entity):
     """
     name = field.String(required=True, unique=True, max_length=50)
     age = field.Integer(default=5)
-    owner = field.Reference('Human')
+    owner = field.Reference('tests.support.human.Human')
 
 
 class RelatedDog2Model(DictModel):

--- a/tests/support/human.py
+++ b/tests/support/human.py
@@ -27,7 +27,7 @@ class HasOneHuman1(Entity):
     first_name = field.String(required=True, unique=True, max_length=50)
     last_name = field.String(required=True, unique=True, max_length=50)
     email = field.String(required=True, unique=True, max_length=50)
-    dog = association.HasOne('HasOneDog1')
+    dog = association.HasOne('tests.support.dog.HasOneDog1')
 
 
 class HasOneHuman1Model(DictModel):
@@ -46,7 +46,7 @@ class HasOneHuman2(Entity):
     first_name = field.String(required=True, unique=True, max_length=50)
     last_name = field.String(required=True, unique=True, max_length=50)
     email = field.String(required=True, unique=True, max_length=50)
-    dog = association.HasOne('HasOneDog2', via='human_id')
+    dog = association.HasOne('tests.support.dog.HasOneDog2', via='human_id')
 
 
 class HasOneHuman2Model(DictModel):
@@ -65,7 +65,7 @@ class HasOneHuman3(Entity):
     first_name = field.String(required=True, unique=True, max_length=50)
     last_name = field.String(required=True, unique=True, max_length=50)
     email = field.String(required=True, unique=True, max_length=50)
-    dog = association.HasOne('HasOneDog3', via='human_id')
+    dog = association.HasOne('tests.support.dog.HasOneDog3', via='human_id')
 
 
 class HasOneHuman3Model(DictModel):
@@ -82,7 +82,7 @@ class HasManyHuman1(Entity):
     first_name = field.String(required=True, unique=True, max_length=50)
     last_name = field.String(required=True, unique=True, max_length=50)
     email = field.String(required=True, unique=True, max_length=50)
-    dogs = association.HasMany('HasManyDog1')
+    dogs = association.HasMany('tests.support.dog.HasManyDog1')
 
 
 class HasManyHuman1Model(DictModel):
@@ -120,7 +120,7 @@ class HasManyHuman3(Entity):
     first_name = field.String(required=True, unique=True, max_length=50)
     last_name = field.String(required=True, unique=True, max_length=50)
     email = field.String(required=True, unique=True, max_length=50)
-    dogs = association.HasMany('HasManyDog3', via='human_id')
+    dogs = association.HasMany('tests.support.dog.HasManyDog3', via='human_id')
 
 
 class HasManyHuman3Model(DictModel):


### PR DESCRIPTION
Entities with the same name can now exist in different packages, but can still resolve correctly.

This PR has changes to clean up Repository Factory, retain one single registry for all query purposes and support search by Entity's fully qualified name or simple class name values.

When an entity class is specified as a string, like in case of Associations, the user can specify either a fully qualified class name (like `tests.support.dog.Dog`) or a simple class name (like 'Dog') as referenced Entity. In case the primary search on entity name fails, repo factory will try to search for the primary class name in registry values. If it finds more than one record, it throws an error asking the user to specify the fully qualified name of the class. Otherwise, it returns the correct Entity class.

Closes #115 