### PR TITLE
Refactor repository methods to be public

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Release History
 ===============
 
+dev
+---
+
+* Rename Repository abstract methods to be public (Ex. `_create_object` → `create`)
+* Add `delete_all()` method to Entity to support Repository cleanup
+
 0.0.10 (2019-04-05)
 -------------------
 

--- a/docs/api/entity.rst
+++ b/docs/api/entity.rst
@@ -51,3 +51,9 @@ Other Methods:
 
 .. automethod:: protean.core.entity.Entity.find_by
 
+.. _api-entity-delete-all:
+
+``delete_all()``
+^^^^^^^^^^^^^^^^
+
+.. automethod:: protean.core.entity.Entity.delete_all

--- a/src/protean/core/repository/base.py
+++ b/src/protean/core/repository/base.py
@@ -26,29 +26,29 @@ class BaseRepository(metaclass=ABCMeta):
         self.model_name = model_cls.opts_.model_name
 
     @abstractmethod
-    def _filter_objects(self, criteria: Q, page: int = 1, per_page: int = 10,
-                        order_by: list = ()) -> Pagination:
+    def filter(self, criteria: Q, page: int = 1, per_page: int = 10,
+               order_by: list = ()) -> Pagination:
         """
         Filter objects from the repository. Method must return a `Pagination`
         object
         """
 
     @abstractmethod
-    def _create_object(self, model_obj: Any):
+    def create(self, model_obj: Any):
         """Create a new model object from the entity"""
 
     @abstractmethod
-    def _update_object(self, model_obj: Any):
+    def update(self, model_obj: Any):
         """Update a model object in the repository and return it"""
 
     @abstractmethod
-    def _update_all_objects(self, criteria: Q, *args, **kwargs):
+    def update_all(self, criteria: Q, *args, **kwargs):
         """Updates object directly in the repository and returns update count"""
 
     @abstractmethod
-    def _delete_object(self):
+    def delete(self):
         """Delete a Record from the Repository"""
 
     @abstractmethod
-    def _delete_all_objects(self, criteria: Q):
+    def delete_all(self, criteria: Q):
         """Delete a Record from the Repository"""

--- a/tests/core/test_entity.py
+++ b/tests/core/test_entity.py
@@ -555,6 +555,21 @@ class TestEntity:
             Dog.get(3)
 
     def test_delete_all(self):
+        """Clean up repository and delete all records"""
+        Dog.create(id=1, name='Athos', owner='John', age=2)
+        Dog.create(id=2, name='Porthos', owner='John', age=3)
+        Dog.create(id=3, name='Aramis', owner='John', age=4)
+        Dog.create(id=4, name='dArtagnan', owner='John', age=5)
+
+        dogs = Dog.query.all()
+        assert dogs.total == 4
+
+        Dog.delete_all()
+
+        dogs = Dog.query.all()
+        assert dogs.total == 0
+
+    def test_delete_all_by_filter(self):
         """Try updating all records satisfying filter in one step, passing a dict"""
         Dog.create(id=1, name='Athos', owner='John', age=2)
         Dog.create(id=2, name='Porthos', owner='John', age=3)

--- a/tests/core/test_repository.py
+++ b/tests/core/test_repository.py
@@ -6,10 +6,14 @@ from tests.support.dog import Dog
 from protean.core.exceptions import ObjectNotFoundError
 from protean.core.exceptions import ValidationError
 from protean.core.repository import repo_factory
+from protean.utils.query import Q
 
 
 class TestRepository:
-    """This class holds tests for Repository class"""
+    """This class holds tests for Repository class
+
+    FIXME Move test cases to directly test Repository class functionality and not via Entity
+    """
 
     def test_init(self):
         """Test successful access to the Dog repository"""
@@ -108,6 +112,24 @@ class TestRepository:
 
         with pytest.raises(ObjectNotFoundError):
             Dog.get(3)
+
+    def test_delete_all(self):
+        """Delete all objects in a repository"""
+
+        Dog.create(id=1, name='Athos', owner='John', age=2)
+        Dog.create(id=2, name='Porthos', owner='John', age=3)
+        Dog.create(id=3, name='Aramis', owner='John', age=4)
+        Dog.create(id=4, name='dArtagnan', owner='John', age=5)
+
+        repo = repo_factory.get_repository(Dog)
+
+        dog_records = repo.filter(Q())
+        assert dog_records.total == 4
+
+        repo.delete_all()
+
+        dog_records = repo.filter(Q())
+        assert dog_records.total == 0
 
 
 class TestLookup:


### PR DESCRIPTION
Interface methods like `_filter_objects` and `_create_object` hint that they are private methods, but they are actually invoked from Protean during Entity Lifecycle. This PR renames them to be more straightforward, and public.