### PR TITLE
Support `raw` queries on Entity Repositories

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ dev
 
 * Rename Repository abstract methods to be public (Ex. `_create_object` → `create`)
 * Add `delete_all()` method to Entity to support Repository cleanup
+* Add support for `raw` queries on Entity repositories
 
 0.0.10 (2019-04-05)
 -------------------

--- a/docs/api/queryset.rst
+++ b/docs/api/queryset.rst
@@ -52,3 +52,9 @@ QuerySet
 
 .. automethod:: protean.core.queryset.QuerySet.delete_all
 
+.. _api-queryset-raw:
+
+``raw``
+^^^^^^^^^^^^^^
+
+.. automethod:: protean.core.queryset.QuerySet.raw

--- a/src/protean/core/repository/base.py
+++ b/src/protean/core/repository/base.py
@@ -52,3 +52,7 @@ class BaseRepository(metaclass=ABCMeta):
     @abstractmethod
     def delete_all(self, criteria: Q):
         """Delete a Record from the Repository"""
+
+    @abstractmethod
+    def raw(self, query_string: str):
+        """Run raw query on Repository"""

--- a/src/protean/impl/repository/dict_repo.py
+++ b/src/protean/impl/repository/dict_repo.py
@@ -1,5 +1,7 @@
 """ Implementation of a dictionary based repository """
 
+import json
+
 from collections import defaultdict
 from itertools import count
 from operator import itemgetter
@@ -212,6 +214,35 @@ class DictRepository(BaseRepository):
             with self.conn['lock']:
                 if self.model_name in self.conn['data']:
                     del self.conn['data'][self.model_name]
+
+    def raw(self, query_string: str):
+        """Run raw query on Repository.
+
+        For this stand-in repository, the query string is a json string that contains kwargs
+        criteria with straigh-forward equality checks. Individual criteria are always ANDed
+        and the result is always a subset of the full repository.
+        """
+        input_db = self.conn['data'][self.model_name]
+        result = None
+
+        try:
+            criteria = json.loads(query_string)
+
+            for key, value in criteria.items():
+                input_db = self._evaluate_lookup(key, value, False, input_db)
+
+            items = list(input_db.values())
+            result = Pagination(
+                page=1,
+                per_page=len(items),
+                total=len(items),
+                items=items)
+
+        except json.JSONDecodeError as exc:
+            # FIXME Log Exception
+            raise Exception("Query Malformed")
+
+        return result
 
 
 operators = {

--- a/tests/core/test_queryset.py
+++ b/tests/core/test_queryset.py
@@ -251,3 +251,25 @@ class TestQuerySet:
         Dog.create(id=5, name='Berry', age=8, owner='John')
         assert query.first.id == 2
         assert query.all().first.id == 5
+
+    def test_raw(self):
+        """Test raw queries"""
+        Dog.create(id=2, name='Murdock', age=7, owner='John')
+        Dog.create(id=3, name='Jean', age=3, owner='John')
+        Dog.create(id=4, name='Bart', age=6, owner='Carrie')
+
+        # Filter by Dog attributes
+        results = Dog.query.raw('{"owner":"John"}')
+        assert results.total == 2
+
+        results = Dog.query.raw("{'owner':'John'}")
+        assert results.total == 2
+
+        results = Dog.query.raw('{"owner":"John", "age":3}')
+        assert results.total == 1
+
+        results = Dog.query.raw('{"owner":"John", "age__in":[6,7]}')
+        assert results.total == 1
+
+        results = Dog.query.raw('{"owner":"John", "age__in":[3,7]}')
+        assert results.total == 2


### PR DESCRIPTION
This pull request has an implementation for the first `raw` method for querying Entity Repositories (refer to #105 for more details).

* This method ignores all other query options like `page`, `per_page` and `order_by`
* This method is capable of running queries on a single Entity Repository alone.
* The result set is a set of Entity Objects
* Dict Repo implementation has been upgraded to support a very simplistic implementation of `raw` queries.