### PR TITLE
121 Eliminate explicit definitions of Models

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,8 @@ dev
 
 * Rename Repository abstract methods to be public (Ex. `_create_object` → `create`)
 * Add `delete_all()` method to Entity to support Repository cleanup
+* Remove requirement for explicit Model definitions for Entities
+    * Move Model options into Entity `Meta` class
 
 0.0.10 (2019-04-05)
 -------------------

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,7 +1,6 @@
 check-manifest==0.37
 coverage==4.5.1
 docutils==0.14
-flake8==3.5.0
 pytest-flake8==1.0.4
 sphinx==1.8.3
 tox==3.1.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,10 @@
 [bdist_wheel]
 universal = 1
 
-
 [flake8]
 max-line-length = 140
 exclude = */migrations/*
-ignore = E731
+extend-ignore = E731
 
 [tool:pytest]
 testpaths = tests

--- a/src/protean/core/field/base.py
+++ b/src/protean/core/field/base.py
@@ -35,7 +35,7 @@ class Field(FieldDescriptorMixin, metaclass=ABCMeta):
     # Default error messages for various kinds of errors.
     default_error_messages = {
         'invalid': 'Value is not a valid type for this field.',
-        'unique': '`{model_name:s}` with this `{field_name:s}` already exists.',
+        'unique': '`{entity_name:s}` with this `{field_name:s}` already exists.',
         'required': 'This field is required.',
         'invalid_choice': 'Value `{value!r}` is not a valid choice. '
                           'Must be one of {choices!r}',

--- a/src/protean/core/field/basic.py
+++ b/src/protean/core/field/basic.py
@@ -14,6 +14,7 @@ class String(Field):
     :param max_length: The maximum allowed length for the field.
     :param min_length: The minimum allowed length for the field.
 
+    FIXME Should max_length be optional?
     """
     default_error_messages = {
         'invalid': '{value}" value must be a string.',

--- a/src/protean/core/field/utils.py
+++ b/src/protean/core/field/utils.py
@@ -3,14 +3,14 @@ from protean.core.repository import repo_factory
 
 
 def fetch_entity_cls_from_registry(entity):
-        """Util Method to fetch an Entity class from an entity's name"""
-        # Defensive check to ensure we only process if `to_cls` is a string
-        if isinstance(entity, str):
-            try:
-                return repo_factory.get_entity(entity)
-            except AssertionError:
-                # Entity has not been registered (yet)
-                # FIXME print a helpful debug message
-                raise
-        else:
-            return entity
+    """Util Method to fetch an Entity class from an entity's name"""
+    # Defensive check to ensure we only process if `to_cls` is a string
+    if isinstance(entity, str):
+        try:
+            return repo_factory.get_entity(entity)
+        except AssertionError:
+            # Entity has not been registered (yet)
+            # FIXME print a helpful debug message
+            raise
+    else:
+        return entity

--- a/src/protean/core/provider/base.py
+++ b/src/protean/core/provider/base.py
@@ -56,9 +56,6 @@ class BaseProvider(RegisterLookupMixin, metaclass=ABCMeta):
     def get_repository(self, model_cls):
         """ Return a repository object configured with a live connection"""
 
-    def get_model(self, model_cls):
-        """ Return the fully baked model, with any additions necessary
-
-        This is a placeholder method that can be overridden in each provider
-        """
-        return model_cls
+    @abstractmethod
+    def get_model(self, entity_cls):
+        """ Return associated Model Class"""

--- a/src/protean/core/queryset.py
+++ b/src/protean/core/queryset.py
@@ -186,7 +186,8 @@ class QuerySet:
         self._result_cache = None
 
         # Fetch Model class and connected repository from Repository Factory
-        model_cls, repository = self._retrieve_model()
+        model_cls = repo_factory.get_model(self._entity_cls)
+        repository = repo_factory.get_repository(self._entity_cls)
 
         try:
             # Call the read method of the repository

--- a/src/protean/core/queryset.py
+++ b/src/protean/core/queryset.py
@@ -33,7 +33,7 @@ class QuerySet:
     :return Returns a `Pagination` object that holds the query results
     """
 
-    def __init__(self, entity_cls: 'Entity', criteria=None, page: int = 1, per_page: int = 10,
+    def __init__(self, entity_cls, criteria=None, page: int = 1, per_page: int = 10,
                  order_by: set = None):
         """Initialize either with empty preferences (when invoked on an Entity)
             or carry forward filters and preferences when chained
@@ -109,14 +109,6 @@ class QuerySet:
 
         return clone
 
-    def _retrieve_model(self):
-        """Retrieve model details associated with this Entity"""
-        # Fetch Model class and connected repository from Repository Factory
-        model_cls = repo_factory.get_model(self._entity_cls)
-        repository = repo_factory.get_repository(self._entity_cls)
-
-        return (model_cls, repository)
-
     def all(self):
         """Primary method to fetch data based on filters
 
@@ -133,10 +125,11 @@ class QuerySet:
         self._result_cache = None
 
         # Fetch Model class and connected repository from Repository Factory
-        model_cls, repository = self._retrieve_model()
+        model_cls = repo_factory.get_model(self._entity_cls)
+        repository = repo_factory.get_repository(self._entity_cls)
 
         # order_by clause must be list of keys
-        order_by = model_cls.opts_.order_by if not self._order_by else self._order_by
+        order_by = self._entity_cls.meta_.order_by if not self._order_by else self._order_by
 
         # Call the read method of the repository
         results = repository.filter(self._criteria, self._page, self._per_page, order_by)
@@ -170,7 +163,7 @@ class QuerySet:
             for item in items:
                 item.update(*data, **kwargs)
                 updated_item_count += 1
-        except Exception as exc:
+        except Exception:
             # FIXME Log Exception
             raise
 
@@ -192,7 +185,7 @@ class QuerySet:
             for item in items:
                 item.delete()
                 deleted_item_count += 1
-        except Exception as exc:
+        except Exception:
             # FIXME Log Exception
             raise
 
@@ -210,10 +203,12 @@ class QuerySet:
             updated if objects rows already have the new value).
         """
         updated_item_count = 0
-        _, repository = self._retrieve_model()
+
+        repository = repo_factory.get_repository(self._entity_cls)
+
         try:
             updated_item_count = repository.update_all(self._criteria, *args, **kwargs)
-        except Exception as exc:
+        except Exception:
             # FIXME Log Exception
             raise
 
@@ -228,10 +223,10 @@ class QuerySet:
         Returns the number of objects matched and deleted.
         """
         deleted_item_count = 0
-        _, repository = self._retrieve_model()
+        repository = repo_factory.get_repository(self._entity_cls)
         try:
             deleted_item_count = repository.delete_all(self._criteria)
-        except Exception as exc:
+        except Exception:
             # FIXME Log Exception
             raise
 

--- a/src/protean/core/repository/__init__.py
+++ b/src/protean/core/repository/__init__.py
@@ -5,9 +5,7 @@ from .factory import RepositoryFactory
 from .factory import repo_factory
 from .lookup import BaseLookup
 from .model import BaseModel
-from .model import BaseModelMeta
-from .model import ModelOptions
 from .pagination import Pagination
 
-__all__ = ('BaseRepository', 'BaseModel', 'BaseModelMeta', 'BaseLookup', 'ModelOptions',
+__all__ = ('BaseRepository', 'BaseModel', 'BaseLookup',
            'RepositoryFactory', 'repo_factory', 'Pagination')

--- a/src/protean/core/repository/base.py
+++ b/src/protean/core/repository/base.py
@@ -18,12 +18,12 @@ class BaseRepository(metaclass=ABCMeta):
     :param model_cls: The model class registered with this repository
     """
 
-    def __init__(self, provider, model_cls):
+    def __init__(self, provider, entity_cls, model_cls):
         self.provider = provider
         self.conn = self.provider.get_connection()
         self.model_cls = model_cls
-        self.entity_cls = model_cls.opts_.entity_cls
-        self.model_name = model_cls.opts_.model_name
+        self.entity_cls = entity_cls
+        self.schema_name = entity_cls.meta_.schema_name
 
     @abstractmethod
     def filter(self, criteria: Q, page: int = 1, per_page: int = 10,
@@ -50,5 +50,5 @@ class BaseRepository(metaclass=ABCMeta):
         """Delete a Record from the Repository"""
 
     @abstractmethod
-    def delete_all(self, criteria: Q):
+    def delete_all(self, criteria: Q = None):
         """Delete a Record from the Repository"""

--- a/src/protean/core/repository/model.py
+++ b/src/protean/core/repository/model.py
@@ -1,79 +1,18 @@
 """ Module containing Model related Class Definitions """
 
 from abc import ABCMeta
-
-from protean.core.exceptions import ConfigurationError
-from protean.utils import inflection
+from abc import abstractmethod
 
 
-class ModelOptions(object):
-    """class Meta options for the :class:`BaseModel`."""
-
-    def __init__(self, meta, model_cls):
-        self.entity_cls = getattr(meta, 'entity', None)
-
-        # Import here to avoid cyclic deps
-        from protean.core.entity import Entity
-        if not self.entity_cls or not issubclass(self.entity_cls, Entity):
-            raise ConfigurationError(
-                '`entity` option must be set and be a subclass of `Entity`.')
-
-        # Get the model name to be used, if not provided default it
-        self.model_name = getattr(meta, 'model_name', None)
-        if not self.model_name:
-            self.model_name = inflection.underscore(model_cls.__name__)
-
-        # Get the database bound to this model
-        self.bind = getattr(meta, 'bind', 'default')
-
-        # Default ordering of the filter response
-        self.order_by = getattr(meta, 'order_by', ())
-
-
-class BaseModelMeta(ABCMeta):
-    """ Metaclass for the BaseModel, sets options and registers the model """
-    def __new__(mcs, name, bases, attrs):
-        klass = super().__new__(mcs, name, bases, attrs)
-
-        # Get the Meta class attribute defined for the base class
-        meta = getattr(klass, 'Meta', None)
-
-        # Load the meta class attributes for non base schemas
-        is_base = getattr(meta, 'base', False)
-        if not is_base:
-            # Set klass.opts by initializing the `options_cls` with the meta
-            klass.opts_ = klass.options_cls(meta, klass)
-
-        return klass
-
-
-class BaseModel(metaclass=BaseModelMeta):
-    """Model that defines an index/table in the repository"""
-    options_cls = ModelOptions
-    opts_ = None
-
-    class Meta(object):
-        """Options object for a Model.
-        Example usage: ::
-            class Meta:
-                entity = Dog
-        Available options:
-        - ``base``: Indicates that this is a base model so ignore the meta
-        - ``entity``: the entity associated with this model.
-        - ``model_name``: name of this model that will be used as table/index
-        names, defaults to underscore version of the class name.
-        - ``bind``: the name of the repository connection associated with this
-        model, default value is `default`.
-        - ``order_by``: default ordering of objects returned by filter queries.
-        """
-        base = True
+class BaseModel(metaclass=ABCMeta):
+    """Model representing a schema in the database"""
 
     @classmethod
+    @abstractmethod
     def from_entity(cls, entity):
         """Initialize Repository Model object from Entity object"""
-        raise NotImplementedError()
 
     @classmethod
+    @abstractmethod
     def to_entity(cls, *args, **kwargs):
         """Convert Repository Model Object to Entity Object"""
-        raise NotImplementedError()

--- a/src/protean/impl/repository/dict_repo.py
+++ b/src/protean/impl/repository/dict_repo.py
@@ -248,7 +248,7 @@ class DictRepository(BaseRepository):
         criteria with straigh-forward equality checks. Individual criteria are always ANDed
         and the result is always a subset of the full repository.
         """
-        input_db = self.conn['data'][self.model_name]
+        input_db = self.conn['data'][self.schema_name]
         result = None
 
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,32 +13,29 @@ def register_models():
        Run only once for the entire test suite
     """
     from protean.core.repository import repo_factory
-    from tests.support.dog import (DogModel, RelatedDogModel, DogRelatedByEmailModel,
-                                   HasOneDog1Model, HasOneDog2Model, HasOneDog3Model,
-                                   HasManyDog1Model, HasManyDog2Model, HasManyDog3Model,
-                                   ThreadedDogModel)
-    from tests.support.human import (HumanModel, HasOneHuman1Model,
-                                     HasOneHuman2Model, HasOneHuman3Model,
-                                     HasManyHuman1Model, HasManyHuman2Model,
-                                     HasManyHuman3Model)
+    from tests.support.dog import (Dog, RelatedDog, DogRelatedByEmail, HasOneDog1,
+                                   HasOneDog2, HasOneDog3, HasManyDog1, HasManyDog2,
+                                   HasManyDog3, ThreadedDog)
+    from tests.support.human import (Human, HasOneHuman1, HasOneHuman2, HasOneHuman3,
+                                     HasManyHuman1, HasManyHuman2, HasManyHuman3)
 
-    repo_factory.register(DogModel)
-    repo_factory.register(RelatedDogModel)
-    repo_factory.register(DogRelatedByEmailModel)
-    repo_factory.register(HasOneDog1Model)
-    repo_factory.register(HasOneDog2Model)
-    repo_factory.register(HasOneDog3Model)
-    repo_factory.register(HasManyDog1Model)
-    repo_factory.register(HasManyDog2Model)
-    repo_factory.register(HasManyDog3Model)
-    repo_factory.register(HumanModel)
-    repo_factory.register(HasOneHuman1Model)
-    repo_factory.register(HasOneHuman2Model)
-    repo_factory.register(HasOneHuman3Model)
-    repo_factory.register(HasManyHuman1Model)
-    repo_factory.register(HasManyHuman2Model)
-    repo_factory.register(HasManyHuman3Model)
-    repo_factory.register(ThreadedDogModel)
+    repo_factory.register(Dog)
+    repo_factory.register(RelatedDog)
+    repo_factory.register(DogRelatedByEmail)
+    repo_factory.register(HasOneDog1)
+    repo_factory.register(HasOneDog2)
+    repo_factory.register(HasOneDog3)
+    repo_factory.register(HasManyDog1)
+    repo_factory.register(HasManyDog2)
+    repo_factory.register(HasManyDog3)
+    repo_factory.register(Human)
+    repo_factory.register(HasOneHuman1)
+    repo_factory.register(HasOneHuman2)
+    repo_factory.register(HasOneHuman3)
+    repo_factory.register(HasManyHuman1)
+    repo_factory.register(HasManyHuman2)
+    repo_factory.register(HasManyHuman3)
+    repo_factory.register(ThreadedDog)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/core/test_entity.py
+++ b/tests/core/test_entity.py
@@ -11,9 +11,9 @@ from tests.support.human import Human
 
 from protean.core import field
 from protean.core.entity import Entity
-from protean.core.queryset import QuerySet
 from protean.core.exceptions import ObjectNotFoundError
 from protean.core.exceptions import ValidationError
+from protean.core.queryset import QuerySet
 
 
 class TestEntity:
@@ -345,7 +345,7 @@ class TestEntity:
             Dog.create(
                 id=2, name='Johnny', owner='Carey')
         assert err.value.normalized_messages == {
-            'name': ['`dogs` with this `name` already exists.']}
+            'name': ['`Dog` with this `name` already exists.']}
 
     def test_query_init(self):
         """Test the initialization of a QuerySet"""
@@ -629,8 +629,85 @@ class TestEntity:
 
 
 class TestEntityMetaAttributes:
-
     """Class that holds testcases for Entity's meta attributes"""
+
+    def test_entity_structure(self):
+        """Test the meta structure of an Entity class"""
+        # Test that an entity has Meta information
+        assert hasattr(Dog, 'meta_')
+
+        meta = getattr(Dog, 'meta_')
+        assert hasattr(meta, 'abstract')
+        # Test that meta has correct defaults
+
+    def test_meta_overriding_abstract(self):
+        """Test that `abstract` flag can be overridden"""
+
+        # Class with overridden meta info
+        class Foo(Entity):
+            bar = field.String(max_length=25)
+
+            class Meta:
+                abstract = True
+
+        # Test that `abstract` is False by default
+        assert getattr(Dog.meta_, 'abstract') is False
+
+        # Test that the option in meta is overridden
+        assert hasattr(Foo.meta_, 'abstract')
+        assert getattr(Foo.meta_, 'abstract') is True
+
+    def test_meta_overriding_schema_name(self):
+        """Test that `schema_name` can be overridden"""
+
+        # Class with overridden meta info
+        class Foo(Entity):
+            bar = field.String(max_length=25)
+
+            class Meta:
+                schema_name = 'foosball'
+
+        # Test that `schema_name` is False by default
+        assert getattr(Dog.meta_, 'schema_name') == 'dog'
+        assert getattr(HasOneHuman1.meta_, 'schema_name') == 'has_one_human1'
+
+        # Test that the option in meta is overridden
+        assert hasattr(Foo.meta_, 'schema_name')
+        assert getattr(Foo.meta_, 'schema_name') == 'foosball'
+
+    def test_meta_overriding_provider(self):
+        """Test that `provider` can be overridden"""
+
+        # Class with overridden meta info
+        class Foo(Entity):
+            bar = field.String(max_length=25)
+
+            class Meta:
+                provider = 'non-default'
+
+        # Test that `provider` is set to `default` by default
+        assert getattr(Dog.meta_, 'provider') == 'default'
+
+        # Test that the option in meta is overridden
+        assert hasattr(Foo.meta_, 'provider')
+        assert getattr(Foo.meta_, 'provider') == 'non-default'
+
+    def test_meta_overriding_order_by(self):
+        """Test that `order_by` can be overridden"""
+
+        # Class with overridden meta info
+        class Foo(Entity):
+            bar = field.String(max_length=25)
+
+            class Meta:
+                order_by = 'bar'
+
+        # Test that `order_by` is an empty tuple by default
+        assert getattr(Dog.meta_, 'order_by') == ()
+
+        # Test that the option in meta is overridden
+        assert hasattr(Foo.meta_, 'order_by')
+        assert getattr(Foo.meta_, 'order_by') == ('bar', )
 
     def test_meta_on_init(self):
         """Test that `meta` attribute is available after initialization"""

--- a/tests/core/test_entity_state.py
+++ b/tests/core/test_entity_state.py
@@ -35,7 +35,7 @@ class TestState:
         try:
             del dog.name
             dog.save()
-        except ValidationError as exc:
+        except ValidationError:
             assert dog.state_.is_new
 
     def test_persisted_after_create(self):

--- a/tests/core/test_repository.py
+++ b/tests/core/test_repository.py
@@ -20,7 +20,7 @@ class TestRepository:
 
         Dog.query.all()
         current_db = dict(repo_factory.get_repository(Dog).conn)
-        assert current_db['data'] == {'dogs': {}}
+        assert current_db['data'] == {'dog': {}}
 
     def test_create_error(self):
         """ Add an entity to the repository missing a required attribute"""
@@ -63,7 +63,7 @@ class TestRepository:
             Dog.create(
                 id=2, name='Johnny', owner='Carey')
         assert err.value.normalized_messages == {
-            'name': ['`dogs` with this `name` already exists.']}
+            'name': ['`Dog` with this `name` already exists.']}
 
     def test_filter(self):
         """ Query the repository using filters """

--- a/tests/core/test_usecase.py
+++ b/tests/core/test_usecase.py
@@ -194,7 +194,7 @@ class TestCreateUseCase:
         assert not response.success
         assert response.value == {
             'code': 422,
-            'message': {'id': ['`dogs` with this `id` already exists.']}}
+            'message': {'id': ['`Dog` with this `id` already exists.']}}
 
 
 class TestUpdateUseCase:
@@ -252,7 +252,7 @@ class TestUpdateUseCase:
         assert response.value == {
             'code': 422,
             'message': {
-                'name': ['`dogs` with this `name` already exists.']}}
+                'name': ['`Dog` with this `name` already exists.']}}
 
 
 class TestDeleteUseCase:

--- a/tests/support/dog.py
+++ b/tests/support/dog.py
@@ -8,7 +8,6 @@ from tests.support.human import Human
 
 from protean.core import field
 from protean.core.entity import Entity
-from protean.impl.repository.dict_repo import DictModel
 
 
 class Dog(Entity):
@@ -18,29 +17,11 @@ class Dog(Entity):
     owner = field.String(required=True, max_length=15)
 
 
-class DogModel(DictModel):
-    """ Model for the Dog Entity"""
-
-    class Meta:
-        """ Meta class for model options"""
-        entity = Dog
-        model_name = 'dogs'
-
-
 class RelatedDog(Entity):
     """This is a dummy Dog Entity class with an association"""
     name = field.String(required=True, unique=True, max_length=50)
     age = field.Integer(default=5)
     owner = field.Reference(Human)
-
-
-class RelatedDogModel(DictModel):
-    """ Model for the RelatedDog Entity"""
-
-    class Meta:
-        """ Meta class for model options"""
-        entity = RelatedDog
-        model_name = 'related_dogs'
 
 
 class RelatedDog2(Entity):
@@ -52,15 +33,6 @@ class RelatedDog2(Entity):
     owner = field.Reference('tests.support.human.Human')
 
 
-class RelatedDog2Model(DictModel):
-    """ Model for the RelatedDog2 Entity"""
-
-    class Meta:
-        """ Meta class for model options"""
-        entity = RelatedDog2
-        model_name = 'related_dogs2'
-
-
 class DogRelatedByEmail(Entity):
     """This is a dummy Dog Entity class with an association"""
     name = field.String(required=True, unique=True, max_length=50)
@@ -68,29 +40,11 @@ class DogRelatedByEmail(Entity):
     owner = field.Reference(Human, via='email')
 
 
-class DogRelatedByEmailModel(DictModel):
-    """ Model for the DogRelatedByEmail Entity"""
-
-    class Meta:
-        """ Meta class for model options"""
-        entity = DogRelatedByEmail
-        model_name = 'related_dogs_by_email'
-
-
 class HasOneDog1(Entity):
     """This is a dummy Dog Entity class to test HasOne Association"""
     name = field.String(required=True, unique=True, max_length=50)
     age = field.Integer(default=5)
     has_one_human1 = field.Reference(HasOneHuman1)
-
-
-class HasOneDog1Model(DictModel):
-    """ Model for the HasOneDog1 Entity"""
-
-    class Meta:
-        """ Meta class for model options"""
-        entity = HasOneDog1
-        model_name = 'has_one_dogs1'
 
 
 class HasOneDog2(Entity):
@@ -102,15 +56,6 @@ class HasOneDog2(Entity):
     human = field.Reference(HasOneHuman2)
 
 
-class HasOneDog2Model(DictModel):
-    """ Model for the HasOneDog2 Entity"""
-
-    class Meta:
-        """ Meta class for model options"""
-        entity = HasOneDog2
-        model_name = 'has_one_dogs2'
-
-
 class HasOneDog3(Entity):
     """This is a dummy Dog Entity class to test HasOne Association"""
     name = field.String(required=True, unique=True, max_length=50)
@@ -118,29 +63,11 @@ class HasOneDog3(Entity):
     human_id = field.Integer()
 
 
-class HasOneDog3Model(DictModel):
-    """ Model for the HasOneDog3 Entity"""
-
-    class Meta:
-        """ Meta class for model options"""
-        entity = HasOneDog3
-        model_name = 'has_one_dogs3'
-
-
 class HasManyDog1(Entity):
     """This is a dummy Dog Entity class to test HasMany Association"""
     name = field.String(required=True, unique=True, max_length=50)
     age = field.Integer(default=5)
     has_many_human1 = field.Reference(HasManyHuman1)
-
-
-class HasManyDog1Model(DictModel):
-    """ Model for the HasManyDog1 Entity"""
-
-    class Meta:
-        """ Meta class for model options"""
-        entity = HasManyDog1
-        model_name = 'has_many_dogs1'
 
 
 class HasManyDog2(Entity):
@@ -152,15 +79,6 @@ class HasManyDog2(Entity):
     human = field.Reference(HasManyHuman2)
 
 
-class HasManyDog2Model(DictModel):
-    """ Model for the HasManyDog2 Entity"""
-
-    class Meta:
-        """ Meta class for model options"""
-        entity = HasManyDog2
-        model_name = 'has_many_dogs2'
-
-
 class HasManyDog3(Entity):
     """This is a dummy Dog Entity class to test HasMany Association"""
     name = field.String(required=True, unique=True, max_length=50)
@@ -168,25 +86,7 @@ class HasManyDog3(Entity):
     human_id = field.Integer()
 
 
-class HasManyDog3Model(DictModel):
-    """ Model for the HasManyDog3 Entity"""
-
-    class Meta:
-        """ Meta class for model options"""
-        entity = HasManyDog3
-        model_name = 'has_many_dogs3'
-
-
 class ThreadedDog(Entity):
     """This is a dummy Dog Entity class"""
     name = field.String(required=True, max_length=50)
     created_by = field.String(required=True, max_length=15)
-
-
-class ThreadedDogModel(DictModel):
-    """ Model for the ThreadedDog Entity"""
-
-    class Meta:
-        """ Meta class for schema options"""
-        entity = ThreadedDog
-        model_name = 'threaded_dogs'

--- a/tests/support/human.py
+++ b/tests/support/human.py
@@ -3,7 +3,6 @@
 from protean.core import field
 from protean.core.entity import Entity
 from protean.core.field import association
-from protean.impl.repository.dict_repo import DictModel
 
 
 class Human(Entity):
@@ -13,30 +12,12 @@ class Human(Entity):
     email = field.String(required=True, unique=True, max_length=50)
 
 
-class HumanModel(DictModel):
-    """ Model for the Human Entity"""
-
-    class Meta:
-        """ Meta class for model options"""
-        entity = Human
-        model_name = 'humans'
-
-
 class HasOneHuman1(Entity):
     """This is a dummy Human Entity class to test HasOne association"""
     first_name = field.String(required=True, unique=True, max_length=50)
     last_name = field.String(required=True, unique=True, max_length=50)
     email = field.String(required=True, unique=True, max_length=50)
     dog = association.HasOne('tests.support.dog.HasOneDog1')
-
-
-class HasOneHuman1Model(DictModel):
-    """ Model for the HasOneHuman1 Entity"""
-
-    class Meta:
-        """ Meta class for model options"""
-        entity = HasOneHuman1
-        model_name = 'has_one_humans1'
 
 
 class HasOneHuman2(Entity):
@@ -49,15 +30,6 @@ class HasOneHuman2(Entity):
     dog = association.HasOne('tests.support.dog.HasOneDog2', via='human_id')
 
 
-class HasOneHuman2Model(DictModel):
-    """ Model for the HasOneHuman2 Entity"""
-
-    class Meta:
-        """ Meta class for model options"""
-        entity = HasOneHuman2
-        model_name = 'has_one_humans2'
-
-
 class HasOneHuman3(Entity):
     """This is a dummy Human Entity class to test HasOne association
        when there is no corresponding Reference defined in the target class
@@ -68,30 +40,12 @@ class HasOneHuman3(Entity):
     dog = association.HasOne('tests.support.dog.HasOneDog3', via='human_id')
 
 
-class HasOneHuman3Model(DictModel):
-    """ Model for the HasOneHuman3 Entity"""
-
-    class Meta:
-        """ Meta class for model options"""
-        entity = HasOneHuman3
-        model_name = 'has_one_humans3'
-
-
 class HasManyHuman1(Entity):
     """This is a dummy Human Entity class to test HasMany association"""
     first_name = field.String(required=True, unique=True, max_length=50)
     last_name = field.String(required=True, unique=True, max_length=50)
     email = field.String(required=True, unique=True, max_length=50)
     dogs = association.HasMany('tests.support.dog.HasManyDog1')
-
-
-class HasManyHuman1Model(DictModel):
-    """ Model for the HasManyHuman1 Entity"""
-
-    class Meta:
-        """ Meta class for model options"""
-        entity = HasManyHuman1
-        model_name = 'has_many_humans1'
 
 
 class HasManyHuman2(Entity):
@@ -104,15 +58,6 @@ class HasManyHuman2(Entity):
     dogs = association.HasMany('HasManyDog2', via='human_id')
 
 
-class HasManyHuman2Model(DictModel):
-    """ Model for the HasManyHuman2 Entity"""
-
-    class Meta:
-        """ Meta class for model options"""
-        entity = HasManyHuman2
-        model_name = 'has_many_humans2'
-
-
 class HasManyHuman3(Entity):
     """This is a dummy Human Entity class to test HasMany association
        when there is no corresponding Reference defined in the target class
@@ -121,12 +66,3 @@ class HasManyHuman3(Entity):
     last_name = field.String(required=True, unique=True, max_length=50)
     email = field.String(required=True, unique=True, max_length=50)
     dogs = association.HasMany('tests.support.dog.HasManyDog3', via='human_id')
-
-
-class HasManyHuman3Model(DictModel):
-    """ Model for the HasManyHuman3 Entity"""
-
-    class Meta:
-        """ Meta class for model options"""
-        entity = HasManyHuman3
-        model_name = 'has_many_humans3'


### PR DESCRIPTION
* Enrich meta options supported in `Meta` inner class of Entity
* Models will be synthesized by `Provider` in `get_model` method
* Supported options are `schema_name`, `provider`, and `order_by`.
	* `schema_name` is the name of the table/index/document in the database
	* `provider` is the provider name as defined in the configuration
	* `order_by` is a list of column names used to order the results automatically

Note that the change of option name `model_name` to `schema_name`, to reflect the generic nature of a grouping of fields for a table, document or mapping. There is no consensus on this aspect though. Most definitions of schema lean toward a *collection* or *representation* of tables or documents in a database, while database treat schema to be a definition of a table/index/document. Let's keep this closer to the database for now, and we can change if proven wrong in the future.

This change means that an explicit Model cannot be provided as an option. All controllable aspects will be provided as options in Entity `Meta` class.

Deeper support for changing column names in the database will be provided in the future, if required, by additional options in Entity `Meta` class.

Closes #121