### PR TITLE
105 Add support to run raw queries on provider

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -118,6 +118,13 @@ To set up `protean` for local development:
 
 6. Submit a pull request through the GitHub website.
 
+Testing
+^^^^^^^
+
+Protean tests have been written to work with **Pytest**, and you can run tests with the command ``pytest``.
+
+By default, tests that are marked as ``slow`` are skipped. If you want to run the slow tests, use ``pytest --slow``.
+
 Pull Request Guidelines
 ^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/protean/core/provider/base.py
+++ b/src/protean/core/provider/base.py
@@ -3,6 +3,7 @@
 import uuid
 from abc import ABCMeta
 from abc import abstractmethod
+from typing import Any
 
 from protean.utils.query import RegisterLookupMixin
 
@@ -46,16 +47,26 @@ class BaseProvider(RegisterLookupMixin, metaclass=ABCMeta):
 
     @abstractmethod
     def get_connection(self):
-        """ Get the connection object for the repository"""
+        """Get the connection object for the repository"""
 
     @abstractmethod
     def close_connection(self, conn):
-        """ Close the connection object for the repository"""
+        """Close the connection object for the repository"""
 
     @abstractmethod
     def get_repository(self, model_cls):
-        """ Return a repository object configured with a live connection"""
+        """Return a repository object configured with a live connection"""
 
     @abstractmethod
     def get_model(self, entity_cls):
-        """ Return associated Model Class"""
+        """Return associated Model Class"""
+
+    @abstractmethod
+    def raw(self, query: Any, data: Any = None):
+        """Run raw query directly on the database
+
+        Query should be executed immediately on the database as a separate unit of work
+            (in a different transaction context). The results should be returned as returned by
+            the database without any intervention. It is left to the consumer to interpret and
+            organize the results correctly.
+        """

--- a/src/protean/core/queryset.py
+++ b/src/protean/core/queryset.py
@@ -1,7 +1,7 @@
 """QuerySet Implementation"""
 
 import logging
-from typing import Union
+from typing import Union, Any
 
 from protean.core.repository import repo_factory
 from protean.utils.query import Q
@@ -169,18 +169,18 @@ class QuerySet:
 
         return updated_item_count
 
-    def raw(self, query_string: str):
+    def raw(self, query: Any, data: Any = None):
         """Runs raw query directly on the database and returns Entity objects
 
         Note that this method will raise an exception if the returned objects
             are not of the Entity type.
 
-        `query_string` is not checked for correctness or validity, and any errors thrown
-            by the plugin or database are passed as-is.
+        `query` is not checked for correctness or validity, and any errors thrown by the plugin or
+            database are passed as-is. Data passed will be transferred as-is to the plugin.
 
         All other query options like `order_by`, `page` and `per_page` are ignored for this action.
         """
-        logger.debug(f'Query `{self.__class__.__name__}` objects with raw query {query_string}')
+        logger.debug(f'Query `{self.__class__.__name__}` objects with raw query {query}')
 
         # Destroy any cached results
         self._result_cache = None
@@ -190,9 +190,8 @@ class QuerySet:
         repository = repo_factory.get_repository(self._entity_cls)
 
         try:
-            # Call the read method of the repository
-            # Ensures that the string contains double quotes around keys and values
-            results = repository.raw(query_string.replace("'", "\""))
+            # Call the raw method of the repository
+            results = repository.raw(query, data)
 
             # Convert the returned results to entity and return it
             entity_items = []

--- a/src/protean/core/repository/base.py
+++ b/src/protean/core/repository/base.py
@@ -54,5 +54,9 @@ class BaseRepository(metaclass=ABCMeta):
         """Delete a Record from the Repository"""
 
     @abstractmethod
-    def raw(self, query_string: str):
-        """Run raw query on Repository"""
+    def raw(self, query: Any, data: Any = None):
+        """Run raw query on Data source.
+
+        Running a raw query on the repository should always returns entity instance objects. If
+        the results were not synthesizable back into entity objects, an exception should be thrown.
+        """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,12 +7,14 @@ os.environ['PROTEAN_CONFIG'] = 'tests.support.sample_config'
 
 
 def pytest_addoption(parser):
+    """Additional options for running tests with pytest"""
     parser.addoption(
         "--slow", action="store_true", default=False, help="run slow tests"
     )
 
 
 def pytest_collection_modifyitems(config, items):
+    """Configure special markers on tests, so as to control execution"""
     if config.getoption("--slow"):
         # --slow given in cli: do not skip slow tests
         return

--- a/tests/core/test_providers.py
+++ b/tests/core/test_providers.py
@@ -2,6 +2,9 @@
 from protean.core.provider import providers
 from protean.impl.repository.dict_repo import DictProvider
 
+from tests.support.dog import Dog, RelatedDog
+from tests.support.human import Human
+
 
 class TestProviders:
     """This class holds tests for Providers Singleton"""
@@ -21,3 +24,37 @@ class TestProviders:
 
         conn = providers.get_provider('default').get_connection()
         assert all(key in conn for key in ['data', 'lock', 'counters'])
+
+    def test_provider_raw(self):
+        """Test raw queries"""
+        Dog.create(name='Murdock', age=7, owner='John')
+        Dog.create(name='Jean', age=3, owner='John')
+        Dog.create(name='Bart', age=6, owner='Carrie')
+
+        # This is a raw query, so should bring results from all repositories
+        human = Human.create(first_name='John', last_name='Doe', email='john.doe@gmail.com')
+        RelatedDog.create(name='RelMurdock', age=2, owner=human)
+
+        provider = providers.get_provider('default')
+
+        # Filter by Dog attributes
+        results = provider.raw('{"owner":"John"}')
+        assert isinstance(results, list)
+        assert len(results) == 2
+
+        # Try with single quotes in JSON String
+        results = provider.raw("{'owner':'John'}")
+        assert len(results) == 2
+
+        results = provider.raw('{"owner":"John", "age":3}')
+        assert len(results) == 1
+
+        # This query brings results from multiple repositories
+        results = provider.raw('{"age__in":[2, 3]}')
+        assert len(results) == 2
+
+        results = provider.raw('{"owner":"John", "age__in":[6,7]}')
+        assert len(results) == 1
+
+        results = provider.raw('{"owner":"John", "age__in":[2, 3,7]}')
+        assert len(results) == 2


### PR DESCRIPTION
This PR has the remaining functionality for #105, which adds the ability to run queries on a Provider (database) directly. The query method signature has been enhanced to be able to provide the query and its related data separately. Provider class has the responsibility of intelligently combining query with data, before firing it on the database.

Results returned from the database are returned to the consumer directly, without any intervention or entity object transformation in the middle.

Closes #105 