### PR TITLE
120 replace paginate with limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,5 +137,4 @@ output/*/index.html
 docs/.doctrees
 
 # TODOs
-
 TODO

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2018, Subhash Bhushan C
+Copyright (c) 2018-2019, Subhash Bhushan C
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following

--- a/docs/api/queryset.rst
+++ b/docs/api/queryset.rst
@@ -3,6 +3,9 @@
 QuerySet
 --------
 
+Fetching Results
+~~~~~~~~~~~~~~~~
+
 .. _api-queryset-all:
 
 ``all()``
@@ -58,3 +61,27 @@ QuerySet
 ^^^^^^^^^^^^^^
 
 .. automethod:: protean.core.queryset.QuerySet.raw
+
+Fetch Options
+~~~~~~~~~~~~~
+
+.. _api-queryset-order-by:
+
+``order_by``
+^^^^^^^^^^^^^^
+
+.. automethod:: protean.core.queryset.QuerySet.order_by
+
+.. _api-queryset-limit:
+
+``limit``
+^^^^^^^^^
+
+.. automethod:: protean.core.queryset.QuerySet.limit
+
+.. _api-queryset-offset:
+
+``offset``
+^^^^^^^^^^
+
+.. automethod:: protean.core.queryset.QuerySet.offset

--- a/docs/user/entities/querying.rst
+++ b/docs/user/entities/querying.rst
@@ -69,6 +69,31 @@ Returns a new :ref:`api-queryset` object containing items that do **NOT** match 
 
 The criteria supplied to these methods should be in the format described in :ref:`entity-queryset-field-lookups`.
 
+Controlling size and order of results
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can order the results by specifying one or more attributes to order by in the :ref:`api-queryset-order-by` call:
+
+.. code-block:: python
+
+    >>> Customer.query.filter(lastname='Doe').order_by('firstname')
+
+By default, results will be sorted the primary identifier of the objects.
+
+You can limit the number of results to be retrieved with the help of :ref:`api-queryset-limit` method:
+
+.. code-block:: python
+
+    >>> Customer.query.filter(lastname='Doe').limit(5)
+
+This query returns the first 5 objects. To offset and fetch results from a certain mark, use :ref:`api-queryset-offset` method:
+
+.. code-block:: python
+
+    >>> Customer.query.filter(lastname='Doe').offset(25).limit(5)
+
+The about resultset will contain 5 objects, present after the first 25 objects.
+
 QuerySet Properties
 ~~~~~~~~~~~~~~~~~~~
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,6 +1,7 @@
 -r dev.txt
 
 mock==2.0.0
+pluggy==0.9.0
 pytest==4.4.1
 pytest-cov==2.5.1
 pytest-travis-fold==1.3.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,7 +1,6 @@
 -r dev.txt
 
 mock==2.0.0
-pytest==3.6.3
+pytest==4.4.1
 pytest-cov==2.5.1
 pytest-travis-fold==1.3.0
-pluggy==0.6.0

--- a/src/protean/conf/default_config.py
+++ b/src/protean/conf/default_config.py
@@ -21,7 +21,7 @@ SECRET_KEY = 'wR5yJVF!PVA3&bBaFK%e3#MQna%DJfyT'
 DATABASES = {}
 
 # Default no. of records to fetch per query
-PER_PAGE = 10
+RESULTS_LIMIT = 10
 
 ####################
 # GENERIC CACHE    #

--- a/src/protean/core/cache/wrapper.py
+++ b/src/protean/core/cache/wrapper.py
@@ -12,19 +12,18 @@ class CacheWrapper:
 
     def __init__(self):
         cache_config = active_config.CACHE
-        if not isinstance(cache_config, dict) or cache_config == {}:
-            raise ConfigurationError(
-                "'CACHES' config must be a dict and at least one "
-                "database must be defined")
+        if cache_config:
+            if not isinstance(cache_config, dict):
+                raise ConfigurationError("'CACHES' config must be a dict")
 
-        # Try to import the cache backend
-        provider = cache_config.pop('PROVIDER')
-        try:
-            provider_cls = perform_import(provider)
-        except ImportError as e:
-            raise ConfigurationError(
-                "Could not find cache provider '%s': %s" % (provider, e))
-        self.provider = provider_cls(cache_config)
+            # Try to import the cache backend
+            provider = cache_config.pop('PROVIDER')
+            try:
+                provider_cls = perform_import(provider)
+            except ImportError as e:
+                raise ConfigurationError(
+                    "Could not find cache provider '%s': %s" % (provider, e))
+            self.provider = provider_cls(cache_config)
 
 
 cache = CacheWrapper()

--- a/src/protean/core/entity.py
+++ b/src/protean/core/entity.py
@@ -68,8 +68,8 @@ class EntityBase(type):
             everytime a new `query` object is created
 
         This is required so as not to corrupt the query object associated with the metaclass
-        when invoked like `Dog.query.all()` directly. A new query, and a corresponding `Pagination`
-        result would be created every time.
+        when invoked like `Dog.query.all()` directly. A new query, and a corresponding `ResultSet`
+        would be created every time.
         """
         return QuerySet(cls)
 
@@ -364,7 +364,7 @@ class Entity(metaclass=EntityBase):
         }
 
         # Find this item in the repository or raise Error
-        results = cls.query.filter(**filters).paginate(page=1, per_page=1).all()
+        results = cls.query.filter(**filters).limit(1).all()
         if not results:
             raise ObjectNotFoundError(
                 f'`{cls.__name__}` object with identifier {identifier} '
@@ -383,7 +383,7 @@ class Entity(metaclass=EntityBase):
                      f'{kwargs}')
 
         # Find this item in the repository or raise Error
-        results = cls.query.filter(**kwargs).paginate(page=1, per_page=1).all()
+        results = cls.query.filter(**kwargs).limit(1).all()
 
         if not results:
             raise ObjectNotFoundError(

--- a/src/protean/core/repository/__init__.py
+++ b/src/protean/core/repository/__init__.py
@@ -5,7 +5,7 @@ from .factory import RepositoryFactory
 from .factory import repo_factory
 from .lookup import BaseLookup
 from .model import BaseModel
-from .pagination import Pagination
+from .resultset import ResultSet
 
 __all__ = ('BaseRepository', 'BaseModel', 'BaseLookup',
-           'RepositoryFactory', 'repo_factory', 'Pagination')
+           'RepositoryFactory', 'repo_factory', 'ResultSet')

--- a/src/protean/core/repository/base.py
+++ b/src/protean/core/repository/base.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from protean.utils.query import Q
 
-from .pagination import Pagination
+from .resultset import ResultSet
 
 logger = logging.getLogger('protean.repository')
 
@@ -26,10 +26,10 @@ class BaseRepository(metaclass=ABCMeta):
         self.schema_name = entity_cls.meta_.schema_name
 
     @abstractmethod
-    def filter(self, criteria: Q, page: int = 1, per_page: int = 10,
-               order_by: list = ()) -> Pagination:
+    def filter(self, criteria: Q, offset: int = 0, limit: int = 10,
+               order_by: list = ()) -> ResultSet:
         """
-        Filter objects from the repository. Method must return a `Pagination`
+        Filter objects from the repository. Method must return a `ResultSet`
         object
         """
 

--- a/src/protean/core/repository/resultset.py
+++ b/src/protean/core/repository/resultset.py
@@ -1,44 +1,29 @@
-"""Utility classes and methods for Repository
-
-FIXME Should this be part of the domain, or be a part of Request/Response infrastructure?
-"""
-from math import ceil
+"""ResultSet Utility class and traversal methods for Repository results"""
 
 
-class Pagination(object):
+class ResultSet(object):
     """Internal helper class returned by :meth:`Repository._read`
     """
 
-    def __init__(self, page: int, per_page: int, total: int,
-                 items: list):
-        # the current page number (1 indexed)
-        self.page = page
+    def __init__(self, offset: int, limit: int, total: int, items: list):
+        # the current offset (zero indexed)
+        self.offset = offset
         # the number of items to be displayed on a page.
-        self.per_page = per_page
+        self.limit = limit
         # the total number of items matching the query
         self.total = total
         # the items for the current page
         self.items = items
 
     @property
-    def pages(self):
-        """The total number of pages"""
-        if self.per_page == 0 or self.total is None:
-            pages = 0
-        else:
-            pages = int(ceil(self.total / float(self.per_page)))
-
-        return pages
-
-    @property
     def has_prev(self):
         """True if a previous page exists"""
-        return bool(self.items) and self.page > 1
+        return bool(self.items) and self.offset > 0
 
     @property
     def has_next(self):
         """True if a next page exists."""
-        return self.page < self.pages
+        return (self.offset + self.limit) < self.total
 
     @property
     def first(self):

--- a/src/protean/core/usecase/generic.py
+++ b/src/protean/core/usecase/generic.py
@@ -103,7 +103,8 @@ class ListUseCase(UseCase):
         """Return a list of resources"""
         resources = (request_object.entity_cls.query
                      .filter(**request_object.filters)
-                     .paginate(page=request_object.page, per_page=request_object.per_page)
+                     .offset((request_object.page - 1) * request_object.per_page)
+                     .limit(request_object.per_page)
                      .order_by(request_object.order_by)
                      .all())
         return ResponseSuccess(Status.SUCCESS, resources)

--- a/src/protean/impl/repository/dict_repo.py
+++ b/src/protean/impl/repository/dict_repo.py
@@ -13,7 +13,7 @@ from protean.core.provider.base import BaseProvider
 from protean.core.repository import BaseLookup
 from protean.core.repository import BaseModel
 from protean.core.repository import BaseRepository
-from protean.core.repository import Pagination
+from protean.core.repository import ResultSet
 from protean.utils.query import Q
 
 # Global in-memory store of dict data. Keyed by name, to provide
@@ -187,7 +187,7 @@ class DictRepository(BaseRepository):
 
         return input_db
 
-    def filter(self, criteria: Q, page: int = 1, per_page: int = 10, order_by: list = ()):
+    def filter(self, criteria: Q, offset: int = 0, limit: int = 10, order_by: list = ()):
         """Read the repository and return results as per the filer"""
 
         if criteria.children:
@@ -203,17 +203,11 @@ class DictRepository(BaseRepository):
                 o_key = o_key[1:]
             items = sorted(items, key=itemgetter(o_key), reverse=reverse)
 
-        # Build the pagination results for the filtered items
-        cur_offset, cur_limit = None, None
-        if per_page > 0:
-            cur_offset = (page - 1) * per_page
-            cur_limit = page * per_page
-
-        result = Pagination(
-            page=page,
-            per_page=per_page,
+        result = ResultSet(
+            offset=offset,
+            limit=limit,
             total=len(items),
-            items=items[cur_offset: cur_limit])
+            items=items[offset: offset + limit])
         return result
 
     def update(self, model_obj):
@@ -298,9 +292,9 @@ class DictRepository(BaseRepository):
                 input_db = self.provider._evaluate_lookup(key, value, False, input_db)
 
             items = list(input_db.values())
-            result = Pagination(
-                page=1,
-                per_page=len(items),
+            result = ResultSet(
+                offset=1,
+                limit=len(items),
                 total=len(items),
                 items=items)
 

--- a/tests/core/test_entity.py
+++ b/tests/core/test_entity.py
@@ -360,8 +360,8 @@ class TestEntity:
         filters = [
             Dog.query.filter(name='Murdock'),
             Dog.query.filter(name='Jean').filter(owner='John'),
-            Dog.query.paginate(page=5),
-            Dog.query.paginate(per_page=25),
+            Dog.query.offset(1),
+            Dog.query.limit(25),
             Dog.query.order_by('name'),
             Dog.query.exclude(name='Murdock')
         ]
@@ -375,8 +375,8 @@ class TestEntity:
         filters = [
             dog,
             Dog.query.filter(name='Jean').filter(owner='John'),
-            dog.paginate(page=5),
-            dog.paginate(per_page=5),
+            dog.offset(5 * 5),
+            dog.limit(5),
             dog.order_by('name'),
             dog.exclude(name='Murdock')
         ]
@@ -526,19 +526,19 @@ class TestEntity:
         with pytest.raises(NotImplementedError):
             Dog.query.filter(age__notexact=3).all()
 
-    def test_pagination(self):
-        """ Test the pagination of the filter results"""
+    def test_result_traversal(self):
+        """ Test the traversal of the filter results"""
         for counter in range(1, 5):
             Dog.create(id=counter, name=counter, owner='Owner Name')
 
-        dogs = Dog.query.paginate(per_page=2).order_by('id')
+        dogs = Dog.query.limit(2).order_by('id')
         assert dogs.total == 4
         assert len(dogs.items) == 2
         assert dogs.first.id == 1
         assert dogs.has_next
         assert not dogs.has_prev
 
-        dogs = Dog.query.paginate(page=2, per_page=2).order_by('id').all()
+        dogs = Dog.query.offset(2).limit(2).order_by('id').all()
         assert len(dogs.items) == 2
         assert dogs.first.id == 3
         assert not dogs.has_next

--- a/tests/core/test_entity_associations.py
+++ b/tests/core/test_entity_associations.py
@@ -20,6 +20,8 @@ from tests.support.human import HasOneHuman3
 from tests.support.human import Human
 
 from protean.core.exceptions import ValidationError
+from protean.core.queryset import QuerySet
+from protean.core.repository import Pagination
 
 
 class TestReference:
@@ -298,6 +300,10 @@ class TestHasMany:
         assert 'dogs' not in human.__dict__
         assert len(human.dogs) == 2
         assert 'dogs' in human.__dict__  # Avaiable after access
+
+        assert isinstance(human.dogs, QuerySet)
+        assert isinstance(human.dogs.all(), Pagination)
+        assert all(dog.id in [101, 102] for dog in human.dogs)  # `__iter__` magic here
 
     def test_init_with_via(self):
         """Test successful HasMany initialization with a class containing via"""

--- a/tests/core/test_entity_associations.py
+++ b/tests/core/test_entity_associations.py
@@ -21,7 +21,7 @@ from tests.support.human import Human
 
 from protean.core.exceptions import ValidationError
 from protean.core.queryset import QuerySet
-from protean.core.repository import Pagination
+from protean.core.repository import ResultSet
 
 
 class TestReference:
@@ -302,7 +302,7 @@ class TestHasMany:
         assert 'dogs' in human.__dict__  # Avaiable after access
 
         assert isinstance(human.dogs, QuerySet)
-        assert isinstance(human.dogs.all(), Pagination)
+        assert isinstance(human.dogs.all(), ResultSet)
         assert all(dog.id in [101, 102] for dog in human.dogs)  # `__iter__` magic here
 
     def test_init_with_via(self):

--- a/tests/core/test_q_object.py
+++ b/tests/core/test_q_object.py
@@ -387,8 +387,8 @@ class TestConjunctions:
         Dog.create(id=6, name='Dave', age=6, owner='Carrie')
 
         q1 = Dog.query.filter(
-            Q(owner='John', name='Jean') |
-            Q(age=6))
+            Q(owner='John', name='Jean')
+            | Q(age=6))
         assert q1.total == 4
 
         q2 = Dog.query.filter(Q(owner='John') | Q(age=6))

--- a/tests/core/test_queryset.py
+++ b/tests/core/test_queryset.py
@@ -33,8 +33,8 @@ class TestQuerySet:
         query = Dog.query.filter(owner='John').order_by('age')
         assert repr(query) == ("<QuerySet: entity: <class 'tests.support.dog.Dog'>, "
                                "criteria: ('protean.utils.query.Q', (), {'owner': 'John'}), "
-                               "page: 1, "
-                               "per_page: 10, order_by: {'age'}>")
+                               "offset: 0, "
+                               "limit: 10, order_by: {'age'}>")
 
     def test_bool_false(self):
         """Test that `bool` returns `False` on no records"""
@@ -110,7 +110,7 @@ class TestQuerySet:
         assert query.total == 2
         assert query._result_cache.total == 2
 
-        query_dup = query.paginate(per_page=25)
+        query_dup = query.limit(25)
         assert query_dup._result_cache is None
 
     def test_total(self):
@@ -146,7 +146,7 @@ class TestQuerySet:
         assert query._result_cache.total == 3
 
     def test_items(self):
-        """Test that items is retrieved from Pagination results"""
+        """Test that items is retrieved from ResultSet"""
         # Add multiple entries to the DB
         Dog.create(id=2, name='Murdock', age=7, owner='John')
         Dog.create(id=3, name='Jean', age=3, owner='John')
@@ -157,7 +157,7 @@ class TestQuerySet:
         assert query.items[0].id == query.all().items[0].id
 
     def test_items_with_cache(self):
-        """Test that items is retrieved from Pagination results"""
+        """Test that items is retrieved from ResultSet"""
         # Add multiple entries to the DB
         Dog.create(id=2, name='Murdock', age=7, owner='John')
         Dog.create(id=3, name='Jean', age=3, owner='John')
@@ -180,7 +180,7 @@ class TestQuerySet:
         Dog.create(id=4, name='Bart', age=6, owner='Carrie')
 
         # Filter by Dog attributes
-        query = Dog.query.paginate(page=1, per_page=2)
+        query = Dog.query.limit(2)
         assert query.has_next is True
 
     def test_has_next_with_cache(self):
@@ -191,7 +191,7 @@ class TestQuerySet:
         dog = Dog.create(id=4, name='Bart', age=6, owner='Carrie')
 
         # Filter by Dog attributes
-        query = Dog.query.paginate(page=1, per_page=2)
+        query = Dog.query.limit(2)
         assert query.has_next is True
 
         dog.delete()
@@ -207,7 +207,7 @@ class TestQuerySet:
         Dog.create(id=4, name='Bart', age=6, owner='Carrie')
 
         # Filter by Dog attributes
-        query = Dog.query.paginate(page=2, per_page=2)
+        query = Dog.query.offset(2).limit(2)
         assert query.has_prev is True
 
     def test_has_prev_with_cache(self):
@@ -218,7 +218,7 @@ class TestQuerySet:
         dog = Dog.create(id=4, name='Bart', age=6, owner='Carrie')
 
         # Filter by Dog attributes
-        query = Dog.query.paginate(page=2, per_page=2)
+        query = Dog.query.offset(2).limit(2)
         assert query.has_prev is True
 
         dog.delete()

--- a/tests/core/test_repository.py
+++ b/tests/core/test_repository.py
@@ -84,12 +84,12 @@ class TestRepository:
         assert dogs.first.age == 7
         assert dogs.first.name == 'Murdock'
 
-    def test_pagination(self):
-        """ Test the pagination of the filter results"""
+    def test_result_traversal(self):
+        """ Test the traversal of the filter results"""
         for counter in range(1, 5):
             Dog.create(id=counter, name=counter, owner='Owner Name')
 
-        dogs = Dog.query.paginate(per_page=2).order_by('id')
+        dogs = Dog.query.limit(2).order_by('id')
         assert dogs is not None
         assert dogs.total == 4
         assert len(dogs.items) == 2
@@ -97,7 +97,7 @@ class TestRepository:
         assert dogs.has_next
         assert not dogs.has_prev
 
-        dogs = Dog.query.paginate(page=2, per_page=2).order_by('id')
+        dogs = Dog.query.offset(2).limit(2).order_by('id').all()
         assert len(dogs.items) == 2
         assert dogs.first.id == 3
         assert not dogs.has_next

--- a/tests/core/test_usecase.py
+++ b/tests/core/test_usecase.py
@@ -154,7 +154,7 @@ class TestListUseCase:
         # Validate the response received
         assert response is not None
         assert response.success
-        assert response.value.page == 1
+        assert response.value.offset == 0
         assert response.value.total == 2
         assert response.value.first.age == 3
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -57,7 +57,7 @@ def test_context_with_threads():
         t.join()
 
     # Get the list of dogs and validate the results
-    dogs = ThreadedDog.query.paginate(per_page=10)
+    dogs = ThreadedDog.query.limit(10)
     assert dogs.total == 5
     for dog in dogs.items:
         if dog.name == 'Johnny':


### PR DESCRIPTION
It is better to  `limit` and `offset` values in queries, than have one `paginate` method. Also, `Pagination` is a concept that usually applies to how UI displays records spread across pages and does not necessarily have anything to do with results or databases. So this PR breaks the `paginate` method into `limit` and 'offset`, and also replaces `Pagination` class with `ResultSet` class.

Note that the parameters sent into Use Cases continue to be `page` and `per_page` which is consistent with requests over HTTP.

Closes #120 and #132 