### PR TITLE
131 Add command line utility to generate Protean project structure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 click==7.0
+cookiecutter==1.6.0
 python-dateutil==2.7.3
+
 -r requirements/dev.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,3 +1,5 @@
+# Development Requirements
+
 check-manifest==0.37
 coverage==4.5.1
 docutils==0.14

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
     ],
     install_requires=[
         'click==7.0',
+        'cookiecutter==1.6.0',
         'python-dateutil==2.7.3'
     ],
     extras_require={

--- a/src/protean/cli.py
+++ b/src/protean/cli.py
@@ -34,3 +34,11 @@ def test():
     errno = pytest.main(['-v', '--flake8'])
 
     sys.exit(errno)
+
+
+@main.command()
+def new():
+    from cookiecutter.main import cookiecutter
+
+    # Create project from the cookiecutter-protean.git repo template
+    cookiecutter('gh:proteanhq/cookiecutter-protean')


### PR DESCRIPTION
Uses cookiecutter to generate the package.

In the future:
1. There will be multiple cookiecutters, one each for app, api, db plugin etc.
2. The `new` command will accept arguments to understand what kind of project structure needs to be generated

Closes #131