### PR TITLE
Support `pre_save` and `post_save` hooks in Entity

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,7 +53,7 @@ Developers should be able to deploy and scale applications in realtime on most p
 Key Features
 ------------
 
-Protean is ready for today's diverse and layered software stack requirements:
+Protean is ready for today's diverse and multilayered software stack requirements:
 
 - Lightweight APIs
 - Non-opinionated and non-enforcing Application Code structure

--- a/src/protean/core/entity.py
+++ b/src/protean/core/entity.py
@@ -443,6 +443,9 @@ class Entity(metaclass=EntityBase):
             # Do unique checks, create this object and return it
             entity._validate_unique()
 
+            # Perform Pre-Save Actions
+            entity.pre_save()
+
             # Build the model object and create it
             model_obj = repository.create(model_cls.from_entity(entity))
 
@@ -457,6 +460,9 @@ class Entity(metaclass=EntityBase):
 
             # Set Entity status to saved
             entity.state_.mark_saved()
+
+            # Perform Post-Save Actions
+            entity.post_save()
 
             return entity
         except ValidationError:
@@ -479,6 +485,9 @@ class Entity(metaclass=EntityBase):
             # Do unique checks, update the record and return the Entity
             self._validate_unique(create=False)
 
+            # Perform Pre-Save Actions
+            self.pre_save()
+
             # Build the model object and create it
             model_obj = repository.create(model_cls.from_entity(self))
 
@@ -493,6 +502,9 @@ class Entity(metaclass=EntityBase):
 
             # Set Entity status to saved
             self.state_.mark_saved()
+
+            # Perform Post-Save Actions
+            self.post_save()
 
             return self
         except Exception:
@@ -525,10 +537,17 @@ class Entity(metaclass=EntityBase):
 
             # Do unique checks, update the record and return the Entity
             self._validate_unique(create=False)
+
+            # Perform Pre-Save Actions
+            self.pre_save()
+
             repository.update(model_cls.from_entity(self))
 
             # Set Entity status to saved
             self.state_.mark_saved()
+
+            # Perform Post-Save Actions
+            self.post_save()
 
             return self
         except Exception:
@@ -597,3 +616,11 @@ class Entity(metaclass=EntityBase):
         except Exception:
             # FIXME Log Exception
             raise
+
+    def pre_save(self):
+        """Pre-Save Hook"""
+        pass
+
+    def post_save(self):
+        """Post-Save Hook"""
+        pass

--- a/tests/core/test_entity.py
+++ b/tests/core/test_entity.py
@@ -846,3 +846,72 @@ class TestEntityMetaAttributes:
 
         assert all(key in dog.meta_.attributes for key in ['age', 'has_one_human1_id', 'id', 'name'])
         assert all(key in human.meta_.attributes for key in ['first_name', 'id', 'last_name', 'email'])
+
+
+class TestEntityHooks:
+    """Test pre-save and post-save hooks defined in Entity"""
+
+    def test_pre_save(self):
+        """Test Pre-Save Hook"""
+        class PreSavedDog(Entity):
+            """A Dog with a unique code in the universe"""
+            name = field.String(required=True, unique=True, max_length=50)
+            age = field.Integer(default=5)
+            owner = field.String(required=True, max_length=15)
+            unique_code = field.String(max_length=255)
+
+            def pre_save(self):
+                """Perform actions before save"""
+                import uuid
+                self.unique_code = uuid.uuid4()
+
+        from protean.core.repository import repo_factory
+        repo_factory.register(PreSavedDog)
+
+        presaved_dog1 = PreSavedDog.create(name='Chucky1', owner='John')
+        assert presaved_dog1.unique_code is not None
+
+        presaved_dog2 = PreSavedDog(name='Chucky2', owner='John')
+        presaved_dog2.save()
+        assert presaved_dog2.unique_code is not None
+
+        presaved_dog3 = PreSavedDog.create(name='Chucky3', owner='John')
+        presaved_dog3_updated = PreSavedDog.get(presaved_dog3.id)
+        presaved_dog3_updated.update(unique_code=None)
+        assert presaved_dog3_updated.unique_code is not None
+
+        repo_factory.get_repository(PreSavedDog).delete_all()
+
+    def test_post_save(self):
+        """Test Post-Save Hook"""
+        class PostSavedDog(Entity):
+            """A Dog with a unique code in the universe"""
+            name = field.String(required=True, unique=True, max_length=50)
+            age = field.Integer(default=5)
+            owner = field.String(required=True, max_length=15)
+            unique_code = field.String(max_length=255)
+
+            def post_save(self):
+                """Perform actions before save"""
+                import uuid
+                self.unique_code = uuid.uuid4()
+
+        from protean.core.repository import repo_factory
+        repo_factory.register(PostSavedDog)
+
+        postsaved_dog1 = PostSavedDog.create(name='Chucky1', owner='John')
+        assert postsaved_dog1.unique_code is not None
+        assert postsaved_dog1.state_.is_changed is True
+
+        postsaved_dog2 = PostSavedDog(name='Chucky2', owner='John')
+        postsaved_dog2.save()
+        assert postsaved_dog2.unique_code is not None
+        assert postsaved_dog2.state_.is_changed is True
+
+        postsaved_dog3 = PostSavedDog.create(name='Chucky3', owner='John')
+        postsaved_dog3_updated = PostSavedDog.get(postsaved_dog3.id)
+        postsaved_dog3_updated.update(unique_code=None)
+        assert postsaved_dog3_updated.unique_code is not None
+        assert postsaved_dog3_updated.state_.is_changed is True
+
+        repo_factory.get_repository(PostSavedDog).delete_all()


### PR DESCRIPTION
Entities can now have `pre_save()` and `post_save()` methods to perform actions before and after save. These are implemented as null action methods in the base entity and overridden in Entity subclasses.