### PR TITLE
Add Request Object Factory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 dist: xenial
 sudo: required
 python:
-    - "3.6"
     - "3.7"
     - "3.7-dev"
 matrix:
@@ -13,13 +12,6 @@ matrix:
           before_install:
             - choco install python3
             - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
-            - python -m pip install --upgrade pip wheel
-        - os: windows
-          language: sh
-          python: "3.6.8"
-          before_install:
-            - choco install python --version 3.6.8
-            - export PATH="/c/Python36:/c/Python36/Scripts:$PATH"
             - python -m pip install --upgrade pip wheel
     allow_failures:
         - python: 3.7-dev

--- a/docs/api/transport.rst
+++ b/docs/api/transport.rst
@@ -1,0 +1,35 @@
+.. _api-transport:
+
+Transfer Objects
+----------------
+
+RequestObjectFactory
+^^^^^^^^^^^^^^^^^^^^
+
+.. _api-request-object-factory-construct:
+
+``construct()``
+~~~~~~~~~~~~~~~
+
+.. automethod:: protean.core.transport.RequestObjectFactory.construct
+
+.. _api-request-object:
+
+RequestObject
+^^^^^^^^^^^^^
+
+.. autoclass:: protean.core.transport.RequestObject
+
+.. _api-request-object-from-dict:
+
+``from_dict()``
+~~~~~~~~~~~~~~~
+
+.. automethod:: protean.core.transport.RequestObject.from_dict
+
+.. _api-invalid-request-object:
+
+InvalidRequestObject
+^^^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: protean.core.transport.InvalidRequestObject

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -68,7 +68,7 @@ Protean is ready for today's diverse and multilayered software stack requirement
 - Kubernetes driven deployment mechanisms
 - Out-of-the-box support for deploying into AWS, Azure and GCP
 
-*Protean officially supports Python 3.6+.*
+*Protean officially supports Python 3.7+.*
 
 .. toctree::
     :maxdepth: 1

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -91,6 +91,7 @@ Protean is ready for today's diverse and multilayered software stack requirement
    :caption: User Guide
 
    user/entities/index
+   user/transport
 
 .. toctree::
    :maxdepth: 1
@@ -99,6 +100,7 @@ Protean is ready for today's diverse and multilayered software stack requirement
    api/entity
    api/field
    api/queryset
+   api/transport
 
 .. toctree::
    :maxdepth: 1

--- a/docs/user/transport.rst
+++ b/docs/user/transport.rst
@@ -1,0 +1,88 @@
+================
+Transfer Objects
+================
+
+Transfer Objects (or DTOs as they are popularly known) are objects that carry data between processes. They encapsulate data, and send it from one subsystem of an application to another, reducing the amount of data that needs to be sent across the wire in distributed applications while also ensuring the necessary data is passed.
+
+Protean has built in support for constructing request and response objects for passing data to and from servics. These objects closely mimic HTTP/REST interactions and bring the familiar status codes, actions and behavior to your application.
+
+Entities or Value Objects can serve as Transfer Objects, but it is generally not recommended to use them as they have specific domain connotations. Transfer Objects, on the other hand, are tied to a specific service; their lifetime is limited to the service's process time. They also have built-in support for tracking return codes (which are nothing but HTTP Status Codes) and errors.
+
+Request Objects
+---------------
+
+A Request Transfer Object is constructed typically from input data to an API and passed forward to the Service object. You can construct unique Request Object classes tied to each service with the help of the RequestObjectFactory, like so:
+
+.. code-block:: python
+
+    from protean.core.entity import Entity
+    from protean.core.transport import RequestObjectFactory
+
+    LoginRequestObject = RequestObjectFactory.construct(
+        'LoginRequestObject',
+        [('email', str, {'required': True}),
+         ('password', str, {'required': True}),
+         ('remember_me', bool, {'default': False}])
+
+The :ref:`api-request-object-factory-construct` method accepts two arguments: the ``name`` of the RequestObject Class and an iterable containing its field definitions.
+
+Each field definition is a tuple of three elements:
+* ``name``: The name of the field
+* ``type``: The type of value stored in the field
+* ``options``: An optional `dict` that allows you to control two aspects:
+* ``required``: If ``required`` is True, the field needs to be present in the data supplied while initializing the request object. If its absent, the request object will be deemed invalid.
+* ``default``: If ``default`` is specified, its value will be set to the field if the field is not supplied during initialization.
+
+Each element can either have just the ``name``, or ``(name, type)``, or the full-fledged ``(name, type, Field)``. If just ``name`` is supplied, ``typing.Any`` is used as the field's type.
+
+``required is ``False`` by default, so ``{required: False, default: 'John'}`` and ``{default: 'John'}`` evaluate to the same field definition. Note that ``default`` is a concrete value of the correct type, and cannot be a callable.
+
+In the example above, `email` and `password` are attributes of the `LoginRequestObject` class. ``email`` and ``password`` have both been marked as required, so the request object will be treated as invalid if they are not supplied. ``remember_me`` is not required, and will be defaulted to ``False`` if not supplied.
+
+An actual request object can then be created with the class:
+
+.. code-block:: python
+
+    request_object = UserShowRequestObject.from_dict(
+        {'email': 'johndoe@gmail.com', 'passwrod': 'secret'})
+
+If you need to implement complex Request Objects, with custom validations and transformations, you can directly subclass from :ref:`api-request-object` and override ``from_dict`` class method.
+
+.. code-block:: python
+
+    class ShowRequestObject(ValidRequestObject):
+    """
+    This class encapsulates the Request Object for retrieving a resource
+    """
+
+    def __init__(self, entity_cls, identifier=None):
+        """Initialize Request Object with ID"""
+        self.entity_cls = entity_cls
+        self.identifier = identifier
+
+    @classmethod
+    def from_dict(cls, entity_cls, adict):
+        """Initialize a ShowRequestObject object from a dictionary."""
+        invalid_req = InvalidRequestObject()
+
+        identifier = None
+        if 'identifier' in adict:
+            identifier = adict['identifier']
+        else:
+            invalid_req.add_error('identifier', 'is required')
+
+        if invalid_req.has_errors:
+            return invalid_req
+
+        return cls(entity_cls, identifier)
+
+If the request object is not valid, it's ``is_valid`` flag will evaluate to false, and an object of :ref:`api-invalid-request-object` will be returned. You can inspect ``errors`` attribute on the object to get parameterized error messages:
+
+.. code-block:: python
+
+    >>> request_object = UserShowRequestObject.from_dict(
+            {'email': 'johndoe@gmail.com'})
+    >>> request_object.is_valid
+    False
+    >>> type(request_object)
+    InvalidRequestObject

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         'Operating System :: POSIX :: Linux',
         'Operating System :: OS/2',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3 :: Only',
         'Topic :: Software Development :: Libraries',
         'Topic :: Software Development :: Libraries :: Application Frameworks',

--- a/src/protean/core/field/base.py
+++ b/src/protean/core/field/base.py
@@ -36,7 +36,7 @@ class Field(FieldDescriptorMixin, metaclass=ABCMeta):
     default_error_messages = {
         'invalid': 'Value is not a valid type for this field.',
         'unique': '`{entity_name:s}` with this `{field_name:s}` already exists.',
-        'required': 'This field is required.',
+        'required': 'is required',
         'invalid_choice': 'Value `{value!r}` is not a valid choice. '
                           'Must be one of {choices!r}',
     }

--- a/src/protean/core/tasklet.py
+++ b/src/protean/core/tasklet.py
@@ -26,7 +26,8 @@ class Tasklet:
 
         # Initialize the use case and request objects
         use_case = usecase_cls()
-        request_object = request_object_cls.from_dict(entity_cls, payload)
+        payload.update({'entity_cls': entity_cls})
+        request_object = request_object_cls.from_dict(payload)
 
         # Run the use case and return the response
         resp = use_case.execute(request_object)

--- a/src/protean/core/transport/__init__.py
+++ b/src/protean/core/transport/__init__.py
@@ -1,0 +1,14 @@
+"""Package for defining interfaces for Repository Implementations"""
+
+from .request import InvalidRequestObject
+from .request import RequestObject
+from .request import RequestObjectFactory
+from .response import ResponseFailure
+from .response import ResponseSuccess
+from .response import ResponseSuccessCreated
+from .response import ResponseSuccessWithNoContent
+from .response import Status
+
+__all__ = ('InvalidRequestObject', 'RequestObject', 'RequestObjectFactory',
+           'ResponseSuccess', 'ResponseFailure', 'ResponseSuccessCreated',
+           'ResponseSuccessWithNoContent', 'Status')

--- a/src/protean/core/transport/request.py
+++ b/src/protean/core/transport/request.py
@@ -40,27 +40,35 @@ class RequestObjectFactory:
     def construct(cls, name: str, declared_fields: typing.List[tuple]):
         """
         Utility method packaged along with the factory to be able to construct Request Object
-          classes on the fly.
+        classes on the fly.
 
         Example:
-        `UserShowRequestObject = Factory.create_request_object(
-          'CreateRequestObject',
-          [('identifier', int, {'required': True}),
-           ('name', str, {'required': True}),
-           ('desc', str, {'default': 'Blah'})])`
+
+        .. code-block:: python
+
+            UserShowRequestObject = Factory.create_request_object(
+                'CreateRequestObject',
+                [('identifier', int, {'required': True}),
+                ('name', str, {'required': True}),
+                ('desc', str, {'default': 'Blah'})])
 
         And then create a request object like so:
-        `request_object = UserShowRequestObject.from_dict({'identifier': 112,
-                                                          'name': 'Jane',
-                                                          'desc': "Doer is not Doe"})`
+
+        .. code-block:: python
+
+            request_object = UserShowRequestObject.from_dict(
+                {'identifier': 112,
+                'name': 'Jane',
+                'desc': "Doer is not Doe"})
 
         The third tuple element is a `dict` of the form: {'required': True, 'default': 'John'}
-        * `required` is False by default, so `{required: False, default: 'John'}` and
-          `{default: 'John'}` evaluate to the same field definition
-        * `default` is a concrete value of the correct type
 
-        # FIXME Refactor this method to make it simpler
+        * ``required`` is False by default, so ``{required: False, default: 'John'}`` and \
+            ``{default: 'John'}`` evaluate to the same field definition
+        * ``default`` is a *concrete* value of the correct type
         """
+        # FIXME Refactor this method to make it simpler
+
         @classmethod
         def from_dict(cls, adict):
             """Validate and initialize a Request Object"""

--- a/src/protean/core/transport/request.py
+++ b/src/protean/core/transport/request.py
@@ -1,11 +1,11 @@
 """Module for Request related Classes"""
+import datetime
 import typing
 from abc import ABCMeta
 from abc import abstractmethod
 from dataclasses import field
 from dataclasses import fields
 from dataclasses import make_dataclass
-import datetime
 
 
 class RequestObject(metaclass=ABCMeta):

--- a/src/protean/core/transport/request.py
+++ b/src/protean/core/transport/request.py
@@ -1,0 +1,171 @@
+"""Module for Request related Classes"""
+import typing
+from abc import ABCMeta
+from abc import abstractmethod
+from dataclasses import field
+from dataclasses import fields
+from dataclasses import make_dataclass
+import datetime
+
+
+class RequestObject(metaclass=ABCMeta):
+    """An Abstract Class to define a basic Valid Request Object and its functionality
+
+    Can be initialized from a dictionary.
+
+    Mirroring the REST world, a request object is usually associated with an Entity class, which is
+    referenced when necessary for performing lifecycle funtions, like validations, persistence etc.
+    """
+    is_valid = True
+
+    @classmethod
+    @abstractmethod
+    def from_dict(cls, entity_cls, adict):
+        """
+        Initialize a Request object from a dictionary.
+
+        This abstract methods should be implemented by a concrete class. Typical tasks executed
+        by the child class would be:
+        * validatin of request object data
+        * deriving of computed attributes
+        * reorganization of data to aid business logic execution
+        """
+        raise NotImplementedError
+
+
+class RequestObjectFactory:
+    """Factory to construct simple request object structures on the fly"""
+
+    @classmethod  # noqa: C901
+    def construct(cls, name: str, declared_fields: typing.List[tuple]):
+        """
+        Utility method packaged along with the factory to be able to construct Request Object
+          classes on the fly.
+
+        Example:
+        `UserShowRequestObject = Factory.create_request_object(
+          'CreateRequestObject',
+          [('identifier', int, {'required': True}),
+           ('name', str, {'required': True}),
+           ('desc', str, {'default': 'Blah'})])`
+
+        And then create a request object like so:
+        `request_object = UserShowRequestObject.from_dict({'identifier': 112,
+                                                          'name': 'Jane',
+                                                          'desc': "Doer is not Doe"})`
+
+        The third tuple element is a `dict` of the form: {'required': True, 'default': 'John'}
+        * `required` is False by default, so `{required: False, default: 'John'}` and
+          `{default: 'John'}` evaluate to the same field definition
+        * `default` is a concrete value of the correct type
+
+        # FIXME Refactor this method to make it simpler
+        """
+        @classmethod
+        def from_dict(cls, adict):
+            """Validate and initialize a Request Object"""
+            invalid_req = InvalidRequestObject()
+
+            values = {}
+            for item in fields(cls):
+                value = None
+                if item.metadata and 'required' in item.metadata and item.metadata['required']:
+                    if item.name not in adict or adict.get(item.name) is None:
+                        invalid_req.add_error(item.name, 'is required')
+                    else:
+                        value = adict[item.name]
+                elif item.name in adict:
+                    value = adict[item.name]
+                elif item.default:
+                    value = item.default
+
+                try:
+                    if item.type not in [typing.Any, 'typing.Any'] and value is not None:
+                        if item.type in [int, float, str, bool, list, dict, tuple,
+                                         datetime.date, datetime.datetime]:
+                            value = item.type(value)
+                        else:
+                            if not (isinstance(value, item.type) or issubclass(value, item.type)):
+                                invalid_req.add_error(
+                                    item.name,
+                                    '{} should be of type {}'.format(item.name, item.type))
+                except Exception:
+                    invalid_req.add_error(
+                        item.name,
+                        'Value {} for {} is invalid'.format(value, item.name))
+
+                values[item.name] = value
+
+            # Return errors, if any, instead of a request object
+            if invalid_req.has_errors:
+                return invalid_req
+
+            # Return the initialized Request Object instance
+            return cls(**values)
+
+        formatted_fields = cls._format_fields(declared_fields)
+        dc = make_dataclass(name, formatted_fields,
+                            namespace={'from_dict': from_dict, 'is_valid': True})
+        return dc
+
+    @classmethod
+    def _format_fields(cls, declared_fields: typing.List[tuple]):
+        """Process declared fields and construct a list of tuples
+        that can be fed into dataclass constructor factory.
+        """
+        formatted_fields = []
+        for declared_field in declared_fields:
+            field_name = field_type = field_defn = None
+
+            # Case when only (name), or "name", is specified
+            if isinstance(declared_field, str) or len(declared_field) == 1:
+                field_name = declared_field
+                field_type = typing.Any
+                field_defn = field(default=None)
+
+            # Case when (name, type) are specified
+            elif len(declared_field) == 2:
+                field_name = declared_field[0]
+                field_type = declared_field[1]
+                field_defn = field(default=None)
+
+            # Case when (name, type, field) are specified
+            elif len(declared_field) == 3:
+                field_name = declared_field[0]
+                field_type = declared_field[1]
+
+                # Process the definition and create a `field` object
+                # Definition will be of the form `{'required': False, 'default': 'John'}`
+                assert isinstance(declared_field[2], dict)
+                metadata = default = None
+                if 'required' in declared_field[2] and declared_field[2]['required']:
+                    metadata = {'required': True}
+                if 'default' in declared_field[2]:
+                    default = declared_field[2]['default']
+                field_defn = field(default=default, metadata=metadata)
+
+            formatted_fields.append((field_name, field_type, field_defn))
+
+        return formatted_fields
+
+
+class InvalidRequestObject:
+    """A utility class to represent an Invalid Request Object
+
+    An object of InvalidRequestObject is created with error information and returned to
+    the callee, if data was missing or corrupt in the input provided.
+    """
+    is_valid = False
+
+    def __init__(self):
+        """Initialize a blank Request object with no errors"""
+        self.errors = []
+
+    def add_error(self, parameter, message):
+        """Utility method to append an error message"""
+        self.errors.append({'parameter': parameter, 'message': message})
+
+    @property
+    def has_errors(self):
+        """Indicates if there are errors"""
+        return len(self.errors) > 0

--- a/src/protean/core/transport/response.py
+++ b/src/protean/core/transport/response.py
@@ -1,7 +1,6 @@
-"""Module for Data Transport Utility Classes"""
+"""Module for Response related Classes"""
 import sys
-from abc import ABCMeta
-from abc import abstractmethod
+
 from enum import Enum
 
 
@@ -19,53 +18,6 @@ class Status(Enum):
     RESOURCE_CONFLICT = 409
     UNPROCESSABLE_ENTITY = 422
     SYSTEM_ERROR = 500
-
-
-class InvalidRequestObject:
-    """A utility class to represent an Invalid Request Object
-
-    Typically, a ValidRequestObject creates an object of InvalidRequestObject
-    to return to the callee along with information on errors.
-    """
-    is_valid = False
-
-    def __init__(self):
-        """Initialize a blank Request object with no errors"""
-        self.errors = []
-
-    def add_error(self, parameter, message):
-        """Utility method to append an error message"""
-        self.errors.append({'parameter': parameter, 'message': message})
-
-    @property
-    def has_errors(self):
-        """Indicates if there are errors"""
-        return len(self.errors) > 0
-
-
-class ValidRequestObject(metaclass=ABCMeta):
-    """An Abstract Class to define a basic Valid Request Object and its functionality
-
-    Can be initialized from a dictionary.
-
-    Mirroring the REST world, a request object is usually associated with an Entity class, which is
-    referenced when necessary for performing lifecycle funtions, like validations, persistence etc.
-    """
-    is_valid = True
-
-    @classmethod
-    @abstractmethod
-    def from_dict(cls, entity_cls, adict):
-        """
-        Initialize a Request object from a dictionary.
-
-        This abstract methods should be implemented by a concrete class. Typical tasks executed
-        by the child class would be:
-        * validatin of request object data
-        * deriving of computed attributes
-        * reorganization of data to aid business logic execution
-        """
-        raise NotImplementedError
 
 
 class ResponseSuccess:

--- a/src/protean/core/transport/response.py
+++ b/src/protean/core/transport/response.py
@@ -1,6 +1,5 @@
 """Module for Response related Classes"""
 import sys
-
 from enum import Enum
 
 

--- a/src/protean/core/usecase/generic.py
+++ b/src/protean/core/usecase/generic.py
@@ -3,15 +3,14 @@
 from protean.conf import active_config
 from protean.core.entity import Entity
 from protean.core.transport import InvalidRequestObject
+from protean.core.transport import RequestObject
+from protean.core.transport import RequestObjectFactory
 from protean.core.transport import ResponseSuccess
 from protean.core.transport import ResponseSuccessCreated
 from protean.core.transport import ResponseSuccessWithNoContent
 from protean.core.transport import Status
-from protean.core.transport import RequestObject
-from protean.core.transport import RequestObjectFactory
 
 from .base import UseCase
-
 
 ShowRequestObject = RequestObjectFactory.construct(
     'ShowRequestObject',

--- a/src/protean/core/usecase/generic.py
+++ b/src/protean/core/usecase/generic.py
@@ -1,41 +1,22 @@
 """Concrete Implementations of some generic use cases"""
 
 from protean.conf import active_config
+from protean.core.entity import Entity
 from protean.core.transport import InvalidRequestObject
 from protean.core.transport import ResponseSuccess
 from protean.core.transport import ResponseSuccessCreated
 from protean.core.transport import ResponseSuccessWithNoContent
 from protean.core.transport import Status
-from protean.core.transport import ValidRequestObject
+from protean.core.transport import RequestObject
+from protean.core.transport import RequestObjectFactory
 
 from .base import UseCase
 
 
-class ShowRequestObject(ValidRequestObject):
-    """
-    This class encapsulates the Request Object for retrieving a resource
-    """
-
-    def __init__(self, entity_cls, identifier=None):
-        """Initialize Request Object with ID"""
-        self.entity_cls = entity_cls
-        self.identifier = identifier
-
-    @classmethod
-    def from_dict(cls, entity_cls, adict):
-        """Initialize a ShowRequestObject object from a dictionary."""
-        invalid_req = InvalidRequestObject()
-
-        identifier = None
-        if 'identifier' in adict:
-            identifier = adict['identifier']
-        else:
-            invalid_req.add_error('identifier', 'is required')
-
-        if invalid_req.has_errors:
-            return invalid_req
-
-        return cls(entity_cls, identifier)
+ShowRequestObject = RequestObjectFactory.construct(
+    'ShowRequestObject',
+    [('entity_cls', Entity, {'required': True}),
+     ('identifier', int, {'required': True})])
 
 
 class ShowUseCase(UseCase):
@@ -53,9 +34,24 @@ class ShowUseCase(UseCase):
         return ResponseSuccess(Status.SUCCESS, resource)
 
 
-class ListRequestObject(ValidRequestObject):
+class ListRequestObject(RequestObject):
     """
     This class encapsulates the Request Object for Listing a resource
+
+    Possible Factory implementation:
+
+        ListRequestObject = RequestObjectFactory.construct(
+            'ListRequestObject',
+            [('entity_cls', Entity, {'required': True}),
+            ('page', int, {'default': 1}),
+            ('per_page', int),
+            ('order_by', tuple),
+            ('filters', dict)
+            ])
+
+    Two aspects prevent us from factory-generating this request object:
+    * `filters` is usually what remains from the `dict` passed to from_dict
+    * Validation - `page` cannot be less than 0
     """
 
     def __init__(self, entity_cls, page=1, per_page=None, order_by=(),
@@ -110,20 +106,10 @@ class ListUseCase(UseCase):
         return ResponseSuccess(Status.SUCCESS, resources)
 
 
-class CreateRequestObject(ValidRequestObject):
-    """
-    This class encapsulates the Request Object for Creating New Resource
-    """
-
-    def __init__(self, entity_cls, data=None):
-        """Initialize Request Object with form data"""
-        self.entity_cls = entity_cls
-        self.data = data
-
-    @classmethod
-    def from_dict(cls, entity_cls, adict):
-        """Initialize a CreateRequestObject object from a dictionary."""
-        return cls(entity_cls, adict)
+CreateRequestObject = RequestObjectFactory.construct(
+    'CreateRequestObject',
+    [('entity_cls', Entity, {'required': True}),
+     ('data', dict, {'required': True})])
 
 
 class CreateUseCase(UseCase):
@@ -138,32 +124,11 @@ class CreateUseCase(UseCase):
         return ResponseSuccessCreated(resource)
 
 
-class UpdateRequestObject(ValidRequestObject):
-    """
-    This class encapsulates the Request Object for Updating a Resource
-    """
-
-    def __init__(self, entity_cls, identifier, data=None):
-        """Initialize Request Object with form data"""
-        self.entity_cls = entity_cls
-        self.identifier = identifier
-        self.data = data
-
-    @classmethod
-    def from_dict(cls, entity_cls, adict):
-        """Initialize a UpdateRequestObject object from a dictionary."""
-        invalid_req = InvalidRequestObject()
-
-        if 'identifier' not in adict:
-            invalid_req.add_error('identifier', 'Identifier is required')
-
-        if 'data' not in adict:
-            invalid_req.add_error('data', 'Data dict is required')
-
-        if invalid_req.has_errors:
-            return invalid_req
-
-        return cls(entity_cls, adict['identifier'], adict['data'])
+UpdateRequestObject = RequestObjectFactory.construct(
+    'UpdateRequestObject',
+    [('entity_cls', Entity, {'required': True}),
+     ('identifier', int, {'required': True}),
+     ('data', dict, {'required': True})])
 
 
 class UpdateUseCase(UseCase):
@@ -182,28 +147,7 @@ class UpdateUseCase(UseCase):
         return ResponseSuccess(Status.SUCCESS, resource)
 
 
-class DeleteRequestObject(ValidRequestObject):
-    """This class encapsulates the Request Object for Deleting a resource"""
-
-    def __init__(self, entity_cls, identifier=None):
-        self.entity_cls = entity_cls
-        self.identifier = identifier
-
-    @classmethod
-    def from_dict(cls, entity_cls, adict):
-        """Initialize a DeleteRequestObject object from a dictionary."""
-        invalid_req = InvalidRequestObject()
-
-        identifier = None
-        if 'identifier' in adict:
-            identifier = adict['identifier']
-        else:
-            invalid_req.add_error('identifier', 'is required')
-
-        if invalid_req.has_errors:
-            return invalid_req
-
-        return cls(entity_cls, identifier)
+DeleteRequestObject = ShowRequestObject
 
 
 class DeleteUseCase(UseCase):

--- a/tests/core/test_entity.py
+++ b/tests/core/test_entity.py
@@ -44,7 +44,7 @@ class TestEntity:
         assert dog2.owner == 'John'
 
     def test_required_fields(self):
-        """Test errors if mandatory fields are missing"""
+        """Test errors if required fields are missing"""
 
         with pytest.raises(ValidationError):
             Dog(id=2, name='John Doe')

--- a/tests/core/test_transport.py
+++ b/tests/core/test_transport.py
@@ -2,13 +2,13 @@
 from dataclasses import fields
 
 from protean.core.transport import InvalidRequestObject
+from protean.core.transport import RequestObject
+from protean.core.transport import RequestObjectFactory
 from protean.core.transport import ResponseFailure
 from protean.core.transport import ResponseSuccess
 from protean.core.transport import ResponseSuccessCreated
 from protean.core.transport import ResponseSuccessWithNoContent
 from protean.core.transport import Status
-from protean.core.transport import RequestObject
-from protean.core.transport import RequestObjectFactory
 
 
 class DummyValidRequestObject(RequestObject):

--- a/tests/core/test_usecase.py
+++ b/tests/core/test_usecase.py
@@ -30,10 +30,10 @@ class TestShowRequestObject:
 
     def test_init(self):
         """Test Initialization of the generic ShowRequest class"""
-        request_obj = ShowRequestObject.from_dict(Dog, {})
-        assert not request_obj.is_valid
+        request_obj = ShowRequestObject.from_dict({'entity_cls': Dog})
+        assert request_obj.is_valid is False
 
-        request_obj = ShowRequestObject.from_dict(Dog, {'identifier': 1})
+        request_obj = ShowRequestObject.from_dict({'entity_cls': Dog, 'identifier': 1})
         assert request_obj.is_valid
         assert request_obj.identifier == 1
 
@@ -58,7 +58,7 @@ class TestCreateRequestObject:
     def test_init(self):
         """Test Initialization of the generic CreateRequest class"""
         request_obj = CreateRequestObject.from_dict(
-            Dog, dict(id=1, name='John Doe', age=10, owner='Jimmy'))
+            {'entity_cls': Dog, 'data': dict(id=1, name='John Doe', age=10, owner='Jimmy')})
         assert request_obj.is_valid
         assert request_obj.data == dict(
             id=1, name='John Doe', age=10, owner='Jimmy')
@@ -69,11 +69,11 @@ class TestUpdateRequestObject:
 
     def test_init(self):
         """Test Initialization of the generic UpdateRequest class"""
-        request_obj = UpdateRequestObject.from_dict(Dog, {'identifier': 1})
-        assert not request_obj.is_valid
+        request_obj = UpdateRequestObject.from_dict({'entity_cls': Dog, 'identifier': 1})
+        assert request_obj.is_valid is False
 
         request_obj = UpdateRequestObject.from_dict(
-            Dog, {'identifier': 1, 'data': {'age': 13}})
+            {'entity_cls': Dog, 'identifier': 1, 'data': {'age': 13}})
         assert request_obj.is_valid
         assert request_obj.identifier == 1
         assert request_obj.data == {'age': 13}
@@ -84,10 +84,10 @@ class TestDeleteRequestObject:
 
     def test_init(self):
         """Test Initialization of the generic DeleteRequest class"""
-        request_obj = DeleteRequestObject.from_dict(Dog, {})
+        request_obj = DeleteRequestObject.from_dict({'entity_cls': Dog})
         assert not request_obj.is_valid
 
-        request_obj = DeleteRequestObject.from_dict(Dog, {'identifier': 1})
+        request_obj = DeleteRequestObject.from_dict({'entity_cls': Dog, 'identifier': 1})
         assert request_obj.is_valid
         assert request_obj.identifier == 1
 
@@ -106,7 +106,8 @@ class TestShowUseCase:
         Dog.create(id=1, name='Johnny', owner='John')
 
         # Build the request object and run the usecase
-        request_obj = ShowRequestObject.from_dict(Dog, {'identifier': 1})
+        request_obj = ShowRequestObject.from_dict({'entity_cls': Dog, 'identifier': 1})
+
         use_case = ShowUseCase()
         response = use_case.execute(request_obj)
         assert response is not None
@@ -119,7 +120,7 @@ class TestShowUseCase:
         """ Test Show Usecase with an invalid request"""
 
         # Build the request object and run the usecase
-        request_obj = ShowRequestObject.from_dict(Dog, {})
+        request_obj = ShowRequestObject.from_dict({'entity_cls': Dog})
         use_case = ShowUseCase()
         response = use_case.execute(request_obj)
         assert response is not None
@@ -129,7 +130,7 @@ class TestShowUseCase:
         """Test Show Usecase for non existent object"""
 
         # Build the request object and run the usecase
-        request_obj = ShowRequestObject.from_dict(Dog, {'identifier': 12})
+        request_obj = ShowRequestObject.from_dict({'entity_cls': Dog, 'identifier': 12})
         use_case = ShowUseCase()
         response = use_case.execute(request_obj)
         assert response is not None
@@ -167,7 +168,7 @@ class TestCreateUseCase:
 
         # Fix and rerun the usecase
         request_data = dict(name='Barry', age=10, owner='Jimmy')
-        request_obj = CreateRequestObject.from_dict(Dog, request_data)
+        request_obj = CreateRequestObject.from_dict({'entity_cls': Dog, 'data': request_data})
         use_case = CreateUseCase()
         response = use_case.execute(request_obj)
 
@@ -179,13 +180,13 @@ class TestCreateUseCase:
         """Test unique validation for create usecase"""
 
         request_data = dict(name='Drew', age=10, owner='Jimmy')
-        request_obj = CreateRequestObject.from_dict(Dog, request_data)
+        request_obj = CreateRequestObject.from_dict({'entity_cls': Dog, 'data': request_data})
         use_case = CreateUseCase()
         response = use_case.execute(request_obj)
 
         # Build the request object and run the usecase
         request_data = dict(id=response.value.id, name='Jerry', age=10, owner='Jimmy')
-        request_obj = CreateRequestObject.from_dict(Dog, request_data)
+        request_obj = CreateRequestObject.from_dict({'entity_cls': Dog, 'data': request_data})
         use_case = CreateUseCase()
         response = use_case.execute(request_obj)
 
@@ -211,7 +212,7 @@ class TestUpdateUseCase:
 
         # Build the request object and run the usecase
         request_obj = UpdateRequestObject.from_dict(
-            Dog, {'identifier': dog_to_update.id, 'data': {'age': 13}})
+            {'entity_cls': Dog, 'identifier': dog_to_update.id, 'data': {'age': 13}})
         use_case = UpdateUseCase()
         response = use_case.execute(request_obj)
 
@@ -225,7 +226,7 @@ class TestUpdateUseCase:
         """Test Update Usecase for validation errors"""
         # Build the request object and run the usecase
         request_obj = UpdateRequestObject.from_dict(
-            Dog, {'identifier': dog_to_update.id, 'data': {'age': 'x'}})
+            {'entity_cls': Dog, 'identifier': dog_to_update.id, 'data': {'age': 'x'}})
         use_case = UpdateUseCase()
         response = use_case.execute(request_obj)
 
@@ -242,7 +243,7 @@ class TestUpdateUseCase:
 
         # Build the request object and run the usecase
         request_obj = UpdateRequestObject.from_dict(
-            Dog, {'identifier': dog_to_update.id, 'data': {'name': 'Barry'}})
+            {'entity_cls': Dog, 'identifier': dog_to_update.id, 'data': {'name': 'Barry'}})
         use_case = UpdateUseCase()
         response = use_case.execute(request_obj)
 
@@ -268,7 +269,7 @@ class TestDeleteUseCase:
 
         # Build the request object and run the usecase
         request_obj = DeleteRequestObject.from_dict(
-            Dog, {'identifier': self.dog.id})
+            {'entity_cls': Dog, 'identifier': self.dog.id})
         use_case = DeleteUseCase()
         response = use_case.execute(request_obj)
 
@@ -278,8 +279,7 @@ class TestDeleteUseCase:
         assert response.value is None
 
         # Try to lookup the object again
-        request_obj = ShowRequestObject.from_dict(
-            Dog, {'identifier': self.dog.id})
+        request_obj = ShowRequestObject.from_dict({'entity_cls': Dog, 'identifier': self.dog.id})
         use_case = ShowUseCase()
         response = use_case.execute(request_obj)
         assert response is not None

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -29,7 +29,7 @@ def run_create_task(thread_name, name, sleep=0):
     # move forward
     time.sleep(sleep)
 
-    Tasklet.perform(ThreadedDog, CreateUseCase2, CreateRequestObject, {'name': name})
+    Tasklet.perform(ThreadedDog, CreateUseCase2, CreateRequestObject, {'data': {'name': name}})
 
 
 def test_context_with_threads():

--- a/tox.ini
+++ b/tox.ini
@@ -4,15 +4,14 @@
 envlist =
     clean,
     check,
-    py{36,37},
+    py37,
     report,
     docs
 skip_missing_interpreters = True
 
 [testenv]
 basepython =
-    {py36,docs,spell}: {env:TOXPYTHON:python3.6}
-    py37: {env:TOXPYTHON:python3.7}
+    {py37,docs,spell}: {env:TOXPYTHON:python3.7}
     {bootstrap,clean,check,report,coveralls,codecov}: {env:TOXPYTHON:python3}
 setenv =
     PYTHONPATH={toxinidir}/tests


### PR DESCRIPTION
The new Request Object Factory allows users to generate request objects on the fly, without verbose coding.

Example:

    UserShowRequestObject = Factory.create_request_object(
        'CreateRequestObject',
        [('identifier', int, {'required': True}),
        ('name', str, {'required': True}),
        ('desc', str, {'default': 'Blah'})])

Then a request object can be created like so:

    request_object = UserShowRequestObject.from_dict({'identifier': 112,
                                                'name': 'Jane',
                                                'desc': "Doer is not Doe"})

The third tuple element is a `dict` of the form: `{'required': True, 'default': 'John'}`
* `required` is False by default, so `{required: False, default: 'John'}` and
`{default: 'John'}` evaluate to the same field definition
* `default` is a concrete value of the correct type

For complex request objects, users can continue using the usual way of subclassing from `RequestObject` and implementing `from_dict` and `__init__` methods.