### PR TITLE
Add support for Entity refresh from DB

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ Release History
 dev
 ---
 
+* Add Request Object Factory to construct Request Object classes on the fly
+* Add `reload` method to refresh an entity's data from database
 
 0.0.11 (2019-04-23)
 -------------------

--- a/src/protean/core/exceptions.py
+++ b/src/protean/core/exceptions.py
@@ -15,6 +15,10 @@ class ObjectNotFoundError(Exception):
     """Object was not found, can raise 404"""
 
 
+class InvalidStateError(Exception):
+    """Object is in invalid state for the given operation"""
+
+
 class NotSupportedError(Exception):
     """Object does not support the operation being performed"""
 

--- a/tests/core/test_entity.py
+++ b/tests/core/test_entity.py
@@ -735,6 +735,22 @@ class TestEntity:
         assert exc1.value.args[0] == ('DogWithRecords class has been marked abstract'
                                       ' and cannot be instantiated')
 
+    def test_reload(self):
+        """Test that entities can be reloaded"""
+        dog = Dog.create(id=1234, name='Johnny', owner='John')
+
+        dog_dup = Dog.get(1234)
+        assert dog_dup is not None
+        assert dog_dup.id == 1234
+        dog_dup.owner = 'Jane'
+        dog_dup.save()
+
+        assert dog_dup.owner == 'Jane'
+        assert dog.owner == 'John'
+
+        dog.reload()
+        assert dog.owner == 'Jane'
+
 
 class TestEntityMetaAttributes:
     """Class that holds testcases for Entity's meta attributes"""


### PR DESCRIPTION
With this change, users can refresh an entity's data from the database by calling `entity.reload()`. This method can be used:
* in tests to ensure the entity's underlying data has changed because of an action
* to refresh an entity's data if it was retrieved from a cache or related entity