### PR TITLE
Make `ReferenceField` a private class

### DIFF
--- a/src/protean/core/entity.py
+++ b/src/protean/core/entity.py
@@ -9,10 +9,11 @@ from protean.core.exceptions import ValidationError
 from protean.core.field import Auto
 from protean.core.field import Field
 from protean.core.field import Reference
-from protean.core.field import ReferenceField
 from protean.core.queryset import QuerySet
 from protean.core.repository import repo_factory
 from protean.utils import inflection
+
+from ..core.field.association import _ReferenceField  # Relative path to private class
 
 logger = logging.getLogger('protean.core.entity')
 
@@ -312,7 +313,7 @@ class Entity(metaclass=EntityBase):
         # for required fields
         for field_name, field_obj in self.meta_.declared_fields.items():
             if field_name not in loaded_fields:
-                if not isinstance(field_obj, (Reference, ReferenceField)):
+                if not isinstance(field_obj, (Reference, _ReferenceField)):
                     setattr(self, field_name, None)
 
         # Raise any errors found during load

--- a/src/protean/core/field/__init__.py
+++ b/src/protean/core/field/__init__.py
@@ -1,7 +1,6 @@
 """Package for defining Field type and its implementations"""
 
 from .association import Reference
-from .association import ReferenceField
 from .base import Field
 from .basic import Auto
 from .basic import Boolean
@@ -19,4 +18,4 @@ from .ext import StringShort
 
 __all__ = ('Field', 'String', 'Boolean', 'Integer', 'Float', 'List', 'Dict',
            'Auto', 'Date', 'DateTime', 'Text', 'StringShort', 'StringMedium',
-           'StringLong', 'Reference', 'ReferenceField')
+           'StringLong', 'Reference')

--- a/src/protean/core/field/association.py
+++ b/src/protean/core/field/association.py
@@ -9,7 +9,7 @@ from .mixins import FieldDescriptorMixin
 from .utils import fetch_entity_cls_from_registry
 
 
-class ReferenceField(Field):
+class _ReferenceField(Field):
     """Shadow Attribute Field to back References"""
 
     def __init__(self, reference, **kwargs):
@@ -62,7 +62,7 @@ class Reference(FieldCacheMixin, Field):
         self._to_cls = to_cls
         self.via = via
 
-        self.relation = ReferenceField(self)
+        self.relation = _ReferenceField(self)
 
     @property
     def to_cls(self):


### PR DESCRIPTION
`ReferenceField` is a shadow attribute class to back a `Reference` field definition in an entity, and has no reason to be used directly.

*Note*: We have the luxury, for now, to remove such classes from the API in one stroke. Once the API stabilizes and projects use it in the mainstream, we will have to deprecate it first, and eventually, remove it after a few releases.