### PR TITLE
Response object enhancements

### DIFF
--- a/docs/api/transport.rst
+++ b/docs/api/transport.rst
@@ -30,6 +30,49 @@ RequestObject
 .. _api-invalid-request-object:
 
 InvalidRequestObject
-^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: protean.core.transport.InvalidRequestObject
+
+.. _api-response-object:
+
+Response Objects
+^^^^^^^^^^^^^^^^
+
+.. _api-response-success:
+
+ResponseSuccess
+~~~~~~~~~~~~~~~
+
+.. autoclass:: protean.core.transport.response.ResponseSuccess
+
+.. _api-response-failure:
+
+ResponseFailure
+~~~~~~~~~~~~~~~
+
+.. autoclass:: protean.core.transport.response.ResponseFailure
+
+.. _api-response-failure-build-response:
+
+.. automethod:: protean.core.transport.response.ResponseFailure.build_response
+
+.. _api-response-failure-build-from-invalid-request:
+
+.. automethod:: protean.core.transport.response.ResponseFailure.build_from_invalid_request
+
+.. _api-response-failure-build-not-found:
+
+.. automethod:: protean.core.transport.response.ResponseFailure.build_not_found
+
+.. _api-response-failure-build-system-error:
+
+.. automethod:: protean.core.transport.response.ResponseFailure.build_system_error
+
+.. _api-response-failure-build-parameters-error:
+
+.. automethod:: protean.core.transport.response.ResponseFailure.build_parameters_error
+
+.. _api-response-failure-build-unprocessable-error:
+
+.. automethod:: protean.core.transport.response.ResponseFailure.build_unprocessable_error

--- a/docs/user/transport.rst
+++ b/docs/user/transport.rst
@@ -86,3 +86,70 @@ If the request object is not valid, it's ``is_valid`` flag will evaluate to fals
     False
     >>> type(request_object)
     InvalidRequestObject
+
+Response Objects
+----------------
+
+A Response Transfer Object is constructed and returned as output from a Service object. Response objects contain success codes and/or values given by the service if they are successful, and errors if the service call failed.
+
+Consider a simply retrieval case of an entity that is already persisted:
+
+.. code-block:: python
+
+    from protean.core.usecase import ShowRequestObject
+    from protean.core.usecase import ShowUseCase
+
+    # Build the request object and run the usecase
+    request_obj = ShowRequestObject.from_dict({'entity_cls': Dog, 'identifier': 1})
+    use_case = ShowUseCase()
+    response = use_case.execute(request_obj)
+
+The ``response`` object contains all necessary information returned from the service call, and ``is_successful`` flag helps you check if the processing was successful .
+
+.. code-block:: python
+
+    >>> response.is_successful
+    True
+
+ResponseSuccess
+^^^^^^^^^^^^^^^
+
+On successfully processing a request, a ``ResponseSuccess`` object is returned. A ``ResponseSuccess`` object usually carries three attributes:
+
+* ``code``: A HTTP 2xx success status code
+* ``value``: The value returned by the service - Can be ``None`` for code 204 (Success Response with no content)
+* ``message``: An optional message sent by the service
+
+.. code-block:: python
+
+    >>> type(response)
+    <class 'protean.core.transport.response.ResponseSuccess'>
+    >>> response.is_successful
+    True
+    >>> response.code
+    <Status.SUCCESS: 200>
+    >>> type(response.value)
+    <class 'Dog'>
+    >>> response.value.to_dict()
+    {'age': 5, 'id': 1, 'name': 'Johnny', 'owner': 'John'}
+
+ResponseFailure
+^^^^^^^^^^^^^^^
+
+If the service call failed, a ``ResponseFailure`` object is returned, containing:
+
+* ``code``: A HTTP 4xx/5xx failure status code
+* ``errors``: A list of key-value errors, with key being the `parameter` or `argument` that triggered the error and `value` being a helpful message
+
+.. code-block:: python
+
+    >>> type(response)
+    <class 'protean.core.transport.response.ResponseFailure'>
+    >>> response.is_successful
+    False
+    >>> response.code
+    <Status.NOT_FOUND: 404>
+    >>> response.errors
+    [{'identifier': 'Object with this ID does not exist.'}]
+
+``ResponseFailure`` class provides many helper methods to construct HTTP style errors. Refer to :ref:`api-response-failure` for full documentation.

--- a/src/protean/core/transport/response.py
+++ b/src/protean/core/transport/response.py
@@ -28,7 +28,7 @@ class ResponseSuccess:
         value (json): Optional data returned with the response
         message (str): Optional messages returned with the response
     """
-    success = True
+    is_successful = True
 
     def __init__(self, code, value=None, message=None):
         """Initialize Successful Response Object"""
@@ -44,7 +44,7 @@ class ResponseFailure:
         code (integer): HTTP code, among 4xx and 5xx errors
         message (str): Custom message or exception returned with the response
     """
-    success = False
+    is_successful = False
     exception_message = "Something went wrong. Please try later!!"
 
     def __init__(self, code, message):

--- a/src/protean/core/transport/response.py
+++ b/src/protean/core/transport/response.py
@@ -42,18 +42,18 @@ class ResponseFailure:
 
     Attributes:
         code (integer): HTTP code, among 4xx and 5xx errors
-        message (str): Custom message or exception returned with the response
+        errors (list): List of key:value format error messages
     """
     is_successful = False
-    exception_message = "Something went wrong. Please try later!!"
+    exception_message = [{"exception": "Something went wrong. Please try later!!"}]
 
-    def __init__(self, code, message):
+    def __init__(self, code, errors):
         """Initialize a Failure Response Object"""
         self.code = code
         if code in [Status.SYSTEM_ERROR, Status.PARAMETERS_ERROR]:
-            self.message = self.exception_message
+            self.errors = self.exception_message
         else:
-            self.message = message
+            self.errors = errors
 
         # Store the original exception if any
         self.exc_type, self.exc, self.trace = sys.exc_info()
@@ -66,55 +66,61 @@ class ResponseFailure:
             code = self.code.value
         else:
             code = self.code
-        return {'code': code, 'message': self.message}
+        return {'code': code, 'errors': self.errors}
 
     @classmethod
-    def build_response(cls, code=Status.SYSTEM_ERROR, message=None):
-        """Utility method to build a new Resource Error object"""
-        return cls(code, message)
+    def build_response(cls, code=Status.SYSTEM_ERROR, errors=None):
+        """Utility method to build a new Resource Error object.
+        Can be used to build all kinds of error messages.
+        """
+        errors = [errors] if not isinstance(errors, list) else errors
+        return cls(code, errors)
 
     @classmethod
     def build_from_invalid_request(cls, invalid_request_object):
-        """Utility method to build a new Error object from parameters"""
-        message = dict([
-            (err['parameter'], err['message']) for err in
-            invalid_request_object.errors])
-        return cls.build_response(Status.UNPROCESSABLE_ENTITY, message)
+        """Utility method to build a new Error object from parameters.
+        Typically used to build HTTP 422 error response."""
+        errors = [{err['parameter']: err['message']} for err in invalid_request_object.errors]
+        return cls.build_response(Status.UNPROCESSABLE_ENTITY, errors)
 
     @classmethod
-    def build_not_found(cls, message=None):
-        """Utility method to build a HTTP 404 Resource Error object"""
-        return cls(Status.NOT_FOUND, message)
+    def build_not_found(cls, errors=None):
+        """Utility method to build a HTTP 404 Resource Error response"""
+        errors = [errors] if not isinstance(errors, list) else errors
+        return cls(Status.NOT_FOUND, errors)
 
     @classmethod
-    def build_system_error(cls, message=None):
-        """Utility method to build a HTTP 500 System Error object"""
-        return cls(Status.SYSTEM_ERROR, message)
+    def build_system_error(cls, errors=None):
+        """Utility method to build a HTTP 500 System Error response"""
+        errors = [errors] if not isinstance(errors, list) else errors
+        return cls(Status.SYSTEM_ERROR, errors)
 
     @classmethod
-    def build_parameters_error(cls, message=None):
-        """Utility method to build a HTTP 400 Parameter Error object"""
-        return cls(Status.PARAMETERS_ERROR, message)
+    def build_parameters_error(cls, errors=None):
+        """Utility method to build a HTTP 400 Parameter Error response"""
+        errors = [errors] if not isinstance(errors, list) else errors
+        return cls(Status.PARAMETERS_ERROR, errors)
 
     @classmethod
-    def build_unprocessable_error(cls, message=None):
+    def build_unprocessable_error(cls, errors=None):
         """Utility method to build a HTTP 422 Parameter Error object"""
-        return cls(Status.UNPROCESSABLE_ENTITY, message)
+        errors = [errors] if not isinstance(errors, list) else errors
+        return cls(Status.UNPROCESSABLE_ENTITY, errors)
 
 
 class ResponseSuccessCreated(ResponseSuccess):
     """Helper class to denote a HTTP 201 CREATED response"""
     status_code = Status.SUCCESS_CREATED
 
-    def __init__(self, value=None, message=None):
+    def __init__(self, value=None, errors=None):
         """Initialize Successful created Response Object"""
-        super().__init__(self.status_code, value, message)
+        super().__init__(self.status_code, value, errors)
 
 
 class ResponseSuccessWithNoContent(ResponseSuccess):
     """Helper class to denote a HTTP 204 NO CONTENT response"""
     status_code = Status.SUCCESS_WITH_NO_CONTENT
 
-    def __init__(self, value=None, message=None):
+    def __init__(self, value=None, errors=None):
         """Initialize Successful created Response Object"""
-        super().__init__(self.status_code, value, message)
+        super().__init__(self.status_code, value, errors)

--- a/src/protean/core/usecase/base.py
+++ b/src/protean/core/usecase/base.py
@@ -27,19 +27,17 @@ class UseCase(metaclass=ABCMeta):
             return self.process_request(request_object)
 
         except ValidationError as err:
-            return ResponseFailure.build_unprocessable_error(
-                err.normalized_messages)
+            return ResponseFailure.build_unprocessable_error(err.normalized_messages)
 
         except ObjectNotFoundError:
             return ResponseFailure.build_not_found(
-                {'identifier': 'Object with this ID does not exist.'})
+                [{'identifier': 'Object with this ID does not exist.'}])
 
         except Exception as exc:
             logger.error(
                 f'{self.__class__.__name__} execution failed due to error {exc}',
                 exc_info=True)
-            return ResponseFailure.build_system_error(
-                "{}: {}".format(exc.__class__.__name__, exc))
+            return ResponseFailure.build_system_error([{exc.__class__.__name__: exc}])
 
     @abstractmethod
     def process_request(self, request_object):

--- a/tests/core/test_tasklet.py
+++ b/tests/core/test_tasklet.py
@@ -31,4 +31,4 @@ class TestTasklet:
         with pytest.raises(UsecaseExecutionError) as exc_info:
             Tasklet.perform(Dog, ShowUseCase, ShowRequestObject, {}, raise_error=True)
         assert exc_info.value.value[0] == Status.UNPROCESSABLE_ENTITY
-        assert exc_info.value.value[1] == {'code': 422, 'message': {'identifier': 'is required'}}
+        assert exc_info.value.value[1] == {'code': 422, 'errors': [{'identifier': 'is required'}]}

--- a/tests/core/test_tasklet.py
+++ b/tests/core/test_tasklet.py
@@ -22,7 +22,7 @@ class TestTasklet:
 
         # Validate the response received
         assert response is not None
-        assert response.success
+        assert response.is_successful
         assert response.value.id == 1
         assert response.value.name == 'Murdock'
 

--- a/tests/core/test_transport.py
+++ b/tests/core/test_transport.py
@@ -205,7 +205,7 @@ class TestResponseFailure:
             Status.PARAMETERS_ERROR, 'Failed to process')
         assert response is not None
         assert response.code == Status.PARAMETERS_ERROR
-        assert response.message == ResponseFailure.exception_message
+        assert response.errors == ResponseFailure.exception_message
 
     def test_success(self):
         """Test that a ResponseFailure is not success"""
@@ -221,7 +221,7 @@ class TestResponseFailure:
 
         expected_value = {
             'code': 400,
-            'message': 'Something went wrong. Please try later!!'
+            'errors': [{'exception': 'Something went wrong. Please try later!!'}]
         }
         assert response.value == expected_value
 
@@ -248,6 +248,6 @@ class TestResponseFailure:
         assert response is not None
         assert response.code == Status.UNPROCESSABLE_ENTITY
         expected_value = {
-            'code': 422, 'message': {'field': 'is required'}
+            'code': 422, 'errors': [{'field': 'is required'}]
         }
         assert response.value == expected_value

--- a/tests/core/test_transport.py
+++ b/tests/core/test_transport.py
@@ -161,7 +161,7 @@ class TestResponseObject:
     def test_success(self):
         """Test that a ResponseObject is success"""
         response = ResponseSuccess(Status.SUCCESS)
-        assert response.success
+        assert response.is_successful
 
 
 class TestResponseSuccessCreated:
@@ -176,7 +176,7 @@ class TestResponseSuccessCreated:
     def test_success(self):
         """Test that a ResponseSuccessCreated is success"""
         response = ResponseSuccessCreated()
-        assert response.success
+        assert response.is_successful
 
 
 class TestResponseSuccessWithNoContent:
@@ -193,7 +193,7 @@ class TestResponseSuccessWithNoContent:
     def test_success(self):
         """Test that a ResponseSuccessWithNoContent is success"""
         response = ResponseSuccessWithNoContent()
-        assert response.success
+        assert response.is_successful
 
 
 class TestResponseFailure:
@@ -211,7 +211,7 @@ class TestResponseFailure:
         """Test that a ResponseFailure is not success"""
         response = ResponseFailure(
             Status.PARAMETERS_ERROR, 'Failed to process')
-        assert not response.success
+        assert not response.is_successful
 
     def test_value(self):
         """Test retrieval of ResponseFailure information"""

--- a/tests/core/test_usecase.py
+++ b/tests/core/test_usecase.py
@@ -195,7 +195,7 @@ class TestCreateUseCase:
         assert not response.is_successful
         assert response.value == {
             'code': 422,
-            'message': {'id': ['`Dog` with this `id` already exists.']}}
+            'errors': [{'id': ['`Dog` with this `id` already exists.']}]}
 
 
 class TestUpdateUseCase:
@@ -234,7 +234,7 @@ class TestUpdateUseCase:
         assert response is not None
         assert not response.is_successful
         assert response.value == {
-            'code': 422, 'message': {'age': ['"x" value must be an integer.']}}
+            'code': 422, 'errors': [{'age': ['"x" value must be an integer.']}]}
 
     def test_unique_validation(self, dog_to_update):
         """Test Update Usecase for unique validation"""
@@ -252,8 +252,8 @@ class TestUpdateUseCase:
         assert not response.is_successful
         assert response.value == {
             'code': 422,
-            'message': {
-                'name': ['`Dog` with this `name` already exists.']}}
+            'errors': [{
+                'name': ['`Dog` with this `name` already exists.']}]}
 
 
 class TestDeleteUseCase:

--- a/tests/core/test_usecase.py
+++ b/tests/core/test_usecase.py
@@ -111,7 +111,7 @@ class TestShowUseCase:
         use_case = ShowUseCase()
         response = use_case.execute(request_obj)
         assert response is not None
-        assert response.success
+        assert response.is_successful
         assert response.value.id == 1
         assert response.value.name == 'Johnny'
         assert response.value.age == 5
@@ -124,7 +124,7 @@ class TestShowUseCase:
         use_case = ShowUseCase()
         response = use_case.execute(request_obj)
         assert response is not None
-        assert not response.success
+        assert not response.is_successful
 
     def test_object_not_found(self):
         """Test Show Usecase for non existent object"""
@@ -134,7 +134,7 @@ class TestShowUseCase:
         use_case = ShowUseCase()
         response = use_case.execute(request_obj)
         assert response is not None
-        assert not response.success
+        assert not response.is_successful
 
 
 class TestListUseCase:
@@ -154,7 +154,7 @@ class TestListUseCase:
 
         # Validate the response received
         assert response is not None
-        assert response.success
+        assert response.is_successful
         assert response.value.offset == 0
         assert response.value.total == 2
         assert response.value.first.age == 3
@@ -173,7 +173,7 @@ class TestCreateUseCase:
         response = use_case.execute(request_obj)
 
         assert response is not None
-        assert response.success
+        assert response.is_successful
         assert response.value.name == 'Barry'
 
     def test_unique_validation(self):
@@ -192,7 +192,7 @@ class TestCreateUseCase:
 
         # Validate the response received
         assert response is not None
-        assert not response.success
+        assert not response.is_successful
         assert response.value == {
             'code': 422,
             'message': {'id': ['`Dog` with this `id` already exists.']}}
@@ -218,7 +218,7 @@ class TestUpdateUseCase:
 
         # Validate the response received
         assert response is not None
-        assert response.success
+        assert response.is_successful
         assert response.value.id == dog_to_update.id
         assert response.value.age == 13
 
@@ -232,7 +232,7 @@ class TestUpdateUseCase:
 
         # Validate the response received
         assert response is not None
-        assert not response.success
+        assert not response.is_successful
         assert response.value == {
             'code': 422, 'message': {'age': ['"x" value must be an integer.']}}
 
@@ -249,7 +249,7 @@ class TestUpdateUseCase:
 
         # Validate the response received
         assert response is not None
-        assert not response.success
+        assert not response.is_successful
         assert response.value == {
             'code': 422,
             'message': {
@@ -275,7 +275,7 @@ class TestDeleteUseCase:
 
         # Validate the response received
         assert response is not None
-        assert response.success
+        assert response.is_successful
         assert response.value is None
 
         # Try to lookup the object again
@@ -283,4 +283,4 @@ class TestDeleteUseCase:
         use_case = ShowUseCase()
         response = use_case.execute(request_obj)
         assert response is not None
-        assert not response.success
+        assert not response.is_successful


### PR DESCRIPTION
* Rename `success` flag to `is_successful` in response objects
* Change `errors` to be of uniform structure everywhere:

        'errors': [{'email': 'is required'}, 
                   {'password', is required'}]
* `ResponseSuccess` and `ResponseFailure` class documentation