### PR TITLE
Implement Identity based Equivalence checks on Entities

### DIFF
--- a/docs/user/entities/equality.rst
+++ b/docs/user/entities/equality.rst
@@ -1,0 +1,66 @@
+.. _entity-equality:
+
+Equality
+--------
+
+Equality in Entities are based on their unique identities. Two entities are considered equal if and only if they are of the same type, and have the same identity.
+
+Let's see some examples of equality in action:
+
+.. code-block:: python
+
+    from protean.core.entity import Entity
+    from protean.core import field
+
+    class Dog(Entity):
+        """This is a dummy Dog Entity class"""
+        name = field.String(required=True, max_length=50)
+        age = field.Integer(default=5)
+        owner = field.String(required=True, max_length=15)
+
+.. code-block:: python
+
+    >>> dog1 = Dog.create(name='Slobber 1', age=6, owner='Jason')
+    <tests.support.dog.Dog at ...>
+    >>> dog2 = Dog.create(name='Slobber 2', age=6, owner='Jason')
+    <tests.support.dog.Dog at ...>
+    >>> dog1 != dog2
+    True
+
+And an example of what seems too obvious:
+
+.. code-block:: python
+
+    from protean.core.entity import Entity
+    from protean.core import field
+
+    class Human(Entity):
+        """This is a dummy Human Entity class"""
+        first_name = field.String(required=True, unique=True, max_length=50)
+        last_name = field.String(required=True, unique=True, max_length=50)
+        email = field.String(required=True, unique=True, max_length=50)
+
+.. code-block:: python
+
+    >>> human = Human(id=dog.id, ...)
+    <tests.support.human.Human at ...>
+    >>> dog1 != human  # Not equal, even though they have the same identity
+    True
+
+This even applies to objects of sub-classes:
+
+.. code-block:: python
+
+    from protean.core.entity import Entity
+    from protean.core import field
+
+    class Puppy(Dog):
+        """This is a dummy Human Entity class"""
+        pass
+
+.. code-block:: python
+
+    >>> puppy = Puppy(id=dog.id, ...)
+    <tests.support.dog.Puppy at ...>
+    >>> dog1 != puppy  # Not equal, even though they have the same identity
+    True

--- a/docs/user/entities/index.rst
+++ b/docs/user/entities/index.rst
@@ -48,6 +48,7 @@ Entity lifecycle
    :maxdepth: 1
 
    lifecycle
+   equality
 
 Querying
 --------

--- a/src/protean/core/entity.py
+++ b/src/protean/core/entity.py
@@ -321,6 +321,20 @@ class Entity(metaclass=EntityBase):
         if self.errors:
             raise ValidationError(self.errors)
 
+    def __eq__(self, other):
+        """Equaivalence check to be based only on Identity"""
+        if type(other) is type(self):
+            self_id = getattr(self, self.meta_.id_field.field_name)
+            other_id = getattr(other, other.meta_.id_field.field_name)
+
+            return self_id == other_id
+
+        return False
+
+    def __hash__(self):
+        """Overrides the default implementation and bases hashing on identity"""
+        return hash(getattr(self, self.meta_.id_field.field_name))
+
     def _update_data(self, *data_dict, **kwargs):
         """
         A private method to process and update entity values correctly.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,7 @@ def register_models():
     from protean.core.repository import repo_factory
     from tests.support.dog import (Dog, RelatedDog, DogRelatedByEmail, HasOneDog1,
                                    HasOneDog2, HasOneDog3, HasManyDog1, HasManyDog2,
-                                   HasManyDog3, ThreadedDog)
+                                   HasManyDog3, ThreadedDog, SubDog)
     from tests.support.human import (Human, HasOneHuman1, HasOneHuman2, HasOneHuman3,
                                      HasManyHuman1, HasManyHuman2, HasManyHuman3)
 
@@ -54,6 +54,7 @@ def register_models():
     repo_factory.register(HasManyHuman2)
     repo_factory.register(HasManyHuman3)
     repo_factory.register(ThreadedDog)
+    repo_factory.register(SubDog)
 
 
 @pytest.fixture(autouse=True)
@@ -62,7 +63,7 @@ def run_around_tests():
     from protean.core.repository import repo_factory
     from tests.support.dog import (Dog, RelatedDog, DogRelatedByEmail, HasOneDog1,
                                    HasOneDog2, HasOneDog3, HasManyDog1, HasManyDog2,
-                                   HasManyDog3, ThreadedDog)
+                                   HasManyDog3, ThreadedDog, SubDog)
     from tests.support.human import (Human, HasOneHuman1, HasOneHuman2, HasOneHuman3,
                                      HasManyHuman1, HasManyHuman2, HasManyHuman3)
 
@@ -86,3 +87,4 @@ def run_around_tests():
     repo_factory.get_repository(HasManyHuman2).delete_all()
     repo_factory.get_repository(HasManyHuman3).delete_all()
     repo_factory.get_repository(ThreadedDog).delete_all()
+    repo_factory.get_repository(SubDog).delete_all()

--- a/tests/support/dog.py
+++ b/tests/support/dog.py
@@ -90,3 +90,8 @@ class ThreadedDog(Entity):
     """This is a dummy Dog Entity class"""
     name = field.String(required=True, max_length=50)
     created_by = field.String(required=True, max_length=15)
+
+
+class SubDog(Dog):
+    """Subclassed Dog Entity Class"""
+    pass


### PR DESCRIPTION
Entities need to be comparable only by their identity. Two entity objects are equal only if they are of the same type, and have the same identity value.

Current behavior was to compare two objects by their unique ID (in address space) and return true if they are the `same` object. Now, the value of their `id_field` attribute is used to compare.

The change to `__eq__` also necessitates re-implementation of `__hash__` because they need to go hand in hand in functionality (plus `__hash__` is "lost" forever when `__eq__` is redefined).