### PR TITLE
Friendly `repr` and `str` outputs for Entities

### DIFF
--- a/src/protean/core/entity.py
+++ b/src/protean/core/entity.py
@@ -355,6 +355,17 @@ class Entity(metaclass=EntityBase):
         return {field_name: getattr(self, field_name, None)
                 for field_name in self.meta_.declared_fields}
 
+    def __repr__(self):
+        """Friendly repr for Entity"""
+        return '<%s: %s>' % (self.__class__.__name__, self)
+
+    def __str__(self):
+        identifier = getattr(self, self.meta_.id_field.field_name)
+        return '%s object (%s)' % (
+            self.__class__.__name__,
+            '{}: {}'.format(self.meta_.id_field.field_name, identifier)
+        )
+
     def clone(self):
         """Deepclone the entity, but reset state"""
         clone_copy = copy.deepcopy(self)

--- a/tests/core/test_entity.py
+++ b/tests/core/test_entity.py
@@ -135,6 +135,16 @@ class TestEntity:
         assert dog.to_dict() == {
             'age': 10, 'id': 1, 'name': 'John Doe', 'owner': 'Jimmy'}
 
+    def test_repr(self):
+        """Test that a meaningful repr is printed for entities"""
+        dog1 = Dog(name='John Doe', age=10, owner='Jimmy')
+        assert str(dog1) == 'Dog object (id: None)'
+        assert repr(dog1) == '<Dog: Dog object (id: None)>'
+
+        dog2 = Dog.create(id=1, name='Jimmy', age=10, owner='John Doe')
+        assert str(dog2) == 'Dog object (id: 1)'
+        assert repr(dog2) == '<Dog: Dog object (id: 1)>'
+
     def test_get(self):
         """Test Entity Retrieval by its primary key"""
         Dog.create(id=1234, name='Johnny', owner='John')


### PR DESCRIPTION
`repr(dog)` prints `<Dog: Dog object (id: 1)>`
`str(dog)` prints `Dog object (id: 1)`