### PR TITLE
Add support for declaring Request Objects with `@RequestObject` annotation

### DIFF
--- a/src/protean/core/transport/__init__.py
+++ b/src/protean/core/transport/__init__.py
@@ -1,9 +1,9 @@
 """Package for defining interfaces for Repository Implementations"""
 
 # Local/Relative Imports
-from .request import InvalidRequestObject, RequestObject, RequestObjectFactory
+from .request import InvalidRequestObject, BaseRequestObject, RequestObjectFactory
 from .response import ResponseFailure, ResponseSuccess, ResponseSuccessCreated, ResponseSuccessWithNoContent, Status
 
-__all__ = ('InvalidRequestObject', 'RequestObject', 'RequestObjectFactory',
+__all__ = ('InvalidRequestObject', 'BaseRequestObject', 'RequestObjectFactory',
            'ResponseSuccess', 'ResponseFailure', 'ResponseSuccessCreated',
            'ResponseSuccessWithNoContent', 'Status')

--- a/src/protean/core/transport/request.py
+++ b/src/protean/core/transport/request.py
@@ -7,7 +7,7 @@ from abc import ABCMeta, abstractmethod
 from dataclasses import field, fields, make_dataclass
 
 
-class RequestObject(metaclass=ABCMeta):
+class BaseRequestObject(metaclass=ABCMeta):
     """An Abstract Class to define a basic Valid Request Object and its functionality
 
     Can be initialized from a dictionary.
@@ -113,6 +113,11 @@ class RequestObjectFactory:
         formatted_fields = cls._format_fields(declared_fields)
         dc = make_dataclass(name, formatted_fields,
                             namespace={'from_dict': from_dict, 'is_valid': True})
+
+        # Register element with domain
+        from protean import domain_registry
+        domain_registry.register_request_object(dc)
+
         return dc
 
     @classmethod

--- a/src/protean/core/usecase/generic.py
+++ b/src/protean/core/usecase/generic.py
@@ -6,7 +6,7 @@ from typing import Any
 # Protean
 from protean.conf import active_config
 from protean.core.entity import BaseEntity
-from protean.core.transport import (InvalidRequestObject, RequestObject, RequestObjectFactory, ResponseSuccess,
+from protean.core.transport import (InvalidRequestObject, BaseRequestObject, RequestObjectFactory, ResponseSuccess,
                                     ResponseSuccessCreated, ResponseSuccessWithNoContent, Status)
 
 # Local/Relative Imports
@@ -33,7 +33,7 @@ class ShowUseCase(UseCase):
         return ResponseSuccess(Status.SUCCESS, resource)
 
 
-class ListRequestObject(RequestObject):
+class ListRequestObject(BaseRequestObject):
     """
     This class encapsulates the Request Object for Listing a resource
 

--- a/tests/support/domains/realworld/article/application/articles.py
+++ b/tests/support/domains/realworld/article/application/articles.py
@@ -7,14 +7,15 @@ from protean.core.transport import InvalidRequestObject
 from protean.core.transport import ResponseFailure
 from protean.core.transport import ResponseSuccess
 from protean.core.transport import Status
-from protean.core.transport import RequestObject
 from protean.core.transport import RequestObjectFactory
 from protean.core.usecase import UseCase
+from protean.domain import RequestObject
 
 from tests.support.domains.realworld.profile.domain.model.user import User, Favorite
 
 
-class ListArticlesRequestObject(RequestObject):
+@RequestObject
+class ListArticlesRequestObject:
     """
     This class encapsulates the Request Object for Listing Articles
     """
@@ -96,7 +97,8 @@ class ListArticlesUseCase(UseCase):
         return ResponseSuccess(Status.SUCCESS, resources)
 
 
-class FeedArticlesRequestObject(RequestObject):
+@RequestObject
+class FeedArticlesRequestObject:
     """
     This class encapsulates the Request Object for Listing Articles
     """

--- a/tests/support/domains/realworld/article/application/comments.py
+++ b/tests/support/domains/realworld/article/application/comments.py
@@ -7,7 +7,7 @@ from protean.core.transport import InvalidRequestObject
 from protean.core.transport import ResponseFailure
 from protean.core.transport import ResponseSuccess
 from protean.core.transport import Status
-from protean.core.transport import RequestObject
+from protean.core.transport import BaseRequestObject
 from protean.core.transport import RequestObjectFactory
 from protean.core.usecase import UseCase
 
@@ -46,7 +46,7 @@ class AddCommentUseCase(UseCase):
         return ResponseSuccess(Status.SUCCESS, comment)
 
 
-class GetCommentsRequestObject(RequestObject):
+class GetCommentsRequestObject(BaseRequestObject):
     """
     This class encapsulates the Request Object for Listing Articles
     """


### PR DESCRIPTION
The annotation also registers the request object with the domain,
for analysis of bounded contexts and to be able to retrieve a request object
from the domain composition root