### PR TITLE
Add support for Domain Service definitions

### DIFF
--- a/src/protean/core/domain_service.py
+++ b/src/protean/core/domain_service.py
@@ -1,0 +1,11 @@
+class BaseDomainService:
+    """Base DomainService class that all other domain services should inherit from.
+
+    This is a placeholder class for now. Methods that are implemented
+    in concreate Domain Service classes are inspired from Domain concepts,
+    and typically use more than one aggregate to accomplish a task"""
+
+    def __new__(cls, *args, **kwargs):
+        if cls is BaseDomainService:
+            raise TypeError("BaseDomainService cannot be instantiated")
+        return object.__new__(cls, *args, **kwargs)

--- a/src/protean/domain.py
+++ b/src/protean/domain.py
@@ -28,6 +28,7 @@ _sentinel = object()
 
 class DomainObjects(Enum):
     AGGREGATE = 'AGGREGATE'
+    DOMAIN_SERVICE = 'DOMAIN_SERVICE'
     ENTITY = 'ENTITY'
     REPOSITORY = 'REPOSITORY'
     REQUEST_OBJECT = 'REQUEST_OBJECT'
@@ -100,6 +101,7 @@ class Domain(_PackageBoundObject):
     """
 
     from protean.core.aggregate import BaseAggregate
+    from protean.core.domain_service import BaseDomainService
     from protean.core.entity import BaseEntity
     from protean.core.repository.base import BaseRepository
     from protean.core.transport.request import BaseRequestObject
@@ -126,6 +128,7 @@ class Domain(_PackageBoundObject):
 
     base_class_mapping = {
             DomainObjects.AGGREGATE.value: BaseAggregate,
+            DomainObjects.DOMAIN_SERVICE.value: BaseDomainService,
             DomainObjects.ENTITY.value: BaseEntity,
             DomainObjects.REPOSITORY.value: BaseRepository,
             DomainObjects.REQUEST_OBJECT.value: BaseRequestObject,
@@ -230,6 +233,10 @@ class Domain(_PackageBoundObject):
     @property
     def aggregates(self):
         return self._domain_registry._elements[DomainObjects.AGGREGATE.value]
+
+    @property
+    def domain_services(self):
+        return self._domain_registry._elements[DomainObjects.DOMAIN_SERVICE.value]
 
     @property
     def entities(self):
@@ -351,6 +358,11 @@ class Domain(_PackageBoundObject):
     def aggregate(self, _cls=None, aggregate=None, bounded_context=None, **kwargs):
         return self._domain_element(
             DomainObjects.AGGREGATE, _cls=_cls, **kwargs,
+            aggregate=aggregate, bounded_context=bounded_context)
+
+    def domain_service(self, _cls=None, aggregate=None, bounded_context=None, **kwargs):
+        return self._domain_element(
+            DomainObjects.DOMAIN_SERVICE, _cls=_cls, **kwargs,
             aggregate=aggregate, bounded_context=bounded_context)
 
     def entity(self, _cls=None, aggregate=None, bounded_context=None, **kwargs):

--- a/tests/domain_service/elements.py
+++ b/tests/domain_service/elements.py
@@ -1,0 +1,6 @@
+from protean.core.domain_service import BaseDomainService
+
+
+class DummyDomainService(BaseDomainService):
+    def do_complex_process(self):
+        print("Performing complex process...")

--- a/tests/domain_service/tests.py
+++ b/tests/domain_service/tests.py
@@ -1,0 +1,31 @@
+import pytest
+
+from protean.core.domain_service import BaseDomainService
+from protean.utils import fully_qualified_name
+
+from .elements import DummyDomainService
+
+
+class TestDomainServiceInitialization:
+    def test_that_base_domain_service_class_cannot_be_instantiated(self):
+        with pytest.raises(TypeError):
+            BaseDomainService()
+
+    def test_that_domain_service_can_be_instantiated(self):
+        service = DummyDomainService()
+        assert service is not None
+
+
+class TestDomainServiceRegistration:
+    def test_that_domain_service_can_be_registered_with_domain(self, test_domain):
+        test_domain.register(DummyDomainService)
+
+        assert fully_qualified_name(DummyDomainService) in test_domain.domain_services
+
+    def test_that_domain_service_can_be_registered_via_annotations(self, test_domain):
+        @test_domain.domain_service
+        class AnnotatedDomainService:
+            def special_method(self):
+                pass
+
+        assert fully_qualified_name(AnnotatedDomainService) in test_domain.domain_services


### PR DESCRIPTION
For now, Domain Service Base class will simply be a marker class. Methods defined
in Domain Services are named to follow the domain concept, so there will be no
predefined abstract methods present.