### PR TITLE
Add support for Application Service definitions

### DIFF
--- a/src/protean/core/application_service.py
+++ b/src/protean/core/application_service.py
@@ -1,0 +1,10 @@
+class BaseApplicationService:
+    """Base ApplicationService class that all other Application services should inherit from.
+    This is a placeholder class for now. Methods that are implemented
+    in concreate Application Service classes are inspired from Application concepts,
+    and typically use more than one aggregate to accomplish a task"""
+
+    def __new__(cls, *args, **kwargs):
+        if cls is BaseApplicationService:
+            raise TypeError("BaseApplicationService cannot be instantiated")
+        return object.__new__(cls, *args, **kwargs)

--- a/src/protean/core/application_service.py
+++ b/src/protean/core/application_service.py
@@ -1,8 +1,14 @@
 class BaseApplicationService:
     """Base ApplicationService class that all other Application services should inherit from.
-    This is a placeholder class for now. Methods that are implemented
-    in concreate Application Service classes are inspired from Application concepts,
-    and typically use more than one aggregate to accomplish a task"""
+
+    This class is a placeholder class for now. Application concepts directly influence the
+    method names in concrete Application Service classes, so no abstract methods are necessary.
+    Each Application Service class is usually associated one-to-one with API calls.
+
+    Application services are responsible for fetching the linked domain, initializing repositories,
+    caches, and message brokers, and injecting dependencies into the domain layer. These are automatable
+    aspects that can be part of the base class in the future.
+    """
 
     def __new__(cls, *args, **kwargs):
         if cls is BaseApplicationService:

--- a/src/protean/domain.py
+++ b/src/protean/domain.py
@@ -28,6 +28,7 @@ _sentinel = object()
 
 class DomainObjects(Enum):
     AGGREGATE = 'AGGREGATE'
+    APPLICATION_SERVICE = 'APPLICATION_SERVICE'
     ENTITY = 'ENTITY'
     REPOSITORY = 'REPOSITORY'
     REQUEST_OBJECT = 'REQUEST_OBJECT'
@@ -100,6 +101,7 @@ class Domain(_PackageBoundObject):
     """
 
     from protean.core.aggregate import BaseAggregate
+    from protean.core.application_service import BaseApplicationService
     from protean.core.entity import BaseEntity
     from protean.core.repository.base import BaseRepository
     from protean.core.transport.request import BaseRequestObject
@@ -126,6 +128,7 @@ class Domain(_PackageBoundObject):
 
     base_class_mapping = {
             DomainObjects.AGGREGATE.value: BaseAggregate,
+            DomainObjects.APPLICATION_SERVICE.value: BaseApplicationService,
             DomainObjects.ENTITY.value: BaseEntity,
             DomainObjects.REPOSITORY.value: BaseRepository,
             DomainObjects.REQUEST_OBJECT.value: BaseRequestObject,
@@ -230,6 +233,10 @@ class Domain(_PackageBoundObject):
     @property
     def aggregates(self):
         return self._domain_registry._elements[DomainObjects.AGGREGATE.value]
+
+    @property
+    def application_services(self):
+        return self._domain_registry._elements[DomainObjects.APPLICATION_SERVICE.value]
 
     @property
     def entities(self):
@@ -351,6 +358,11 @@ class Domain(_PackageBoundObject):
     def aggregate(self, _cls=None, aggregate=None, bounded_context=None, **kwargs):
         return self._domain_element(
             DomainObjects.AGGREGATE, _cls=_cls, **kwargs,
+            aggregate=aggregate, bounded_context=bounded_context)
+
+    def application_service(self, _cls=None, aggregate=None, bounded_context=None, **kwargs):
+        return self._domain_element(
+            DomainObjects.APPLICATION_SERVICE, _cls=_cls, **kwargs,
             aggregate=aggregate, bounded_context=bounded_context)
 
     def entity(self, _cls=None, aggregate=None, bounded_context=None, **kwargs):

--- a/tests/application_service/elements.py
+++ b/tests/application_service/elements.py
@@ -1,0 +1,6 @@
+from protean.core.application_service import BaseApplicationService
+
+
+class DummyApplicationService(BaseApplicationService):
+    def do_application_process(self):
+        print("Performing application process...")

--- a/tests/application_service/tests.py
+++ b/tests/application_service/tests.py
@@ -6,7 +6,7 @@ from protean.utils import fully_qualified_name
 from .elements import DummyApplicationService
 
 
-class TestDomainServiceInitialization:
+class TestApplicationServiceInitialization:
     def test_that_base_application_service_class_cannot_be_instantiated(self):
         with pytest.raises(TypeError):
             BaseApplicationService()
@@ -16,7 +16,7 @@ class TestDomainServiceInitialization:
         assert service is not None
 
 
-class TestDomainServiceRegistration:
+class TestApplicationServiceRegistration:
     def test_that_application_service_can_be_registered_with_domain(self, test_domain):
         test_domain.register(DummyApplicationService)
 

--- a/tests/application_service/tests.py
+++ b/tests/application_service/tests.py
@@ -1,0 +1,31 @@
+import pytest
+
+from protean.core.application_service import BaseApplicationService
+from protean.utils import fully_qualified_name
+
+from .elements import DummyApplicationService
+
+
+class TestDomainServiceInitialization:
+    def test_that_base_application_service_class_cannot_be_instantiated(self):
+        with pytest.raises(TypeError):
+            BaseApplicationService()
+
+    def test_that_application_service_can_be_instantiated(self):
+        service = DummyApplicationService()
+        assert service is not None
+
+
+class TestDomainServiceRegistration:
+    def test_that_application_service_can_be_registered_with_domain(self, test_domain):
+        test_domain.register(DummyApplicationService)
+
+        assert fully_qualified_name(DummyApplicationService) in test_domain.application_services
+
+    def test_that_application_service_can_be_registered_via_annotations(self, test_domain):
+        @test_domain.application_service
+        class AnnotatedApplicationService:
+            def special_method(self):
+                pass
+
+        assert fully_qualified_name(AnnotatedApplicationService) in test_domain.application_services


### PR DESCRIPTION
For now, Application Service Base class will simply be a marker class. Methods defined
in Application Services are named to follow the domain concept, so there will be no
predefined abstract methods present.