### PR TITLE
Bugfix - Handle unknown repository searches elegantly

### DIFF
--- a/tests/repository/elements.py
+++ b/tests/repository/elements.py
@@ -3,6 +3,7 @@ from typing import List
 from protean.core.aggregate import BaseAggregate
 from protean.core.repository.base import BaseRepository
 from protean.core.field.basic import Integer, String
+from protean.globals import current_domain
 
 
 class Person(BaseAggregate):
@@ -12,8 +13,8 @@ class Person(BaseAggregate):
 
 
 class PersonRepository(BaseRepository):
-    def find_adults(self, age: int = 21) -> List[Person]:
-        pass  # FIXME Implement filter method
+    def find_adults(self, minimum_age: int = 21) -> List[Person]:
+        return current_domain.get_dao(Person).filter(age__gte=minimum_age)
 
     class Meta:
         aggregate_cls = Person

--- a/tests/repository/tests.py
+++ b/tests/repository/tests.py
@@ -1,0 +1,59 @@
+import pytest
+
+from protean.core.exceptions import ConfigurationError, IncorrectUsageError
+from protean.core.repository.base import BaseRepository
+from protean.utils import fully_qualified_name
+
+from .elements import Person, PersonRepository
+
+
+class TestRepositoryInitialization:
+    def test_that_base_repository_class_cannot_be_instantiated(self):
+        with pytest.raises(TypeError):
+            BaseRepository()
+
+    def test_that_repository_can_be_instantiated(self, test_domain):
+        repo = PersonRepository(test_domain)
+        assert repo is not None
+
+
+class TestRepositoryRegistration:
+    def test_that_repository_can_be_registered_with_domain(self, test_domain):
+        test_domain.register(PersonRepository)
+
+        assert fully_qualified_name(PersonRepository) in test_domain.repositories
+
+    def test_that_repository_can_be_registered_via_annotations(self, test_domain):
+        @test_domain.repository
+        class AnnotatedRepository:
+            def special_method(self):
+                pass
+
+            class Meta:
+                aggregate_cls = Person
+
+        assert fully_qualified_name(AnnotatedRepository) in test_domain.repositories
+
+    def test_that_repository_can_be_registered_via_annotations_with_aggregate_cls_parameter(self, test_domain):
+        @test_domain.repository(aggregate_cls=Person)
+        class AnnotatedRepository:
+            def special_method(self):
+                pass
+
+        assert fully_qualified_name(AnnotatedRepository) in test_domain.repositories
+
+    def test_that_repository_cannot_be_registered_via_annotations_without_aggregate_cls(self, test_domain):
+        with pytest.raises(IncorrectUsageError):
+            @test_domain.repository
+            class AnnotatedRepository:
+                def special_method(self):
+                    pass
+
+    def test_that_repository_can_be_retrieved_from_domain_by_its_aggregate_cls(self, test_domain):
+        test_domain.register(PersonRepository)
+
+        assert isinstance(test_domain.repository_for(Person), PersonRepository)
+
+    def test_that_trying_to_retrieve_an_unknown_repository_by_aggregate_cls_throws_error(self, test_domain):
+        with pytest.raises(ConfigurationError):
+            test_domain.repository_for(Person)


### PR DESCRIPTION
If the user is searching for a repository via its aggregate class, and there is no such repository, throw a Configuration Error.

This PR also contains additional test cases for the Repository class, as well as a mechanism to register a repository via annotations.