### PR TITLE
Association revamp for ddd

### DIFF
--- a/src/protean/core/field/association.py
+++ b/src/protean/core/field/association.py
@@ -252,7 +252,8 @@ class Association(FieldDescriptorMixin, FieldCacheMixin):
                 self._set_own_value(instance, reference_obj)
             else:
                 # No Objects were found in the remote entity with this Entity's ID
-                reference_obj = None
+                reference_obj = current_domain.get_dao(self.to_cls).query
+            self._set_own_value(instance, reference_obj)
 
         return reference_obj
 

--- a/src/protean/core/field/association.py
+++ b/src/protean/core/field/association.py
@@ -242,17 +242,19 @@ class Association(FieldDescriptorMixin, FieldCacheMixin):
         if isinstance(self.to_cls, str):
             self.to_cls = fetch_entity_cls_from_registry(self.to_cls)
 
+            # FIXME Test that `to_cls` contains a corresponding `Reference` field
+
         try:
             reference_obj = self.get_cached_value(instance)
         except KeyError:
             # Fetch target object by own Identifier
             id_value = getattr(instance, instance.meta_.id_field.field_name)
             reference_obj = self._fetch_objects(self._linked_attribute(owner), id_value)
-            if reference_obj:
-                self._set_own_value(instance, reference_obj)
-            else:
+
+            if not reference_obj:
                 # No Objects were found in the remote entity with this Entity's ID
                 reference_obj = current_domain.get_dao(self.to_cls).query
+
             self._set_own_value(instance, reference_obj)
 
         return reference_obj

--- a/src/protean/core/queryset.py
+++ b/src/protean/core/queryset.py
@@ -7,6 +7,7 @@ from typing import Any, Union
 
 # Protean
 from protean.utils.query import Q
+from protean.core.repository.resultset import ResultSet
 
 logger = logging.getLogger('protean.core.entity')
 
@@ -368,3 +369,20 @@ class QuerySet:
             return self._result_cache.has_prev
 
         return self.all().has_prev
+
+    #######################
+    # Association support #
+    #######################
+
+    def add(self, item):
+        if self._result_cache:
+            if item.id not in [value.id for value in self._result_cache.items]:
+                self._result_cache.items.append(item)
+                self._result_cache.total += 1
+        else:
+            self._result_cache = ResultSet(0, 10, 1, [item])
+
+    def remove(self, item):
+        if self._result_cache:
+            self._result_cache.items[:] = [value for value in self._result_cache.items if value.id != item.id]
+            self._result_cache.total -= 1

--- a/tests/aggregate/aggregate_elements.py
+++ b/tests/aggregate/aggregate_elements.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+
+from protean.core.aggregate import BaseAggregate
+from protean.core.entity import BaseEntity
+from protean.core.field.association import HasMany, HasOne, Reference
+from protean.core.field.basic import DateTime, Integer, String, Text
+
+
+class Post(BaseAggregate):
+    title = String(required=True, max_length=1000)
+    slug = String(required=True, max_length=1024)
+    content = Text(required=True)
+    posted_at = DateTime(required=True, default=datetime.now())
+
+    meta = HasOne('tests.aggregate.aggregate_elements.PostMeta')
+    comments = HasMany('tests.aggregate.aggregate_elements.Comment')
+
+
+class PostMeta(BaseEntity):
+    likes = Integer(default=0)
+
+    post = Reference(Post)
+
+    class Meta:
+        aggregate_cls = Post
+
+
+class Comment(BaseEntity):
+    content = Text(required=True)
+    commented_at = DateTime(required=True, default=datetime.now())
+
+    post = Reference(Post)
+
+    class Meta:
+        aggregate_cls = Post

--- a/tests/aggregate/test_aggregates_with_entities.py
+++ b/tests/aggregate/test_aggregates_with_entities.py
@@ -1,0 +1,61 @@
+import pytest
+
+from .aggregate_elements import Post, PostMeta, Comment
+
+
+class TestAggregatesWithEntities:
+    @pytest.fixture(autouse=True)
+    def register_elements(self, test_domain):
+        test_domain.register(Post)
+        test_domain.register(PostMeta)
+        test_domain.register(Comment)
+
+    @pytest.fixture
+    def persisted_post(self, test_domain):
+        post = test_domain.get_dao(Post).create(title='Test Post', slug='test-post', content='Do Re Mi Fa')
+        return post
+
+    def test_that_an_entity_can_be_added(self, persisted_post):
+        comment = Comment(content='So La Ti Do')
+        persisted_post.comments.add(comment)
+
+        assert comment in persisted_post.comments
+
+    def test_that_adding_an_existing_entity_does_not_create_duplicates(self, persisted_post):
+        comment = Comment(content='So La Ti Do')
+        persisted_post.comments.add(comment)
+
+        assert comment in persisted_post.comments
+        assert len(persisted_post.comments) == 1
+
+        # Add the child object again
+        persisted_post.comments.add(comment)
+
+        assert comment in persisted_post.comments
+        assert len(persisted_post.comments) == 1
+
+    def test_that_an_entity_can_be_removed(self, persisted_post):
+        comment = Comment(content='So La Ti Do')
+        persisted_post.comments.add(comment)
+
+        assert comment in persisted_post.comments
+
+        persisted_post.comments.remove(comment)
+        assert comment not in persisted_post.comments
+
+    def test_that_one_entity_amongst_many_can_be_removed(self, persisted_post):
+        comment1 = Comment(content='So La Ti Do')
+        comment2 = Comment(content='Sa Re Ga Ma')
+        persisted_post.comments.add(comment1)
+        persisted_post.comments.add(comment2)
+
+        assert comment1 in persisted_post.comments
+        assert comment2 in persisted_post.comments
+        assert len(persisted_post.comments) == 2
+
+        persisted_post.comments.remove(comment1)
+
+        assert len(persisted_post.comments) == 1
+        assert comment1 not in persisted_post.comments
+        assert comment2 in persisted_post.comments
+        assert comment2.id == persisted_post.comments[0].id

--- a/tests/field/elements.py
+++ b/tests/field/elements.py
@@ -1,0 +1,32 @@
+from datetime import datetime
+
+from protean.core.aggregate import BaseAggregate
+from protean.core.entity import BaseEntity
+from protean.core.field.association import HasMany, HasOne, Reference
+from protean.core.field.basic import DateTime, Integer, String, Text
+
+
+class Post(BaseAggregate):
+    title = String(required=True, max_length=1000)
+    slug = String(required=True, max_length=1024)
+    content = Text(required=True)
+    posted_at = DateTime(required=True, default=datetime.now())
+
+    meta = HasOne('PostMeta')
+    comments = HasMany('Comment')
+
+
+class PostMeta(BaseEntity):
+    likes = Integer(default=0)
+
+    post = Reference(Post)
+
+
+class Comment(BaseEntity):
+    content = Text(required=True)
+    commented_at = DateTime(required=True, default=datetime.now())
+
+    post = Reference(Post)
+
+    class Meta:
+        aggregate_cls = Post

--- a/tests/field/test_associations.py
+++ b/tests/field/test_associations.py
@@ -1,0 +1,25 @@
+from .elements import Comment, Post
+
+
+class TestReferenceField:
+    def test_that_reference_field_has_a_shadow_attribute(self):
+        assert 'post_id' in Comment.meta_.attributes
+
+    def test_that_reference_field_does_not_appear_among_fields(self):
+        assert 'post_id' not in Comment.meta_.declared_fields
+
+
+class TestHasOneField:
+    def test_that_has_one_field_appears_in_fields(self):
+        assert 'meta' in Post.meta_.declared_fields
+
+    def test_that_has_one_field_does_not_appear_in_attributes(self):
+        assert 'meta' not in Post.meta_.attributes
+
+
+class TestHasManyField:
+    def test_that_has_many_field_appears_in_fields(self):
+        assert 'comments' in Post.meta_.declared_fields
+
+    def test_that_has_many_field_does_not_appear_in_attributes(self):
+        assert 'comments' not in Post.meta_.attributes

--- a/tests/unit_of_work/aggregate_elements.py
+++ b/tests/unit_of_work/aggregate_elements.py
@@ -1,0 +1,40 @@
+from datetime import datetime
+
+from protean.core.aggregate import BaseAggregate
+from protean.core.entity import BaseEntity
+from protean.core.field.association import HasMany, HasOne, Reference
+from protean.core.field.basic import DateTime, Integer, String, Text
+from protean.core.repository.base import BaseRepository
+
+
+class Post(BaseAggregate):
+    title = String(required=True, max_length=1000)
+    slug = String(required=True, max_length=1024)
+    content = Text(required=True)
+    posted_at = DateTime(required=True, default=datetime.now())
+
+    meta = HasOne('tests.unit_of_work.aggregate_elements.PostMeta')
+    comments = HasMany('tests.unit_of_work.aggregate_elements.Comment')
+
+
+class PostMeta(BaseEntity):
+    likes = Integer(default=0)
+
+    post = Reference(Post)
+
+    class Meta:
+        aggregate_cls = Post
+
+
+class Comment(BaseEntity):
+    content = Text(required=True)
+    commented_at = DateTime(required=True, default=datetime.now())
+
+    post = Reference(Post)
+
+    class Meta:
+        aggregate_cls = Post
+
+
+class PostRepository(BaseRepository):
+    pass

--- a/tests/unit_of_work/test_child_object_persistence.py
+++ b/tests/unit_of_work/test_child_object_persistence.py
@@ -1,0 +1,78 @@
+import pytest
+
+from protean.core.unit_of_work import UnitOfWork
+
+from .aggregate_elements import Comment, Post, PostMeta, PostRepository
+
+
+class TestUnitOfWorkRegistration:
+    @pytest.fixture(autouse=True)
+    def register_elements(self, test_domain):
+        test_domain.register(Post)
+        test_domain.register(PostMeta)
+        test_domain.register(Comment)
+
+        test_domain.register(PostRepository, aggregate_cls=Post)
+
+        yield
+
+    @pytest.fixture
+    def persisted_post(self, test_domain):
+        post = test_domain.get_dao(Post).create(title='Test Post', slug='test-post', content='Do Re Mi Fa')
+        return post
+
+    def test_that_an_entity_can_be_added_within_uow(self, test_domain, persisted_post):
+        with UnitOfWork(test_domain) as uow:
+            comment = Comment(content='So La Ti Do')
+            persisted_post.comments.add(comment)
+
+            repo = test_domain.repository_for(Post).within(uow)
+            repo.add(persisted_post)
+
+            assert comment.id in uow.changes_to_be_committed['default']['ADDED']
+
+        repo = test_domain.repository_for(Post)
+        post = repo.get(persisted_post.id)
+        assert post.comments[0].content == 'So La Ti Do'
+
+    def test_that_an_entity_can_be_updated_within_uow(self, test_domain, persisted_post):
+        comment = Comment(content='So La Ti Do')
+        persisted_post.comments.add(comment)
+
+        repo = test_domain.repository_for(Post)
+        repo.add(persisted_post)
+
+        post = repo.get(persisted_post.id)
+        assert post.comments[0].content == 'So La Ti Do'
+
+        with UnitOfWork(test_domain) as uow:
+            comment = persisted_post.comments[0]
+            comment.content = ('Pa Da Ni Sa')
+            persisted_post.comments.add(comment)
+
+            repo = test_domain.repository_for(Post).within(uow)
+            repo.add(persisted_post)
+
+            assert comment.id in uow.changes_to_be_committed['default']['UPDATED']
+
+        post = repo.get(persisted_post.id)
+        assert post.comments[0].content == 'Pa Da Ni Sa'
+
+    def test_that_an_entity_can_be_removed_within_uow(self, test_domain, persisted_post):
+        comment = Comment(content='So La Ti Do')
+        persisted_post.comments.add(comment)
+
+        repo = test_domain.repository_for(Post)
+        repo.add(persisted_post)
+
+        with UnitOfWork(test_domain) as uow:
+            comment = persisted_post.comments[0]
+            persisted_post.comments.remove(comment)
+
+            repo = test_domain.repository_for(Post).within(uow)
+            repo.add(persisted_post)
+
+            assert comment.id in uow.changes_to_be_committed['default']['REMOVED']
+
+        post = repo.get(persisted_post.id)
+        assert len(post.comments) == 0


### PR DESCRIPTION
Association objects were so far used only for lazy loading connected objects into aggregates and entities. With this change, they will double up as containers for adding/removing objects from Parent objects. So aggregates will be able to add and remove child entities within the domain layer.

The implementation mechanism reuses the existing `QuerySet` class as the container for holding in-transit objects.

When it is time to persist, the changes to child entities within the Aggregate are automatically synced with the datastore. When a Unit of Work is available, it will be used for transactional consistency.

Pending (to be completed in a later PR):
* Ensure Child objects have a ReferenceField pointing to the parent for correct storage
* Handle conflicts that may occur with existing objects loaded in a resultset