### PR TITLE
Add support for Serializers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ click==7.0
 cookiecutter==1.6.0
 flask==1.0.3
 inflect==2.1.0
-marshmallow==2.19.5
+marshmallow==3.0.0rc8
 python-dateutil==2.8.0
 sqlalchemy==1.3.5
 werkzeug==0.15.4

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         'cookiecutter==1.6.0',
         'flask==1.0.3',
         'inflect==2.1.0',
-        'marshmallow==2.19.2',
+        'marshmallow==3.0.0rc8',
         'python-dateutil==2.8.0',
         'sqlalchemy==1.3.4',
         'werkzeug==0.15.4'

--- a/src/protean/core/field/basic.py
+++ b/src/protean/core/field/basic.py
@@ -213,6 +213,14 @@ class Identifier(Field):
         return value
 
 
+class CustomObject(Field):
+    """Concrete field implementation for objects. Values are instances of custom classes"""
+
+    def _cast_to_type(self, value):
+        """ Perform no validation for identifier fields. Return the value as is"""
+        return value
+
+
 class Date(Field):
     """ Concrete field implementation for the Date type.
     """

--- a/src/protean/core/field/basic.py
+++ b/src/protean/core/field/basic.py
@@ -221,6 +221,30 @@ class CustomObject(Field):
         return value
 
 
+class Method(Field):
+    """Helper field for custom methods associated with serializer fields"""
+
+    def __init__(self, method_name, **kwargs):
+        self.method_name = method_name
+        super().__init__(**kwargs)
+
+    def _cast_to_type(self, value):
+        """ Perform no validation for identifier fields. Return the value as is"""
+        return value
+
+
+class Nested(Field):
+    """Helper field for nested objects associated with serializer fields"""
+
+    def __init__(self, schema_name, **kwargs):
+        self.schema_name = schema_name
+        super().__init__(**kwargs)
+
+    def _cast_to_type(self, value):
+        """ Perform no validation for identifier fields. Return the value as is"""
+        return value
+
+
 class Date(Field):
     """ Concrete field implementation for the Date type.
     """

--- a/src/protean/core/serializer.py
+++ b/src/protean/core/serializer.py
@@ -1,0 +1,150 @@
+"""Serializer Object Functionality and Classes"""
+# Standard Library Imports
+import logging
+
+from marshmallow import fields, Schema
+
+# Protean
+from protean.core.exceptions import NotSupportedError
+from protean.core.field.basic import Boolean, Date, DateTime, Field, Float, Integer, String
+
+logger = logging.getLogger('protean.core.data_transfer_object')
+
+
+class _SerializerMetaclass(type):
+    """
+    This base metaclass processes the class declaration and constructs a Marshmellow Class meta object that can
+    be used to load and dump data. It also sets up a `meta_` attribute on the Serializer to be an instance of Meta,
+    either the default or one that is defined in the Serializer class.
+
+    `meta_` is setup with these attributes:
+        * `declared_fields`: A dictionary that gives a list of any instances of `Field`
+            included as attributes on either the class or on any of its superclasses
+    """
+
+    def __new__(mcs, name, bases, attrs, **kwargs):  # noqa: C901
+        """Initialize Serializer MetaClass and load attributes"""
+
+        def _declared_base_class_fields(bases, attrs):
+            """If this class is subclassing another Serializer, add that Serializer's
+            fields.  Note that we loop over the bases in *reverse*.
+            This is necessary in order to maintain the correct order of fields.
+            """
+            declared_fields = {}
+
+            for base in reversed(bases):
+                if hasattr(base, 'meta_') and \
+                        hasattr(base.meta_, 'declared_fields'):
+                    base_class_fields = {
+                        field_name: field_obj for (field_name, field_obj)
+                        in base.meta_.declared_fields.items()
+                        if field_name not in attrs and not field_obj.identifier
+                    }
+                    declared_fields.update(base_class_fields)
+
+            return declared_fields
+
+        def _declared_fields(attrs):
+            """Load field items into Class"""
+            declared_fields = {}
+
+            for attr_name, attr_obj in attrs.items():
+                if isinstance(attr_obj, Field):
+                    declared_fields[attr_name] = attr_obj
+
+            return declared_fields
+
+        # Ensure initialization is only performed for subclasses of Serializer
+        # (excluding Serializer class itself).
+        parents = [b for b in bases if isinstance(b, _SerializerMetaclass)]
+        if not parents:
+            return super().__new__(mcs, name, bases, attrs)
+
+        # Load declared fields
+        declared_fields = _declared_fields(attrs)
+
+        # Load declared fields from Base class, in case this Entity is subclassing another
+        base_class_fields = _declared_base_class_fields(bases, attrs)
+
+        all_fields = {**declared_fields, **base_class_fields}
+
+        schema_fields = {}
+        for field_name, field_obj in all_fields.items():
+            if isinstance(field_obj, Boolean):
+                schema_fields[field_name] = fields.Boolean()
+            elif isinstance(field_obj, Date):
+                schema_fields[field_name] = fields.Date()
+            elif isinstance(field_obj, DateTime):
+                schema_fields[field_name] = fields.DateTime()
+            elif isinstance(field_obj, String):
+                schema_fields[field_name] = fields.String()
+            elif isinstance(field_obj, Integer):
+                schema_fields[field_name] = fields.Integer()
+            elif isinstance(field_obj, Float):
+                schema_fields[field_name] = fields.Float()
+            else:
+                raise NotSupportedError("{} Field not supported".format(type(field_obj)))
+
+        # Remove `abstract` in base classes if defined
+        for base in bases:
+            if hasattr(base, 'Meta') and hasattr(base.Meta, 'abstract'):
+                delattr(base.Meta, 'abstract')
+
+        new_class = type(name, (Schema,), schema_fields)
+
+        # Gather `Meta` class/object if defined
+        attr_meta = attrs.pop('Meta', None)
+        meta = attr_meta or getattr(new_class, 'Meta', None)
+        setattr(new_class, 'meta_', SerializerMeta(meta, declared_fields))
+
+        return new_class
+
+
+class SerializerMeta:
+    """ Metadata info for the Serializer.
+
+    Also acts as a placeholder for generated entity fields like:
+
+        :declared_fields: dict
+            Any instances of `Field` included as attributes on either the class
+            or on any of its superclasses will be include in this dictionary.
+    """
+
+    def __init__(self, meta, declared_fields):
+        self.aggregate_cls = getattr(meta, 'aggregate_cls', None)
+
+        # Initialize Options
+        self.declared_fields = declared_fields if declared_fields else {}
+
+
+class BaseSerializer(metaclass=_SerializerMetaclass):
+    """The Base class for Protean-Compliant Serializers.
+
+    Provides helper methods to load and dump data during runtime, from protean entity objects.
+
+    Basic Usage::
+
+        @Serializer
+        class Address:
+            unit = field.String()
+            address = field.String(required=True, max_length=255)
+            city = field.String(max_length=50)
+            province = field.String(max_length=2)
+            pincode = field.String(max_length=6)
+
+    (or)
+
+        class Address(BaseSerializer):
+            unit = field.String()
+            address = field.String(required=True, max_length=255)
+            city = field.String(max_length=50)
+            province = field.String(max_length=2)
+            pincode = field.String(max_length=6)
+
+        domain.register_element(Address)
+    """
+
+    def __new__(cls, *args, **kwargs):
+        if cls is BaseSerializer:
+            raise TypeError("BaseSerializer cannot be instantiated")
+        return super().__new__(cls)

--- a/src/protean/domain.py
+++ b/src/protean/domain.py
@@ -348,7 +348,7 @@ class Domain(_PackageBoundObject):
                 or (element_type == DomainObjects.SERIALIZER)):
             aggregate_cls = new_cls.meta_.aggregate_cls or kwargs.pop('aggregate_cls', None)
             if not aggregate_cls:
-                raise IncorrectUsageError("Repositories need to be associated with an Aggregate")
+                raise IncorrectUsageError("Repositories and Serializers need to be associated with an Aggregate")
 
         if element_type == DomainObjects.SUBSCRIBER and self._validate_subscriber_class(new_cls):
             domain_event_cls = new_cls.meta_.domain_event_cls or kwargs.pop('domain_event', None)

--- a/src/protean/domain.py
+++ b/src/protean/domain.py
@@ -4,6 +4,7 @@ to register Domain Elements.
 # Standard Library Imports
 import importlib
 import logging
+import marshmallow
 import sys
 
 from collections import defaultdict
@@ -35,6 +36,7 @@ class DomainObjects(Enum):
     ENTITY = 'ENTITY'
     REPOSITORY = 'REPOSITORY'
     REQUEST_OBJECT = 'REQUEST_OBJECT'
+    SERIALIZER = 'SERIALIZER'
     SUBSCRIBER = 'SUBSCRIBER'
     VALUE_OBJECT = 'VALUE_OBJECT'
 
@@ -112,6 +114,7 @@ class Domain(_PackageBoundObject):
     from protean.core.domain_service import BaseDomainService
     from protean.core.entity import BaseEntity
     from protean.core.repository.base import BaseRepository
+    from protean.core.serializer import BaseSerializer
     from protean.core.transport.request import BaseRequestObject
     from protean.core.value_object import BaseValueObject
     from protean.utils import IdentityStrategy
@@ -144,6 +147,7 @@ class Domain(_PackageBoundObject):
             DomainObjects.ENTITY.value: BaseEntity,
             DomainObjects.REPOSITORY.value: BaseRepository,
             DomainObjects.REQUEST_OBJECT.value: BaseRequestObject,
+            DomainObjects.SERIALIZER.value: marshmallow.Schema,
             DomainObjects.SUBSCRIBER.value: BaseSubscriber,
             DomainObjects.VALUE_OBJECT.value: BaseValueObject,
         }
@@ -277,6 +281,10 @@ class Domain(_PackageBoundObject):
         return self._domain_registry._elements[DomainObjects.REPOSITORY.value]
 
     @property
+    def serializers(self):
+        return self._domain_registry._elements[DomainObjects.SERIALIZER.value]
+
+    @property
     def subscribers(self):
         return self._domain_registry._elements[DomainObjects.SUBSCRIBER.value]
 
@@ -305,7 +313,19 @@ class Domain(_PackageBoundObject):
                 if element_type.value not in self.base_class_mapping:
                     raise
 
-                new_cls = type(element_cls.__name__, (self.base_class_mapping[element_type.value], ), new_dict)
+                # Hacky code to switch between `marshmallow.Schema` and `BaseSerializer`
+                #   while creating the derived class for Serializers
+                #
+                # This becomes necessary because we need to derive the undecorated class
+                #   from `BaseSerializer`, but once derived, the base heirarchy only reflects
+                #   `marshmallow.Schema` (This is a metaclass, so it disrupts heirarchy).
+                if element_type == DomainObjects.SERIALIZER:
+                    from protean.core.serializer import BaseSerializer
+                    base_cls = BaseSerializer
+                else:
+                    base_cls = self.base_class_mapping[element_type.value]
+
+                new_cls = type(element_cls.__name__, (base_cls, ), new_dict)
             else:
                 new_cls = element_cls  # Element was already subclassed properly
         except BaseException as exc:
@@ -324,7 +344,8 @@ class Domain(_PackageBoundObject):
             model_cls = None  # FIXME Add ability to specify model_cls explicitly
 
         aggregate_cls = None
-        if element_type == DomainObjects.REPOSITORY and self._validate_repository_class(new_cls):
+        if ((element_type == DomainObjects.REPOSITORY and self._validate_repository_class(new_cls))
+                or (element_type == DomainObjects.SERIALIZER)):
             aggregate_cls = new_cls.meta_.aggregate_cls or kwargs.pop('aggregate_cls', None)
             if not aggregate_cls:
                 raise IncorrectUsageError("Repositories need to be associated with an Aggregate")
@@ -377,6 +398,16 @@ class Domain(_PackageBoundObject):
         if not issubclass(element_cls, BaseRepository):
             raise AssertionError(
                 f'Element {element_cls.__name__} must be subclass of `BaseRepository`')
+
+        return True
+
+    def _validate_serializer_class(self, element_cls):
+        # Import here to avoid cyclic dependency
+        from protean.core.serializer import BaseSerializer
+
+        if not issubclass(element_cls, BaseSerializer):
+            raise AssertionError(
+                f'Element {element_cls.__name__} must be subclass of `BaseSerializer`')
 
         return True
 
@@ -449,6 +480,11 @@ class Domain(_PackageBoundObject):
     def request_object(self, _cls=None, aggregate_cls=None, bounded_context=None, **kwargs):
         return self._domain_element(
             DomainObjects.REQUEST_OBJECT, _cls=_cls, **kwargs,
+            aggregate_cls=aggregate_cls, bounded_context=bounded_context)
+
+    def serializer(self, _cls=None, aggregate_cls=None, bounded_context=None, **kwargs):
+        return self._domain_element(
+            DomainObjects.SERIALIZER, _cls=_cls, **kwargs,
             aggregate_cls=aggregate_cls, bounded_context=bounded_context)
 
     def subscriber(self, domain_event, _cls=None, aggregate_cls=None, bounded_context=None, **kwargs):
@@ -600,7 +636,7 @@ class Domain(_PackageBoundObject):
         try:
             repository_record = next(
                 repository for _, repository in self.repositories.items()
-                if type(repository.cls.meta_.aggregate_cls) == type(aggregate_cls))  # FIXME Avoid comparing classes
+                if repository.cls.meta_.aggregate_cls == aggregate_cls)  # FIXME Avoid comparing classes
         except StopIteration:
             raise ConfigurationError(
                 "Invalid or Unregistered Aggregate class specified, "

--- a/tests/serializer/elements.py
+++ b/tests/serializer/elements.py
@@ -1,0 +1,17 @@
+from protean.core.aggregate import BaseAggregate
+from protean.core.serializer import BaseSerializer
+
+from protean.core.field.basic import Integer, String
+
+
+class User(BaseAggregate):
+    name = String(required=True)
+    age = Integer(required=True)
+
+
+class UserSchema(BaseSerializer):
+    name = String(required=True)
+    age = Integer(required=True)
+
+    class Meta:
+        aggregate_cls = User

--- a/tests/serializer/tests.py
+++ b/tests/serializer/tests.py
@@ -1,0 +1,49 @@
+import pytest
+
+from protean.core.serializer import BaseSerializer
+from protean.core.field.basic import Integer, String
+from protean.utils import fully_qualified_name
+
+from .elements import User, UserSchema
+
+
+class TestSerializerInitialization:
+    def test_that_base_serializer_class_cannot_be_instantiated(self):
+        with pytest.raises(TypeError):
+            BaseSerializer()
+
+    def test_that_a_concrete_serializer_can_be_instantiated(self):
+        schema = UserSchema()
+        assert schema is not None
+
+    def test_that_meta_is_loaded_with_attributes(self):
+        assert UserSchema.meta_.aggregate_cls is not None
+        assert UserSchema.meta_.aggregate_cls == User
+
+        assert UserSchema.meta_.declared_fields is not None
+        assert all(key in UserSchema.meta_.declared_fields for key in ['name', 'age'])
+
+
+class TestSerializerRegistration:
+    def test_that_serializer_can_be_registered_with_domain(self, test_domain):
+        test_domain.register(UserSchema)
+
+        assert fully_qualified_name(UserSchema) in test_domain.serializers
+
+    def test_that_serializer_can_be_registered_via_annotations(self, test_domain):
+        @test_domain.serializer
+        class PersonSchema:
+            name = String(required=True)
+            age = Integer(required=True)
+
+            class Meta:
+                aggregate_cls = User
+
+        assert fully_qualified_name(PersonSchema) in test_domain.serializers
+
+
+class TestSerializerDump:
+    def test_that_serializer_dumps_data_from_domain_element(self):
+        user = User(name='John Doe', age=24)
+        json_result = UserSchema().dump(user)
+        assert json_result.data == {'age': 24, 'name': 'John Doe'}

--- a/tests/serializer/tests.py
+++ b/tests/serializer/tests.py
@@ -46,4 +46,4 @@ class TestSerializerDump:
     def test_that_serializer_dumps_data_from_domain_element(self):
         user = User(name='John Doe', age=24)
         json_result = UserSchema().dump(user)
-        assert json_result.data == {'age': 24, 'name': 'John Doe'}
+        assert json_result == {'age': 24, 'name': 'John Doe'}


### PR DESCRIPTION
With this change, Application services can dump code from domain objects
directly into JSON format, with the help of Marshmallow schemas. We don't
have to handcraft representation/resource objects and serialize manually anymore.