### PR TITLE
Bugfix - Value Object fixes for setting values

### DIFF
--- a/src/protean/core/aggregate.py
+++ b/src/protean/core/aggregate.py
@@ -350,8 +350,10 @@ class BaseAggregate(metaclass=_AggregateMetaclass):
                 }
                 try:
                     value_object = field_obj.value_object_cls.build(**vals)
-                    setattr(self, field_name, value_object)
-                    loaded_fields.append(field_name)
+                    # Set VO value only if the value object is not None/Empty
+                    if value_object:
+                        setattr(self, field_name, value_object)
+                        loaded_fields.append(field_name)
                 except ValidationError as err:
                     for sub_field_name in err.messages:
                         self.errors['{}_{}'.format(field_name, sub_field_name)].extend(err.messages[sub_field_name])

--- a/src/protean/core/aggregate.py
+++ b/src/protean/core/aggregate.py
@@ -338,14 +338,14 @@ class BaseAggregate(metaclass=_AggregateMetaclass):
 
         # Load Value Objects
         for field_name, field_obj in self.meta_.declared_fields.items():
-            if isinstance(field_obj, (ValueObjectField)):
+            if isinstance(field_obj, (ValueObjectField)) and not getattr(self, field_name):
                 attributes = [
                     (embedded_field.field_name, embedded_field.attribute_name)
                     for embedded_field
                     in field_obj.embedded_fields.values()
                     ]
                 vals = {
-                    name: getattr(self, attr)
+                    name: kwargs.get(attr)
                     for name, attr in attributes
                 }
                 try:
@@ -354,7 +354,7 @@ class BaseAggregate(metaclass=_AggregateMetaclass):
                     loaded_fields.append(field_name)
                 except ValidationError as err:
                     for sub_field_name in err.messages:
-                        self.errors['{}-{}'.format(field_name, sub_field_name)].extend(err.messages[sub_field_name])
+                        self.errors['{}_{}'.format(field_name, sub_field_name)].extend(err.messages[sub_field_name])
 
         if not getattr(self, self.meta_.id_field.field_name, None) and type(self.meta_.id_field) is Auto:
             setattr(self, self.meta_.id_field.field_name, self._generate_identity())

--- a/src/protean/core/field/base.py
+++ b/src/protean/core/field/base.py
@@ -181,7 +181,8 @@ class Field(FieldDescriptorMixin, metaclass=ABCMeta):
 
         """
 
-        if value in self.empty_values:
+        # Check if value is one among recognized empty values, or is False (for complex objects)
+        if value in self.empty_values or not value:
             # If a default has been set for the field return it
             if self.default is not None:
                 default = self.default
@@ -192,10 +193,12 @@ class Field(FieldDescriptorMixin, metaclass=ABCMeta):
             elif self.required:
                 self.fail('required')
 
-            # In all other cases just return `None` as we do not want to
+            # In all other cases just return the passed value, as we do not want to
             # run validations against an empty value
+            # Because of this behavior, we preserve the data sanctity for int and float objects,
+            # and return 0 or 0.0, as need be.
             else:
-                return None
+                return value
 
         # If choices exist then validate that value is be one of the choices
         if self.choices:

--- a/src/protean/core/field/embedded.py
+++ b/src/protean/core/field/embedded.py
@@ -85,19 +85,18 @@ class ValueObjectField(Field):
 
     def __set__(self, instance, value):
         """Override `__set__` to coordinate between value object and its embedded fields"""
+        if isinstance(self.value_object_cls, str):
+            self.value_object_cls = fetch_value_object_cls_from_domain(self.value_object_cls)
+
+            # Refresh attribute name, now that we know `value_object_cls` class
+            self.attribute_name = self.get_attribute_name()
+
+        value = self._load(value)
+
         if value:
-            if isinstance(self.value_object_cls, str):
-                self.value_object_cls = fetch_value_object_cls_from_domain(self.value_object_cls)
-
-                # Refresh attribute name, now that we know `value_object_cls` class
-                self.attribute_name = self.get_attribute_name()
-
-            value = self._load(value)
-
-            if value:
-                # Check if the reference object has been saved. Otherwise, throw ValueError
-                self._set_own_value(instance, value)
-                self._set_embedded_values(instance, value)
+            # Check if the reference object has been saved. Otherwise, throw ValueError
+            self._set_own_value(instance, value)
+            self._set_embedded_values(instance, value)
         else:
             self._reset_values(instance)
 

--- a/src/protean/core/field/embedded.py
+++ b/src/protean/core/field/embedded.py
@@ -35,7 +35,6 @@ class _ShadowField(Field):
 
     def _reset_values(self, instance):
         """Reset all associated values and clean up dictionary items"""
-        self.value = None
         instance.__dict__.pop(self.field_name, None)
 
 
@@ -103,7 +102,6 @@ class ValueObjectField(Field):
             self._reset_values(instance)
 
     def _set_own_value(self, instance, value):
-        self.value = value
         if value is None:
             instance.__dict__.pop(self.field_name, None)
         else:

--- a/src/protean/core/value_object.py
+++ b/src/protean/core/value_object.py
@@ -263,6 +263,14 @@ class BaseValueObject(metaclass=_ValueObjectMetaclass):
             '{}'.format(self.to_dict())
         )
 
+    def __bool__(self):
+        """ Return this object's truthiness to be `False`,
+        if all its attributes evaluate to truthiness `False`
+        """
+        return any(
+            bool(getattr(self, field_name, None))
+            for field_name in self.meta_.attributes)
+
     def to_dict(self):
         """ Return data as a dictionary """
         return {field_name: getattr(self, field_name, None)

--- a/tests/field/test_field_types.py
+++ b/tests/field/test_field_types.py
@@ -140,6 +140,15 @@ class TestFloatField:
             score = Float(max_value=5.5)
             score._load(5.6)
 
+    @pytest.mark.xfail
+    def test_none_value(self):
+        """ Test None value treatment for the float field"""
+
+        score = Float(max_value=5.5)
+        score._load(None)
+
+        assert score.value == 0.0
+
 
 class TestBooleanField:
     """ Test the Boolean Field Implementation"""

--- a/tests/value_object/elements.py
+++ b/tests/value_object/elements.py
@@ -68,7 +68,7 @@ class Balance(BaseValueObject):
     amount = Float()
 
     def clean(self):
-        if self.amount < -1000000000000.0:
+        if self.amount and self.amount < -1000000000000.0:
             raise ValidationError("Amount cannot be less than 1 Trillion")
 
     def replace(self, **kwargs):
@@ -77,3 +77,8 @@ class Balance(BaseValueObject):
         amount = kwargs.pop('amount', None)
         return Balance(currency=currency or self.currency,
                        amount=amount or self.amount)
+
+
+class Account(BaseAggregate):
+    balance = ValueObjectField(Balance, required=True)
+    kind = String(max_length=15, required=True)

--- a/tests/value_object/elements.py
+++ b/tests/value_object/elements.py
@@ -2,8 +2,10 @@
 from enum import Enum
 
 # Protean
+from protean.core.aggregate import BaseAggregate
 from protean.core.exceptions import ValidationError
 from protean.core.field.basic import Float, String
+from protean.core.field.embedded import ValueObjectField
 from protean.core.value_object import BaseValueObject
 
 
@@ -14,44 +16,35 @@ class Email(BaseValueObject):
     """
 
     # This is the external facing data attribute
-    address = String(max_length=254)
-
-    def __init__(self, *template, local_part=None, domain_part=None, **kwargs):
-        super(Email, self).__init__(*template, **kwargs)
-
-        # `local_part` and `domain_part` are internal attributes that capture
-        #   and preserve the validity of an Email Address
-        self.local_part = local_part
-        self.domain_part = domain_part
-
-        if self.local_part and self.domain_part:
-            self.address = '@'.join([self.local_part, self.domain_part])
-        else:
-            raise ValidationError("`local_part` and `domain_part` of email address are mandatory")
+    address = String(max_length=254, required=True)
 
     @classmethod
     def from_address(cls, address):
+        """ Construct an Email VO from an email address.
+
+        email = Email.from_address('john.doe@gmail.com')
+
+        """
         if not cls.validate(address):
             raise ValueError('Email address is invalid')
 
-        local_part, _, domain_part = address.partition('@')
-
-        return cls(local_part=local_part, domain_part=domain_part)
-
-    @classmethod
-    def from_parts(cls, local_part, domain_part):
-        return cls(local_part=local_part, domain_part=domain_part)
+        return cls(address=address)
 
     @classmethod
     def validate(cls, address):
-        if type(address) is not str:
-            return False
-        if '@' not in address:
-            return False
-        if len(address) > 255:
+        """ Business rules of Email address """
+        if (type(address) is not str or
+                '@' not in address or
+                address.count('@') > 1 or
+                len(address) > 255):
             return False
 
         return True
+
+
+class User(BaseAggregate):
+    email = ValueObjectField(Email, required=True)
+    name = String(max_length=255)
 
 
 class MyOrgEmail(Email):

--- a/tests/value_object/tests.py
+++ b/tests/value_object/tests.py
@@ -4,7 +4,7 @@ import pytest
 from protean.core.exceptions import InvalidOperationError, ValidationError
 
 # Local/Relative Imports
-from .elements import Balance, Currency, Email, MyOrgEmail
+from .elements import Balance, Currency, Email, MyOrgEmail, User
 
 
 class TestEquivalence:
@@ -58,7 +58,7 @@ class TestEmailVOProperties:
     def test_that_value_objects_are_immutable(self):
         email = Email.from_address(address='john.doe@gmail.com')
         with pytest.raises(InvalidOperationError):
-            email.local_part = 'jane.doe'
+            email.address = 'jane.doe@gmail.com'
 
 
 class TestEmailVOStructure:
@@ -143,19 +143,46 @@ class TestEmailVOBehavior:
             Email.from_address('john.doe')
 
     def test_init_from_constructor(self):
-        email = Email(local_part='john.doe', domain_part='gmail.com')
+        email = Email(address='john.doe@gmail.com')
         assert email is not None
-        assert email.local_part == 'john.doe'
-        assert email.domain_part == 'gmail.com'
-
-    def test_init_from_parts(self):
-        email = Email.from_parts('john.doe', 'gmail.com')
-        assert email is not None
-        assert email.local_part == 'john.doe'
-        assert email.domain_part == 'gmail.com'
+        assert email.address == 'john.doe@gmail.com'
 
     def test_init_build(self):
         email = Email.from_address('john.doe@gmail.com')
         assert email is not None
-        assert email.local_part == 'john.doe'
-        assert email.domain_part == 'gmail.com'
+        assert email.address == 'john.doe@gmail.com'
+
+
+class TestVOEmbedding:
+    def test_that_user_has_all_the_required_fields(self):
+        assert all(
+            field_name in User.meta_.declared_fields
+            for field_name in
+            ['email', 'name'])
+
+    def test_that_user_can_be_initialized_successfully(self):
+        user = User(email=Email.from_address('john.doe@gmail.com'))
+        assert user is not None
+        assert user.id is not None
+        assert user.email == Email.from_address(address='john.doe@gmail.com')
+        assert user.email_address == 'john.doe@gmail.com'
+
+    def test_that_user_can_be_initialized_successfully_with_embedded_fields(self):
+        user = User(email_address='john.doe@gmail.com', name='John Doe')
+        assert user is not None
+        assert user.id is not None
+        assert user.email == Email.from_address('john.doe@gmail.com')
+        assert user.email_address == 'john.doe@gmail.com'
+
+    def test_that_mandatory_fields_are_validated(self):
+        with pytest.raises(ValidationError) as multi_exceptions:
+            User()
+
+        assert 'email_address' in multi_exceptions.value.messages
+        assert multi_exceptions.value.messages['email_address'] == ['is required']
+
+        with pytest.raises(ValidationError) as email_exception:
+            User(name='John Doe')
+
+        assert 'email_address' in email_exception.value.messages
+        assert email_exception.value.messages['email_address'] == ['is required']


### PR DESCRIPTION
* Should be able to set VO value by its underlying attribute name. `User(email_address='john.doe@gmail.com')`
* VO value should be blank during the start of initialization of parent
* Return value as-is if among empty values (so 0 and 0.0 will be returned for int and float types, for example)
* Run required validations on Value Objects
* Only set VO value if at least one of the elements in it is present