### PR TITLE
Bugfix/235 - Do not raise ValidationError when loading data from database

### DIFF
--- a/src/protean/impl/repository/dict_repo.py
+++ b/src/protean/impl/repository/dict_repo.py
@@ -44,7 +44,7 @@ class DictModel(BaseModel):
     @classmethod
     def to_entity(cls, item: 'DictModel'):
         """Convert the dictionary record to an entity """
-        return cls.entity_cls(item)
+        return cls.entity_cls(item, raise_errors=False)
 
 
 class DictSession:

--- a/src/protean/impl/repository/sqlalchemy_repo.py
+++ b/src/protean/impl/repository/sqlalchemy_repo.py
@@ -178,7 +178,7 @@ class SqlalchemyModel(BaseModel):
         item_dict = {}
         for field_name in cls.entity_cls.meta_.attributes:
             item_dict[field_name] = getattr(model_obj, field_name, None)
-        return cls.entity_cls(item_dict)
+        return cls.entity_cls(item_dict, raise_errors=False)
 
 
 class SADAO(BaseDAO):

--- a/src/protean/utils/container.py
+++ b/src/protean/utils/container.py
@@ -2,6 +2,8 @@
 import copy
 import logging
 
+from collections import defaultdict
+
 # Protean
 from protean.core.exceptions import NotSupportedError, ValidationError
 from protean.core.field.basic import Field
@@ -110,7 +112,7 @@ class BaseContainer(metaclass=_ContainerMetaclass):
             raise TypeError("BaseContainer cannot be instantiated")
         return super().__new__(cls)
 
-    def __init__(self, *template, owner=None, **kwargs):
+    def __init__(self, *template, owner=None, raise_errors=True, **kwargs):
         """
         Initialise the container.
 
@@ -125,7 +127,8 @@ class BaseContainer(metaclass=_ContainerMetaclass):
                 f'{self.__class__.__name__} class has been marked abstract'
                 f' and cannot be instantiated')
 
-        self.errors = {}
+        self.errors = defaultdict(list)
+        self.raise_errors = raise_errors
 
         # Entity/Aggregate to which this Command is connected to
         self.owner = owner
@@ -154,13 +157,17 @@ class BaseContainer(metaclass=_ContainerMetaclass):
             if field_name not in loaded_fields:
                 setattr(self, field_name, None)
 
-        # Raise any errors found during load
-        if self.errors:
-            raise ValidationError(self.errors)
-
         self.defaults()
 
-        self.clean()
+        # `clean()` will return a `defaultdict(list)` if errors are to be raised
+        custom_errors = self.clean()
+        for field in custom_errors:
+            self.errors[field].append(custom_errors[field])
+
+        # Raise any errors found during load
+        if self.errors and self.raise_errors:
+            logger.error(self.errors)
+            raise ValidationError(self.errors)
 
     @classmethod
     def build(cls, **values):
@@ -178,6 +185,7 @@ class BaseContainer(metaclass=_ContainerMetaclass):
         """Placeholder method for validations.
         To be overridden in concrete Containers, when complex validations spanning multiple fields are required.
         """
+        return defaultdict(list)
 
     def __eq__(self, other):
         """Equaivalence check for commands is based only on data.
@@ -212,7 +220,7 @@ class BaseContainer(metaclass=_ContainerMetaclass):
             for field_name in self.meta_.attributes)
 
     def __setattr__(self, name, value):
-        if name in self.meta_.declared_fields or name in ['errors', 'owner']:
+        if name in self.meta_.declared_fields or name in ['raise_errors', 'errors', 'owner']:
             super().__setattr__(name, value)
         else:
             raise AttributeError("%s has no attribute %s" % (self.__class__.__name__, name))

--- a/tests/entity/elements.py
+++ b/tests/entity/elements.py
@@ -1,8 +1,8 @@
+from collections import defaultdict
 from enum import Enum
 
 # Protean
 from protean.core.entity import BaseEntity
-from protean.core.exceptions import ValidationError
 from protean.core.field.basic import Auto, Integer, String
 
 
@@ -118,5 +118,9 @@ class Building(BaseEntity):
                 self.status = BuildingStatus.WIP.value
 
     def clean(self):
+        errors = defaultdict(list)
+
         if self.floors >= 4 and self.status != BuildingStatus.DONE.value:
-            raise ValidationError({'status': ['should be DONE']})
+            errors['status'].append('should be DONE')
+
+        return errors

--- a/tests/impl/repository/sqlalchemy_repo/postgresql/elements.py
+++ b/tests/impl/repository/sqlalchemy_repo/postgresql/elements.py
@@ -1,11 +1,11 @@
 # Standard Library Imports
 import re
 
+from collections import defaultdict
 from datetime import datetime
 
 # Protean
 from protean.core.aggregate import BaseAggregate
-from protean.core.exceptions import ValidationError
 from protean.core.field.basic import DateTime, Integer, String
 from protean.core.field.embedded import ValueObjectField
 from protean.core.repository.base import BaseRepository
@@ -42,8 +42,12 @@ class Email(BaseValueObject):
 
     def clean(self):
         """ Business rules of Email address """
+        errors = defaultdict(list)
+
         if not bool(re.match(Email.REGEXP, self.address)):
-            raise ValidationError({'address': ["is invalid"]})
+            errors['address'].append('is invalid')
+
+        return errors
 
 
 class ComplexUser(BaseAggregate):

--- a/tests/impl/repository/sqlalchemy_repo/sqlite/elements.py
+++ b/tests/impl/repository/sqlalchemy_repo/sqlite/elements.py
@@ -1,11 +1,11 @@
 # Standard Library Imports
 import re
 
+from collections import defaultdict
 from datetime import datetime
 
 # Protean
 from protean.core.aggregate import BaseAggregate
-from protean.core.exceptions import ValidationError
 from protean.core.field.basic import DateTime, Integer, String
 from protean.core.field.embedded import ValueObjectField
 from protean.core.repository.base import BaseRepository
@@ -42,8 +42,12 @@ class Email(BaseValueObject):
 
     def clean(self):
         """ Business rules of Email address """
+        errors = defaultdict(list)
+
         if not bool(re.match(Email.REGEXP, self.address)):
-            raise ValidationError({'address': ["is invalid"]})
+            errors['address'].append('is invalid')
+
+        return errors
 
 
 class ComplexUser(BaseAggregate):

--- a/tests/repository/elements.py
+++ b/tests/repository/elements.py
@@ -1,11 +1,11 @@
 # Standard Library Imports
 import re
 
+from collections import defaultdict
 from typing import List
 
 # Protean
 from protean.core.aggregate import BaseAggregate
-from protean.core.exceptions import ValidationError
 from protean.core.field.basic import Integer, String
 from protean.core.field.embedded import ValueObjectField
 from protean.core.repository.base import BaseRepository
@@ -35,8 +35,12 @@ class Email(BaseValueObject):
 
     def clean(self):
         """ Business rules of Email address """
+        errors = defaultdict(list)
+
         if not bool(re.match(Email.REGEXP, self.address)):
-            raise ValidationError({'address': ["is invalid"]})
+            errors['address'].append('is invalid')
+
+        return errors
 
 
 class User(BaseAggregate):

--- a/tests/value_object/elements.py
+++ b/tests/value_object/elements.py
@@ -1,9 +1,9 @@
 # Standard Library Imports
+from collections import defaultdict
 from enum import Enum
 
 # Protean
 from protean.core.aggregate import BaseAggregate
-from protean.core.exceptions import ValidationError
 from protean.core.field.basic import Float, Integer, String
 from protean.core.field.embedded import ValueObjectField
 from protean.core.value_object import BaseValueObject
@@ -68,8 +68,10 @@ class Balance(BaseValueObject):
     amount = Float()
 
     def clean(self):
+        errors = defaultdict(list)
         if self.amount and self.amount < -1000000000000.0:
-            raise ValidationError("Amount cannot be less than 1 Trillion")
+            errors['amount'].append('cannot be less than 1 Trillion')
+        return errors
 
     def replace(self, **kwargs):
         # FIXME Find a way to do this generically and move method to `BaseValueObject`
@@ -102,5 +104,7 @@ class Building(BaseValueObject):
                 self.status = BuildingStatus.WIP.value
 
     def clean(self):
+        errors = defaultdict(list)
         if self.floors >= 4 and self.status != BuildingStatus.DONE.value:
-            raise ValidationError({'status': ['should be DONE']})
+            errors['status'].append('should be DONE')
+        return errors


### PR DESCRIPTION
A new flag `raise_errors` will control this behavior. The value of
`raise_errors` will be TRUE except when data is loaded from the db
with the help of `to_entity` method.

Closes #235 