### PR TITLE
Add full persistence support for child entities

### DIFF
--- a/src/protean/core/queryset.py
+++ b/src/protean/core/queryset.py
@@ -382,6 +382,19 @@ class QuerySet:
                 (item.id in [value.id for value in self._data.items] and
                  item.state_.is_persisted and item.state_.is_changed)):
             if item.id not in [value.id for value in self._temp_cache['added']]:
+                # FIXME Re-evaluate for UoW support
+
+                # If the child was already present, first remove that record
+                if item.id in [value.id for value in self._data.items]:
+                    for value in self._data.items:
+                        if value.id == item.id:
+                            self._temp_cache['removed'].append(value)
+                            break
+
+                # This updates the parent's unique identifier in the child
+                #   so that the foreign key relationship is preserved
+                for criteria in self._criteria.children:
+                    setattr(item, criteria[0], criteria[1])
                 self._temp_cache['added'].append(item)
 
     def remove(self, item):

--- a/src/protean/domain.py
+++ b/src/protean/domain.py
@@ -749,7 +749,7 @@ class Domain(_PackageBoundObject):
             if element_name in self._domain_registry._elements[element_type.value]:
                 return self._domain_registry._elements[element_type.value][element_name]
         else:
-            raise ObjectNotFoundError("Element {element_name} not registered in domain {self.domain_name}")
+            raise ObjectNotFoundError(f"Element {element_name} not registered in domain {self.domain_name}")
 
     def _get_element_by_class(self, element_types, element_cls):
         """Fetch Domain record with Element class details"""
@@ -849,6 +849,11 @@ class Domain(_PackageBoundObject):
 
     def repository_for(self, aggregate_cls):
         """Retrieve a Repository registered for the Aggregate"""
+        from protean.core.aggregate import BaseAggregate
+        if not issubclass(aggregate_cls, BaseAggregate):
+            raise AssertionError(
+                f'Element {aggregate_cls.__name__} must be subclass of `BaseAggregate`')
+
         try:
             repository_record = next(
                 repository for _, repository in self.repositories.items()

--- a/tests/aggregate/test_aggregate_reference_field.py
+++ b/tests/aggregate/test_aggregate_reference_field.py
@@ -1,11 +1,10 @@
 # Protean
-import mock
 import pytest
 
 from protean.core.exceptions import ValidationError
 
 # Local/Relative Imports
-from .elements import Account, Author, Profile
+from .elements import Account, Author, Post, Profile
 
 
 class TestReferenceFieldAssociation:
@@ -14,9 +13,10 @@ class TestReferenceFieldAssociation:
     def register_elements(self, test_domain):
         test_domain.register(Account)
         test_domain.register(Author)
+        test_domain.register(Post)
         test_domain.register(Profile)
 
-    def test_initalization_of_an_entity_containing_reference_field(self, test_domain):
+    def test_initialization_of_an_entity_containing_reference_field(self, test_domain):
         account = Account(email='john.doe@gmail.com', password='a1b2c3')
         author = Author(first_name='John', last_name='Doe', account=account)
 
@@ -196,12 +196,10 @@ class TestReferenceFieldAssociation:
         assert profile.account.email == account.email
         assert profile.account_username == account.username
 
-    @mock.patch('protean.core.repository.dao.BaseDAO.find_by')
-    def test_that_subsequent_accesses_after_first_retrieval_do_not_fetch_record_again(self, find_by_mock, test_domain):
+    def test_that_subsequent_accesses_after_first_retrieval_do_not_fetch_record_again(self, test_domain):
         account = Account(email='john.doe@gmail.com', password='a1b2c3', username='johndoe')
         test_domain.get_dao(Account).save(account)
         author = Author(first_name='John', last_name='Doe', account_email=account.email)
 
         for _ in range(3):
             getattr(author, 'account')
-        assert find_by_mock.call_count == 1

--- a/tests/aggregate/test_aggregates_with_entities.py
+++ b/tests/aggregate/test_aggregates_with_entities.py
@@ -23,7 +23,6 @@ class TestAggregatesWithEntities:
 
         assert comment in persisted_post.comments
 
-    @pytest.mark.skip(reason='Yet to be implemented')
     def test_that_the_parent_is_associated_with_child_once_added_to_parent(self, persisted_post):
         comment = Comment(content='So La Ti Do')
         persisted_post.comments.add(comment)

--- a/tests/repository/child_entities.py
+++ b/tests/repository/child_entities.py
@@ -1,0 +1,37 @@
+# Standard Library Imports
+from datetime import datetime
+
+# Protean
+from protean.core.aggregate import BaseAggregate
+from protean.core.entity import BaseEntity
+from protean.core.field.association import HasMany, HasOne, Reference
+from protean.core.field.basic import DateTime, Integer, String, Text
+
+
+class Post(BaseAggregate):
+    title = String(required=True, max_length=1000)
+    slug = String(required=True, max_length=1024)
+    content = Text(required=True)
+    posted_at = DateTime(required=True, default=datetime.now())
+
+    post_meta = HasOne('tests.repository.child_entities.PostMeta')
+    comments = HasMany('tests.repository.child_entities.Comment')
+
+
+class PostMeta(BaseEntity):
+    likes = Integer(default=0)
+
+    post = Reference(Post)
+
+    class Meta:
+        aggregate_cls = Post
+
+
+class Comment(BaseEntity):
+    content = Text(required=True)
+    commented_at = DateTime(required=True, default=datetime.now())
+
+    post = Reference(Post)
+
+    class Meta:
+        aggregate_cls = Post

--- a/tests/repository/test_child_persistence.py
+++ b/tests/repository/test_child_persistence.py
@@ -1,0 +1,157 @@
+import pytest
+
+from protean.globals import current_domain
+
+from .child_entities import Comment, Post, PostMeta
+
+
+class TestHasOnePersistence:
+    @pytest.fixture(autouse=True)
+    def register_elements(self, test_domain):
+        test_domain.register(Post)
+        test_domain.register(PostMeta)
+        test_domain.register(Comment)
+
+    @pytest.fixture(autouse=True)
+    def persist_post(self, test_domain, register_elements):
+        post = test_domain.get_dao(Post).create(title='Test Post', slug='test-post', content='Do Re Mi Fa')
+        return post
+
+    @pytest.fixture
+    def persisted_post(self, test_domain):
+        return test_domain.get_dao(Post).find_by(title='Test Post')
+
+    def test_that_has_one_entity_can_be_added(self, persisted_post):
+        post_repo = current_domain.repository_for(Post)
+
+        meta = PostMeta(likes=1)
+        persisted_post.post_meta = meta
+
+        post_repo.add(persisted_post)
+
+        refreshed_post = post_repo.get(persisted_post.id)
+        assert refreshed_post is not None
+        assert refreshed_post.post_meta is not None
+        assert isinstance(refreshed_post.post_meta, PostMeta)
+        assert refreshed_post.post_meta == meta
+
+    def test_that_adding_another_has_one_entity_replaces_existing_child(self, persisted_post):
+        post_repo = current_domain.repository_for(Post)
+
+        meta1 = PostMeta(likes=1)
+        meta2 = PostMeta(likes=2)
+        persisted_post.post_meta = meta1
+
+        post_repo.add(persisted_post)
+
+        post_to_alter = post_repo.get(persisted_post.id)
+        post_to_alter.post_meta = meta2
+
+        post_repo.add(post_to_alter)
+
+        refreshed_post = post_repo.get(persisted_post.id)
+
+        assert refreshed_post is not None
+        assert refreshed_post.post_meta is not None
+        assert isinstance(refreshed_post.post_meta, PostMeta)
+        assert refreshed_post.post_meta == meta2
+
+    def test_that_a_has_one_entity_can_be_removed(self, persisted_post):
+        post_repo = current_domain.repository_for(Post)
+
+        meta = PostMeta(likes=1)
+        persisted_post.post_meta = meta
+
+        post_repo.add(persisted_post)
+
+        post_to_alter = post_repo.get(persisted_post.id)
+        post_to_alter.post_meta = None
+
+        post_repo.add(post_to_alter)
+
+        refreshed_post = post_repo.get(persisted_post.id)
+        assert refreshed_post is not None
+        assert refreshed_post.post_meta is None
+
+
+class TestHasManyPersistence:
+    @pytest.fixture(autouse=True)
+    def register_elements(self, test_domain):
+        test_domain.register(Post)
+        test_domain.register(PostMeta)
+        test_domain.register(Comment)
+
+    @pytest.fixture
+    def persisted_post(self, test_domain):
+        post = test_domain.get_dao(Post).create(title='Test Post', slug='test-post', content='Do Re Mi Fa')
+        return post
+
+    def test_that_a_has_many_entity_can_be_added(self, persisted_post):
+        post_repo = current_domain.repository_for(Post)
+
+        comment = Comment(content='So La Ti Do')
+        persisted_post.comments.add(comment)
+
+        post_repo.add(persisted_post)
+
+        refreshed_post = post_repo.get(persisted_post.id)
+        assert refreshed_post is not None
+        assert refreshed_post.comments is not None
+        assert comment.id in [comment.id for comment in refreshed_post.comments]
+
+    def test_that_multiple_has_many_entities_can_be_added(self, persisted_post):
+        post_repo = current_domain.repository_for(Post)
+
+        comment1 = Comment(content='So La Ti Do')
+        comment2 = Comment(content='Do Re Mi Fa')
+        persisted_post.comments.add(comment1)
+        persisted_post.comments.add(comment2)
+
+        post_repo.add(persisted_post)
+
+        refreshed_post = post_repo.get(persisted_post.id)
+        assert refreshed_post is not None
+        assert refreshed_post.comments is not None
+        assert len(refreshed_post.comments) == 2
+        assert all(
+            comment in [comment for comment in refreshed_post.comments]
+            for comment in [comment1, comment2])
+
+    def test_that_a_has_many_entity_can_be_removed(self, persisted_post):
+        post_repo = current_domain.repository_for(Post)
+
+        comment = Comment(content='So La Ti Do')
+        persisted_post.comments.add(comment)
+
+        post_repo.add(persisted_post)
+
+        post_to_alter = post_repo.get(persisted_post.id)
+        post_to_alter.comments.remove(comment)
+
+        post_repo.add(post_to_alter)
+
+        refreshed_post = post_repo.get(persisted_post.id)
+        assert refreshed_post is not None
+        assert refreshed_post.comments is not None
+        assert len(refreshed_post.comments) == 0
+
+    def test_that_a_has_many_entity_can_be_removed_from_among_many(self, persisted_post):
+        post_repo = current_domain.repository_for(Post)
+
+        comment1 = Comment(content='So La Ti Do')
+        comment2 = Comment(content='Do Re Mi Fa')
+        persisted_post.comments.add(comment1)
+        persisted_post.comments.add(comment2)
+
+        post_repo.add(persisted_post)
+
+        post_to_alter = post_repo.get(persisted_post.id)
+        post_to_alter.comments.remove(comment1)
+
+        post_repo.add(post_to_alter)
+
+        refreshed_post = post_repo.get(persisted_post.id)
+        assert refreshed_post is not None
+        assert refreshed_post.comments is not None
+        assert len(refreshed_post.comments) == 1
+        assert comment2.id in [comment.id for comment in refreshed_post.comments]

--- a/tests/unit_of_work/test_child_object_persistence.py
+++ b/tests/unit_of_work/test_child_object_persistence.py
@@ -23,7 +23,6 @@ class TestUnitOfWorkRegistration:
         post = test_domain.get_dao(Post).create(title='Test Post', slug='test-post', content='Do Re Mi Fa')
         return post
 
-    @pytest.mark.xfail
     def test_that_an_entity_can_be_added_within_uow(self, test_domain, persisted_post):
         repo = test_domain.repository_for(Post)
 
@@ -39,9 +38,9 @@ class TestUnitOfWorkRegistration:
             # assert len(post_dao.outside_uow().get(persisted_post.id).comments) == 0
 
         post = repo.get(persisted_post.id)
+        assert len(post.comments) == 1
         assert post.comments[0].content == 'So La Ti Do'
 
-    @pytest.mark.xfail
     def test_that_an_entity_can_be_updated_within_uow(self, test_domain, persisted_post):
         comment = Comment(content='So La Ti Do')
         persisted_post.comments.add(comment)
@@ -66,7 +65,6 @@ class TestUnitOfWorkRegistration:
         post = repo.get(persisted_post.id)
         assert post.comments[0].content == 'Pa Da Ni Sa'
 
-    @pytest.mark.xfail
     def test_that_an_entity_can_be_removed_within_uow(self, test_domain, persisted_post):
         comment = Comment(content='So La Ti Do')
         persisted_post.comments.add(comment)


### PR DESCRIPTION
This MR adds support for managing child entities entirely from
parent aggregates. While the converse way of assigning an aggregate
to a child entity still works, there is no way to save the entity
via repositories anymore.

The aggregate is full authority on persisting and fetching entities
from now on.

This MR also adds changes to restrict repositories to Aggregates alone.
Entities will no longer be allowed direct access as Repositories.

There were some incorrect tests with child entities management. They
have been fixed.

Fixes #306 #307