### PR TITLE
Allow Postgres Models to choose b/w Pickle or Custom Types

### DIFF
--- a/src/protean/core/field/basic.py
+++ b/src/protean/core/field/basic.py
@@ -143,7 +143,7 @@ class List(Field):
         "invalid_content": "Invalid value",
     }
 
-    def __init__(self, content_type=String, **kwargs):
+    def __init__(self, content_type=String, pickled=False, **kwargs):
         if content_type not in [
             String,
             Integer,
@@ -155,54 +155,7 @@ class List(Field):
         ]:
             raise ValidationError({"content_type": ["Content type not supported"]})
         self.content_type = content_type
-
-        super().__init__(**kwargs)
-
-    def _cast_to_type(self, value):
-        """ Raise errors if the value is not a list, or
-        the items in the list are not of the right data type.
-        """
-        if not isinstance(value, list):
-            self.fail("invalid", value=value)
-
-        # Try to cast value into the destination type.
-        #   Throw error if the underlying type does not support value.
-        new_value = []
-        try:
-            for item in value:
-                new_value.append(self.content_type()._load(item))
-        except ValidationError:
-            self.fail("invalid_content", value=value)
-
-        if new_value != value:
-            self.fail("invalid_content", value=value)
-
-        return value
-
-
-class Array(Field):
-    """Concrete field implementation for the Array type.
-
-    This field is supported only for Postgresql database.
-    """
-
-    default_error_messages = {
-        "invalid": '"{value}" value must be of list type.',
-        "invalid_content": "Invalid value",
-    }
-
-    def __init__(self, content_type=String, **kwargs):
-        if content_type not in [
-            String,
-            Integer,
-            Identifier,
-            Float,
-            Date,
-            DateTime,
-            Boolean,
-        ]:
-            raise ValidationError({"content_type": ["Content type not supported"]})
-        self.content_type = content_type
+        self.pickled = pickled
 
         super().__init__(**kwargs)
 
@@ -250,6 +203,11 @@ class Dict(Field):
     default_error_messages = {
         "invalid": '"{value}" value must be of dict type.',
     }
+
+    def __init__(self, content_type=String, pickled=False, **kwargs):
+        self.pickled = pickled
+
+        super().__init__(**kwargs)
 
     def _cast_to_type(self, value):
         """ Raise error if the value is not a dict """

--- a/src/protean/impl/repository/sqlalchemy_repo.py
+++ b/src/protean/impl/repository/sqlalchemy_repo.py
@@ -10,8 +10,6 @@ from typing import Any
 from protean.core.exceptions import ConfigurationError, ObjectNotFoundError
 from protean.core.field.association import Reference
 from protean.core.field.basic import (
-    JSON,
-    Array,
     Auto,
     Boolean,
     Date,
@@ -111,7 +109,6 @@ class DeclarativeMeta(sa_dec.DeclarativeMeta, ABCMeta):
         # Update the class attrs with the entity attributes
 
         field_mapping = {
-            Array: sa_types.ARRAY,
             Auto: _get_identity_type(),
             Boolean: sa_types.Boolean,
             Date: sa_types.Date,
@@ -120,7 +117,6 @@ class DeclarativeMeta(sa_dec.DeclarativeMeta, ABCMeta):
             Float: sa_types.Float,
             Identifier: _get_identity_type(),
             Integer: sa_types.Integer,
-            JSON: sa_types.JSON,
             List: sa_types.PickleType,
             String: sa_types.String,
             Text: sa_types.Text,
@@ -140,13 +136,15 @@ class DeclarativeMeta(sa_dec.DeclarativeMeta, ABCMeta):
                     # Get the SA type
                     sa_type_cls = field_mapping.get(field_cls)
 
+                    if field_cls == List:
+                        type_args.append(field_mapping.get(field_obj.content_type))
+
                     # Upgrade to Postgresql specific Data Types
                     if cls.metadata.bind.dialect.name == "postgresql":
-                        if field_cls == Dict:
-                            sa_type_cls = field_mapping.get(JSON)
-                        if field_cls == List:
-                            sa_type_cls = field_mapping.get(Array)
-                            type_args.append(field_mapping.get(field_obj.content_type))
+                        if field_cls == Dict and not field_obj.pickled:
+                            sa_type_cls = sa_types.JSON
+                        if field_cls == List and not field_obj.pickled:
+                            sa_type_cls = sa_types.ARRAY
 
                     # Default to the text type if no mapping is found
                     if not sa_type_cls:

--- a/src/protean/impl/repository/sqlalchemy_repo.py
+++ b/src/protean/impl/repository/sqlalchemy_repo.py
@@ -32,7 +32,7 @@ from protean.utils import Database, IdentityType
 from protean.utils.query import Q
 from sqlalchemy import Column, MetaData, and_, create_engine, or_, orm
 from sqlalchemy import types as sa_types
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import UUID, ARRAY, JSON
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.exc import DatabaseError
 from sqlalchemy.ext import declarative as sa_dec
@@ -142,9 +142,9 @@ class DeclarativeMeta(sa_dec.DeclarativeMeta, ABCMeta):
                     # Upgrade to Postgresql specific Data Types
                     if cls.metadata.bind.dialect.name == "postgresql":
                         if field_cls == Dict and not field_obj.pickled:
-                            sa_type_cls = sa_types.JSON
+                            sa_type_cls = JSON
                         if field_cls == List and not field_obj.pickled:
-                            sa_type_cls = sa_types.ARRAY
+                            sa_type_cls = ARRAY
 
                     # Default to the text type if no mapping is found
                     if not sa_type_cls:
@@ -669,7 +669,6 @@ operators = {
     "lt": "__lt__",
     "lte": "__le__",
     "in": "in_",
-    "overlap": "overlap",
     "any": "any",
 }
 
@@ -784,24 +783,7 @@ class In(DefaultLookup):
 
 
 @SAProvider.register_lookup
-class Overlap(DefaultLookup):
-    """In Query"""
-
-    lookup_name = "in"
-
-    def process_target(self):
-        """Ensure target is a list or tuple"""
-        assert isinstance(self.target, (list, tuple))
-        return super().process_target()
-
-
-@SAProvider.register_lookup
 class Any(DefaultLookup):
     """In Query"""
 
-    lookup_name = "in"
-
-    def process_target(self):
-        """Ensure target is a list or tuple"""
-        assert isinstance(self.target, (list, tuple))
-        return super().process_target()
+    lookup_name = "any"

--- a/tests/entity/test_fields.py
+++ b/tests/entity/test_fields.py
@@ -1,7 +1,7 @@
 import pytest
 from protean.core.entity import BaseEntity
 from protean.core.exceptions import ValidationError
-from protean.core.field.basic import Array, Boolean, Dict, Integer, JSON, List
+from protean.core.field.basic import Boolean, Dict, Integer, List
 
 
 class TestFields:
@@ -9,15 +9,6 @@ class TestFields:
     def test_list_default(self):
         class Lottery(BaseEntity):
             numbers = List(content_type=Integer)
-
-        lottery = Lottery()
-        assert lottery.numbers is not None
-        assert lottery.numbers == []
-
-    @pytest.mark.xfail  # To be addressed as part of https://github.com/proteanhq/protean/issues/335
-    def test_array_default(self):
-        class Lottery(BaseEntity):
-            numbers = Array(content_type=Integer)
 
         lottery = Lottery()
         assert lottery.numbers is not None
@@ -37,15 +28,6 @@ class TestFields:
     def test_dict_default(self):
         class Lottery(BaseEntity):
             numbers = Dict()
-
-        lottery = Lottery()
-        assert lottery.numbers is not None
-        assert lottery.numbers == {}
-
-    @pytest.mark.xfail  # To be addressed as part of https://github.com/proteanhq/protean/issues/335
-    def test_json_default(self):
-        class Lottery(BaseEntity):
-            numbers = JSON()
 
         lottery = Lottery()
         assert lottery.numbers is not None

--- a/tests/impl/model/sqlalchemy_model/postgresql/conftest.py
+++ b/tests/impl/model/sqlalchemy_model/postgresql/conftest.py
@@ -42,8 +42,10 @@ def setup_db():
         )
         from .test_array_datatype import ArrayUser, IntegerArrayUser
         from .test_json_datatype import Event
+        from .test_lookups import GenericPostgres
 
         domain.register(ArrayUser)
+        domain.register(GenericPostgres)
         domain.register(ComplexUser)
         domain.register(Event)
         domain.register(IntegerArrayUser)
@@ -54,6 +56,7 @@ def setup_db():
         domain.register_model(ProviderCustomModel, entity_cls=Provider)
 
         domain.get_dao(ArrayUser)
+        domain.get_dao(GenericPostgres)
         domain.get_dao(ComplexUser)
         domain.get_dao(Event)
         domain.get_dao(IntegerArrayUser)

--- a/tests/impl/model/sqlalchemy_model/postgresql/test_lookups.py
+++ b/tests/impl/model/sqlalchemy_model/postgresql/test_lookups.py
@@ -1,0 +1,59 @@
+import pytest
+
+# Standard Library Imports
+from datetime import datetime
+
+# Protean
+from protean.core.aggregate import BaseAggregate
+from protean.core.field.basic import List, String
+from protean.impl.repository.sqlalchemy_repo import Any, In
+
+
+class GenericPostgres(BaseAggregate):
+    ids = List()
+    role = String()
+
+
+@pytest.mark.postgresql
+class TestLookups:
+    def test_any_lookup(self, test_domain):
+        model_cls = test_domain.get_model(GenericPostgres)
+
+        identifier = "foobar"
+        lookup = Any("ids", identifier, model_cls)
+        expr = lookup.as_expression()
+
+        assert str(expr.compile()) == ":param_1 = ANY (public.any_user.ids)"
+        assert expr.compile().params == {"param_1": "foobar"}
+
+    def test_in_lookup(self, test_domain):
+        model_cls = test_domain.get_model(GenericPostgres)
+
+        target_roles = ["foo", "bar", "baz"]
+        lookup = In("role", target_roles, model_cls)
+        expr = lookup.as_expression()
+
+        assert (
+            str(expr.compile()) == "public.any_user.role IN (:role_1, :role_2, :role_3)"
+        )
+        assert expr.compile().params == {
+            "role_1": "foo",
+            "role_2": "bar",
+            "role_3": "baz",
+        }
+
+    def test__lookup(self, test_domain):
+        model_cls = test_domain.get_model(GenericPostgres)
+
+        target_roles = ["foo", "bar", "baz"]
+        lookup = In("role", target_roles, model_cls)
+        expr = lookup.as_expression()
+
+        assert (
+            str(expr.compile()) == "public.any_user.role IN (:role_1, :role_2, :role_3)"
+        )
+        assert expr.compile().params == {
+            "role_1": "foo",
+            "role_2": "bar",
+            "role_3": "baz",
+        }

--- a/tests/impl/model/sqlalchemy_model/postgresql/test_lookups.py
+++ b/tests/impl/model/sqlalchemy_model/postgresql/test_lookups.py
@@ -23,7 +23,7 @@ class TestLookups:
         lookup = Any("ids", identifier, model_cls)
         expr = lookup.as_expression()
 
-        assert str(expr.compile()) == ":param_1 = ANY (public.any_user.ids)"
+        assert str(expr.compile()) == ":param_1 = ANY (public.generic_postgres.ids)"
         assert expr.compile().params == {"param_1": "foobar"}
 
     def test_in_lookup(self, test_domain):
@@ -34,7 +34,8 @@ class TestLookups:
         expr = lookup.as_expression()
 
         assert (
-            str(expr.compile()) == "public.any_user.role IN (:role_1, :role_2, :role_3)"
+            str(expr.compile())
+            == "public.generic_postgres.role IN (:role_1, :role_2, :role_3)"
         )
         assert expr.compile().params == {
             "role_1": "foo",
@@ -50,7 +51,8 @@ class TestLookups:
         expr = lookup.as_expression()
 
         assert (
-            str(expr.compile()) == "public.any_user.role IN (:role_1, :role_2, :role_3)"
+            str(expr.compile())
+            == "public.generic_postgres.role IN (:role_1, :role_2, :role_3)"
         )
         assert expr.compile().params == {
             "role_1": "foo",

--- a/tests/impl/repository/sqlalchemy_repo/postgresql/test_persistence.py
+++ b/tests/impl/repository/sqlalchemy_repo/postgresql/test_persistence.py
@@ -5,13 +5,13 @@ from datetime import datetime
 import pytest
 
 from protean.core.aggregate import BaseAggregate
-from protean.core.field.basic import JSON, DateTime, String
+from protean.core.field.basic import Dict, DateTime, String
 
 
 class Event(BaseAggregate):
     name = String(max_length=255)
     created_at = DateTime(default=datetime.utcnow())
-    payload = JSON()
+    payload = Dict()
 
 
 @pytest.mark.postgresql


### PR DESCRIPTION
A new kwarg `pickled` has been introduced for `List` and `Dict` field types. When `pickled` is `True`, the database column will be of type `PickleType`. When `False`, columns will be `JSON` or `Array` types.