### PR TITLE
Add separator config for es namespace

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.0
+current_version = 0.8.1
 commit = True
 tag = True
 

--- a/docs/adapters/database.rst
+++ b/docs/adapters/database.rst
@@ -23,7 +23,9 @@ Additional options are available for finer control:
 .. py:data:: NAMESPACE_PREFIX
 
     Index names in Elasticsearch instance are prefixed with the specified string. For example, if the namespace
-    prefix is "prod", the index of an aggregate `Person` will be `prod-person`.
+    prefix is "prod", the index of an aggregate `Person` will be `prod_person`. You can set your own separator
+    by passing `NAMESPACE_SEPARATOR`. For example, if the `NAMESPACE_SEPARATOR` is `-`, the index of the above
+    mentioned aggregate will be `prod-person`.
 
 .. py:data:: SETTINGS
 

--- a/src/protean/adapters/repository/elasticsearch.py
+++ b/src/protean/adapters/repository/elasticsearch.py
@@ -305,8 +305,11 @@ class ESProvider(BaseProvider):
 
         # Prepend Namespace prefix if one has been provided
         if "NAMESPACE_PREFIX" in self.conn_info and self.conn_info["NAMESPACE_PREFIX"]:
+            separator = "_"
+            if "NAMESPACE_SEPARATOR" in self.conn_info and self.conn_info["NAMESPACE_SEPARATOR"]:
+                separator = self.conn_info["NAMESPACE_SEPARATOR"]
             schema_name = (
-                f"{self.conn_info['NAMESPACE_PREFIX']}_{entity_cls.meta_.schema_name}"
+                f"{self.conn_info['NAMESPACE_PREFIX']}{separator}{entity_cls.meta_.schema_name}"
             )
 
         return schema_name

--- a/tests/adapters/model/elasticsearch_model/tests.py
+++ b/tests/adapters/model/elasticsearch_model/tests.py
@@ -136,6 +136,18 @@ class TestModelOptions:
             assert model_cls.__name__ == "PersonModel"
             assert model_cls._index._name == "foo_person"
 
+        def test_generated_index_name_with_namespace_separator(self, test_domain):
+            test_domain.config["DATABASES"]["default"]["NAMESPACE_SEPARATOR"] = "-"
+            class Person(BaseAggregate):
+                name = String(max_length=50, required=True)
+                about = Text()
+
+            test_domain.register(Person)
+            model_cls = test_domain.get_model(Person)
+
+            assert model_cls.__name__ == "PersonModel"
+            assert model_cls._index._name == "foo-person"
+
         def test_explicit_index_name_with_namespace_prefix(self, test_domain):
             class Person(BaseAggregate):
                 name = String(max_length=50, required=True)


### PR DESCRIPTION
Currently, protean uses `underscore` as the default separator to concat `NAMESPACE_PREFIX` and `schema_name`.

Some of the projects have indices name with different separators. So, introducing a new config key `NAMESPACE_SEPARATOR`.