### PR TITLE
Lock SQLAlchemy Version & Handle Exception

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
     name: Python ${{ matrix.python-version }} Tests
 
     services:

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,8 @@ def read(*names, **kwargs):
 
 elasticsearch_requires = ["elasticsearch>=7.13.1", "elasticsearch-dsl>=7.3.0"]
 redis_requires = ["redis==3.5.2"]
-sqlite_requires = ["sqlalchemy>=1.4.9"]
-postgresql_requires = ["psycopg2>=2.8.4", "sqlalchemy>=1.4.1"]
+sqlite_requires = ["sqlalchemy==1.4.47"]
+postgresql_requires = ["psycopg2>=2.8.4", "sqlalchemy==1.4.47"]
 celery_requires = ["celery[redis]~=4.4.2"]
 sendgrid_requires = ["sendgrid>=6.1.3"]
 flask_requires = ["flask>=1.1.1"]

--- a/src/protean/domain/context.py
+++ b/src/protean/domain/context.py
@@ -120,4 +120,4 @@ class DomainContext(object):
         self.pop(exc_value)
 
         if exc_type is not None:
-            raise (exc_type, exc_value, tb)
+            raise exc_type(exc_value, tb)


### PR DESCRIPTION
Locking SQLAlchemy Version at 1.4.47
Upgrading to 2.0.x results in a primary key exception. 

This also fixes Fixes https://github.com/proteanhq/protean/issues/378

Removing 3.7 tests as it is stuck with installation step. Please refer: https://github.com/proteanhq/protean/actions/runs/4509141945/jobs/7939729996