### PR TITLE
Add a description attribute to fields

### DIFF
--- a/src/protean/fields/base.py
+++ b/src/protean/fields/base.py
@@ -56,6 +56,7 @@ class Field(FieldBase, FieldDescriptorMixin, metaclass=ABCMeta):
     def __init__(
         self,
         referenced_as: str = None,
+        description: str = None,
         identifier: bool = False,
         default: Any = None,
         required: bool = False,
@@ -66,7 +67,7 @@ class Field(FieldBase, FieldDescriptorMixin, metaclass=ABCMeta):
     ):
 
         # Pass to FieldDescriptorMixin for initialization
-        super().__init__(referenced_as=referenced_as)
+        super().__init__(referenced_as=referenced_as, description=description)
 
         self.identifier = identifier
         self.default = default

--- a/src/protean/fields/mixins.py
+++ b/src/protean/fields/mixins.py
@@ -1,5 +1,7 @@
 NOT_PROVIDED = object()
 
+import inflection
+
 
 class FieldCacheMixin:
     """Provide an API for working with the entity's fields value cache."""
@@ -35,11 +37,19 @@ class FieldDescriptorMixin:
         # These are set up when the owner (Entity class) adds the field to itself
         self.field_name = None
         self.attribute_name = None
+        self.description = kwargs.pop("description", None)
         self.referenced_as = kwargs.pop("referenced_as", None)
 
     def __set_name__(self, entity_cls, name):
         self.field_name = name
         self.attribute_name = self.get_attribute_name()
+
+        # Set the description for this field
+        self.description = (
+            self.description
+            if self.description
+            else inflection.titleize(self.attribute_name).strip()
+        )
 
         # Record Entity setting up the field
         self._entity_cls = entity_cls

--- a/tests/entity/test_fields.py
+++ b/tests/entity/test_fields.py
@@ -3,6 +3,7 @@ import pytest
 from protean import BaseEntity
 from protean.exceptions import ValidationError
 from protean.fields import Boolean, Dict, Integer, List
+from protean.reflection import fields
 
 
 class TestFields:
@@ -43,3 +44,15 @@ class TestFields:
             Lottery(jackpot=True)
 
         assert exc.value.messages == {"numbers": ["is required"]}
+
+    def test_field_description(self):
+        class Lottery(BaseEntity):
+            jackpot = Boolean(description="Jackpot won or not")
+
+        assert fields(Lottery)["jackpot"].description == "Jackpot won or not"
+
+    def test_field_default_description(self):
+        class Lottery(BaseEntity):
+            jackpot = Boolean()
+
+        assert fields(Lottery)["jackpot"].description == "Jackpot"


### PR DESCRIPTION
Description is preserved when supplied, otherwise one is derived using the field's attribute name, converting underscores to spaces and titleizing the words.

Fixes #376