### PR TITLE
Control domain directory traversal explicitly in `init()`

### DIFF
--- a/config.py
+++ b/config.py
@@ -11,9 +11,6 @@ from protean.utils import (
 class Config:
     DEBUG = True
 
-    # Parse domain directory and autoload domain modules
-    AUTOLOAD_DOMAIN = True
-
     # A secret key for this particular Protean installation. Used in secret-key
     # hashing algorithms.
     SECRET_KEY = os.environ.get(

--- a/docs/user/composing-a-domain.rst
+++ b/docs/user/composing-a-domain.rst
@@ -48,6 +48,9 @@ inject dependencies into the domain elements.
 
 By default, a protean domain is configured to use an in-memory repository. This is useful for testing and prototyping.
 
+If you do not want Protean to traverse the directory structure to discover domain elements, you can pass the
+``traverse`` flag as ``False`` to the ``init`` method.
+
 You can optionally pass a config file to the domain before initializing it. Refer to :doc:`config` to understand the different ways to configure the domain.
 
 Activating a Domain

--- a/docs/user/composing-a-domain.rst
+++ b/docs/user/composing-a-domain.rst
@@ -11,7 +11,7 @@ The Domain is the one-stop gateway to:
 - Retrieve dynamically-constructed artifacts like repositories and models
 - Access injected technology components at runtime
 
-Initializing a Domain
+Define a Domain
 ---------------------
 
 Constructing the object graph is a two-step procedure. First, you initialize a domain object at a reasonable starting
@@ -30,24 +30,25 @@ in application configuration.
 
 .. code-block:: python
 
-    from sample_app import domain
-
     @domain.aggregate
     class User:
         name = String()
         email = String(required=True)
 
 
-Configuring a Domain
---------------------
+Initializing the Domain
+-----------------------
 
-You can pass a config file to the domain, like so:
+Finally, the domain is initialized by calling the ``init`` method. This method will construct the object graph and
+inject dependencies into the domain elements.
 
 .. code-block:: python
 
-    domain.config.from_pyfile(config_path)
+    domain.init()
 
-Refer to :doc:`config` to understand the different ways to configure the domain.
+By default, a protean domain is configured to use an in-memory repository. This is useful for testing and prototyping.
+
+You can optionally pass a config file to the domain before initializing it. Refer to :doc:`config` to understand the different ways to configure the domain.
 
 Activating a Domain
 -------------------
@@ -102,6 +103,8 @@ the ``app`` object.
 
         @app.before_request
         def set_context():
+            domain.init()
+
             # Push up a Domain Context
             # This should be done within Flask App
             context = domain.domain_context()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ click = ">=7.0"
 cookiecutter = ">=1.7.0"
 copier = ">=6.1.0"
 inflection = ">=0.5.1"
+marshmallow = ">=3.15.0"  # FIXME Remove core dependency
 python-dateutil = ">=2.8.2"
 werkzeug = ">=2.0.0"
 
@@ -51,7 +52,6 @@ redis = {version = "~3.5.2", optional = true}
 sqlalchemy = {version = "~1.4.50", optional = true}
 psycopg2 = {version = ">=2.9.9", optional = true}
 celery = { version = "~5.2.7", extras = ["redis"], optional = true}
-marshmallow = {version = ">=3.15.0", optional = true}
 flask = {version = ">=1.1.1", optional = true}
 sendgrid = {version = ">=6.1.3", optional = true}
 message-db-py = {version = ">=0.1.2", optional = true}
@@ -63,7 +63,6 @@ postgresql = ["sqlalchemy", "psycopg2"]
 sqlite = ["sqlalchemy"]
 celery = ["celery"]
 message-db = ["message-db-py"]
-marshmallow = ["marshmallow"]
 flask = ["flask"]
 sendgrid = ["sendgrid"]
 

--- a/src/protean/domain/__init__.py
+++ b/src/protean/domain/__init__.py
@@ -96,7 +96,6 @@ class Domain(_PackageBoundObject):
             "ENV": None,
             "DEBUG": None,
             "SECRET_KEY": None,
-            "AUTOLOAD_DOMAIN": True,
             "IDENTITY_STRATEGY": IdentityStrategy.UUID.value,
             "IDENTITY_TYPE": IdentityType.STRING.value,
             "DATABASES": {
@@ -171,15 +170,14 @@ class Domain(_PackageBoundObject):
         # FIXME Should all protean elements be subclassed from a base element?
         self._pending_class_resolutions: dict[str, Any] = defaultdict(list)
 
-    def init(self):  # noqa: C901
+    def init(self, traverse=True):  # noqa: C901
         """Parse the domain folder, and attach elements dynamically to the domain.
 
         Protean parses all files in the domain file's folder, as well as under it,
         to load elements. So, all domain files are to be nested under the file contain
         the domain definition.
 
-        One can use the `AUTOLOAD_DOMAIN` flag in Protean config, `True` by default,
-        to control this functionality.
+        One can use the `traverse` flag to control this functionality, `True` by default.
 
         When enabled, Protean is responsible for loading domain elements and ensuring
         all functionality is activated.
@@ -194,7 +192,7 @@ class Domain(_PackageBoundObject):
 
         This method bubbles up circular import issues, if present, in the domain code.
         """
-        if self.config["AUTOLOAD_DOMAIN"] is True:
+        if traverse is True:
             # Standard Library Imports
             import importlib.util
             import inspect


### PR DESCRIPTION
By default, Protean will try to traverse the domain's directory to discover elements.

The flag `traverse` can be used to skip traversing the directory if the entire domain code is in a single file or the elements are being registered manually. 