### PR TITLE
CLI commands refactoring

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: 24.2.0
     hooks:
       - id: black
-        language_version: python3.8
+        language_version: python3
 
   - repo: git@github.com:PyCQA/autoflake.git
     rev: v2.3.1

--- a/src/protean/cli.py
+++ b/src/protean/cli.py
@@ -425,3 +425,14 @@ def server(
 
     engine = Engine(domain, test_mode=test_mode)
     engine.run()
+
+
+@app.command()
+def generate_docker_compose(
+    domain_path: Annotated[str, typer.Argument()] = "",
+):
+    """Generate a `docker-compose.yml` from Domain config"""
+    domain = derive_domain(domain_path)
+    domain.init()
+
+    # FIXME Generate docker-compose.yml from domain config

--- a/src/protean/exceptions.py
+++ b/src/protean/exceptions.py
@@ -1,6 +1,7 @@
 """
 Custom Protean exception classes
 """
+
 import logging
 
 logger = logging.getLogger(__name__)
@@ -19,6 +20,10 @@ class ProteanException(Exception):
 
     def __reduce__(self):
         return (ProteanException, (self.messages,))
+
+
+class NoDomainException(ProteanException):
+    """Raised if a domain cannot be found or loaded in a module"""
 
 
 class ConfigurationError(Exception):

--- a/tests/cli/test_domain_loading.py
+++ b/tests/cli/test_domain_loading.py
@@ -8,7 +8,7 @@ import pytest
 from typer.testing import CliRunner
 
 from protean import Domain
-from protean.cli import NoDomainException, derive_domain, find_best_domain
+from protean.cli import NoDomainException, derive_domain, find_domain_in_module
 
 
 @pytest.fixture
@@ -16,37 +16,37 @@ def runner():
     return CliRunner()
 
 
-def test_find_best_domain():
+def test_find_domain_in_module():
     class Module:
         domain = Domain(__file__, "name")
 
-    assert find_best_domain(Module) == Module.domain
+    assert find_domain_in_module(Module) == Module.domain
 
     class Module:
         subdomain = Domain(__file__, "name")
 
-    assert find_best_domain(Module) == Module.subdomain
+    assert find_domain_in_module(Module) == Module.subdomain
 
     class Module:
         my_domain = Domain(__file__, "name")
 
-    assert find_best_domain(Module) == Module.my_domain
+    assert find_domain_in_module(Module) == Module.my_domain
 
     class Module:
         pass
 
-    pytest.raises(NoDomainException, find_best_domain, Module)
+    pytest.raises(NoDomainException, find_domain_in_module, Module)
 
     class Module:
         my_domain1 = Domain(__file__, "name1")
         my_domain2 = Domain(__file__, "name2")
 
-    pytest.raises(NoDomainException, find_best_domain, Module)
+    pytest.raises(NoDomainException, find_domain_in_module, Module)
 
     class Module:
         foo = "bar"
 
-    pytest.raises(NoDomainException, find_best_domain, Module)
+    pytest.raises(NoDomainException, find_domain_in_module, Module)
 
 
 class TestDomainLoading:

--- a/tests/cli/test_find_domain_by_string.py
+++ b/tests/cli/test_find_domain_by_string.py
@@ -1,0 +1,91 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from protean import Domain
+from protean.cli import NoDomainException, find_domain_by_string
+
+
+class MagicMockWithName(MagicMock):
+    __name__ = "mock_module"
+
+
+@pytest.fixture
+def mock_module():
+    module = MagicMockWithName()
+
+    # Configure the module for different test scenarios
+    module.valid_domain = Domain(__file__)
+    module.not_a_domain = "not a domain instance"
+    return module
+
+
+def test_find_domain_by_string_with_empty_domain_name(mock_module):
+    with pytest.raises(NoDomainException) as exc_info:
+        find_domain_by_string(mock_module, "")
+    assert "Failed to parse" in str(
+        exc_info.value
+    ), "Should raise exception for empty domain name"
+
+
+def test_find_domain_by_string_with_whitespace_domain_name(mock_module):
+    mock_module.valid_domain = Domain(__file__)
+    domain = find_domain_by_string(mock_module, " valid_domain ")
+    assert isinstance(
+        domain, Domain
+    ), "Should correctly ignore leading/trailing whitespace"
+
+
+def test_find_domain_by_string_with_none_as_domain(mock_module):
+    mock_module.none_domain = None  # Set a None domain
+    with pytest.raises(NoDomainException) as exc_info:
+        find_domain_by_string(mock_module, "none_domain")
+    assert "A valid Protean domain was not obtained" in str(
+        exc_info.value
+    ), "Should raise exception when the domain is None"
+
+
+def test_find_domain_by_string_with_valid_domain(mock_module):
+    domain = find_domain_by_string(mock_module, "valid_domain")
+    assert isinstance(domain, Domain), "Should return a Domain instance"
+
+
+def test_find_domain_by_string_with_non_domain(mock_module):
+    with pytest.raises(NoDomainException) as exc_info:
+        find_domain_by_string(mock_module, "not_a_domain")
+    assert "A valid Protean domain was not obtained" in str(exc_info.value)
+
+
+def test_find_domain_by_string_with_invalid_syntax():
+    with pytest.raises(NoDomainException) as exc_info:
+        find_domain_by_string(None, "invalid syntax!")
+    assert "Failed to parse" in str(exc_info.value)
+
+
+def test_find_domain_by_string_with_nonexistent_attribute(mock_module):
+    with pytest.raises(NoDomainException) as exc_info:
+        find_domain_by_string(mock_module, "nonexistent")
+    assert "A valid Protean domain was not obtained from " in str(exc_info.value)
+
+
+def test_find_domain_by_string_with_function_call(mock_module):
+    mock_module.domain_function = MagicMock(return_value=Domain(__file__))
+    domain = find_domain_by_string(mock_module, "domain_function()")
+    assert isinstance(domain, Domain), "Should handle function calls correctly"
+
+
+def test_find_domain_by_string_with_function_call_with_arguments(mock_module):
+    with pytest.raises(NoDomainException) as exc_info:
+        find_domain_by_string(mock_module, "domain_function(arg1, arg2)")
+    assert "Function calls with arguments are not supported" in str(
+        exc_info.value
+    ), "Should raise exception for function calls with arguments"
+
+
+def test_find_domain_by_string_returns_correct_domain_instance(mock_module):
+    expected_domain = Domain(__file__)
+    mock_module.specific_domain = expected_domain
+    actual_domain = find_domain_by_string(mock_module, "specific_domain")
+    assert (
+        actual_domain is expected_domain
+    ), "Should return the specific Domain instance associated with 'specific_domain'"

--- a/tests/cli/test_generate_docker_compose.py
+++ b/tests/cli/test_generate_docker_compose.py
@@ -1,0 +1,81 @@
+import os
+import sys
+
+from pathlib import Path
+
+import pytest
+
+from protean.cli import derive_domain, generate_docker_compose
+
+
+def change_working_directory_to(path):
+    """Change working directory to a specific test directory
+    and add it to the Python path so that the test can import.
+
+    The test directory is expected to be in `support/test_domains`.
+    """
+    test_path = (
+        Path(__file__) / ".." / ".." / "support" / "test_domains" / path
+    ).resolve()
+
+    os.chdir(test_path)
+    sys.path.insert(0, test_path)
+
+
+class TestGenerateDockerCompose:
+    @pytest.fixture(autouse=True)
+    def reset_path(self, request):
+        """Reset sys.path after every test run"""
+        original_path = sys.path[:]
+        cwd = Path.cwd()
+
+        yield
+
+        sys.path[:] = original_path
+        os.chdir(cwd)
+
+    class TestGenerateSqliteService:
+        @pytest.mark.sqlite
+        def test_correct_config_is_loaded(self):
+            """Test that the correct configuration is loaded for SQLite database"""
+            change_working_directory_to("test8")
+
+            domain = derive_domain("sqlite_domain")
+            domain.init()
+            assert domain is not None
+            assert domain.domain_name == "SQLite-Domain"
+            assert (
+                domain.providers["default"].conn_info["PROVIDER"]
+                == "protean.adapters.repository.sqlalchemy.SAProvider"
+            )
+            assert domain.providers["default"].conn_info["DATABASE"] == "sqlite"
+            assert domain.providers["default"]._engine.url.database == ":memory:"
+            assert domain.providers["default"]._engine.url.drivername == "sqlite"
+
+        @pytest.mark.sqlite
+        def test_docker_compose_is_generated(self):
+            """Test that the docker-compose.yml file is generated for SQLite database"""
+            change_working_directory_to("test8")
+
+            generate_docker_compose("sqlite_domain")
+
+            # FIXME - This test is failing because the docker-compose.yml file is not being generated
+            #   A few example tests have been provided as illustration.
+
+            # Assert that the docker-compose.yml file is generated in the same directory as the domain file
+            # assert Path("docker-compose.yml").exists()
+            # assert Path("docker-compose.yml").is_file()
+
+            # with open("docker-compose.yml", "r") as f:
+            #     content = f.read()
+
+            #     assert "version: '3.8'" in content
+            #     assert "services:" in content
+            #     assert "sqlite:" in content
+            #     assert "image: sqlite" in content
+            #     assert "container_name: sqlite" in content
+            #     assert "restart: always" in content
+            #     assert "volumes:" in content
+            #     assert "sqlite:/var/lib/sqlite" in content
+            #     assert "networks:" in content
+            #     assert "default:" in content

--- a/tests/support/test_domains/test8/sqlite_domain.py
+++ b/tests/support/test_domains/test8/sqlite_domain.py
@@ -1,0 +1,12 @@
+from protean.domain import Domain
+
+domain = Domain(__file__, "SQLite-Domain")
+
+
+domain.config["DATABASES"] = {
+    "default": {
+        "PROVIDER": "protean.adapters.repository.sqlalchemy.SAProvider",
+        "DATABASE": "sqlite",
+        "DATABASE_URI": "sqlite:///:memory:",
+    }
+}


### PR DESCRIPTION
- Move NoDomainException to the central `protean.exceptions` module
- Rename `find_best_domain` to `find_domain_in_module`
- Refactor `test` method to run core tests by default + misc fixes
- Refactor and test `find_domain_by_string` function
- Add placeholder for docker-compose generation command