### PR TITLE
Enhance support for different identity types in `Identifier` field

### DIFF
--- a/docs/guides/domain-definition/fields.md
+++ b/docs/guides/domain-definition/fields.md
@@ -1,7 +1,173 @@
 # Fields (draft)
 
-Fields are attributes that define the structure of data container elements in
-Protean.
+As we saw with Aggregates, Entities, and Value Objects, fields are attributes
+that define the structure of data container elements.
+
+This document lists all field types and their options available in Protean,
+and their built-in capabilities.
+
+## Options
+
+### `required`
+
+If `True`, the field is not allowed to be blank. Default is `False`.
+
+```python hl_lines="9"
+{! docs_src/guides/domain-definition/fields/001.py !}
+```
+
+Leaving the field blank or not specifying a value will raise a
+`ValidationError`:
+
+```shell hl_lines="4"
+In [1]: p = Person()
+ERROR: Error during initialization: {'name': ['is required']}
+...
+ValidationError: {'name': ['is required']}
+```
+
+### `identifier`
+
+If True, the field is the primary identifier for the entity (a la _primary key_
+in RDBMS).
+
+```python hl_lines="9"
+{! docs_src/guides/domain-definition/fields/002.py !}
+```
+
+The field is validated to be unique and non-blank:
+
+```shell hl_lines="6 11"
+In [1]: from protean.reflection import declared_fields
+
+In [2]: p = Person(email='john.doe@example.com', name='John Doe')
+
+In [3]: declared_fields(p)
+Out[3]: {'email': String(identifier=True), 'name': String(required=True)}
+
+In [4]: p = Person(name='John Doe')
+ERROR: Error during initialization: {'email': ['is required']}
+...
+ValidationError: {'email': ['is required']}
+```
+
+Aggregates and Entities need at least one field to be marked as an identifier.
+If you don’t specify one, Protean will automatically add a field called `id`
+to act as the primary identifier. This means that you don’t need to explicitly
+set `identifier=True` on any of your fields unless you want to override the
+default behavior or the name of the field.
+
+Alternatively, you can use [`Identifier`](#identifier-field) field type for
+primary identifier fields.
+
+By default, Protean dynamically generates UUIDs as values of identifier fields
+unless explicitly provided. You can customize the type of value accepted with
+`identity-strategy` config parameter. More details are in
+[Configuration](../compose-a-domain/configuration.md) section.
+
+### `default`
+
+The default value assigned to the field on initialization.
+
+This can be a value or a callable object. If callable, the function will be
+called every time a new object is created.
+
+```python hl_lines="16"
+{! docs_src/guides/domain-definition/fields/003.py !}
+```
+
+```shell hl_lines="6"
+In [1]: post = Post(title='Foo')
+
+In [2]: post.to_dict()
+Out[2]: 
+{'title': 'Foo',
+ 'created_at': '2024-05-09 00:58:10.781744+00:00',
+ 'id': '4f6b1fef-bc60-44c2-9ba6-6f844e0d31b0'}
+```
+
+#### Mutable object defaults
+
+**IMPORTANT**: The default cannot be a mutable object (list, set, dict, entity
+instance, etc.), because the reference to the same object would be used as the
+default in all instances. Instead, wrap the desired default in a callable.
+
+For example, to specify a default `list` for `List` field, use a function:
+
+```python hl_lines="12"
+{! docs_src/guides/domain-definition/fields/004.py !}
+```
+
+Initializing an Adult aggregate will populate the defaults correctly:
+
+```shell
+In [1]: adult = Adult(name="John Doe")
+
+In [2]: adult.to_dict()
+Out[2]: 
+{'name': 'John Doe',
+ 'topics': ['Music', 'Cinema', 'Politics'],
+ 'id': '14381a6f-b62a-4135-a1d7-d50f68e2afba'}
+```
+
+#### Lambda expressions
+
+You can use lambda expressions to specify an anonymous function:
+
+```python hl_lines="13"
+{! docs_src/guides/domain-definition/fields/005.py !}
+```
+
+```shell hl_lines="4"
+In [1]: dice = Dice()
+
+In [2]: dice.to_dict()
+Out[2]: {'sides': 6, 'id': '0536ade5-f3a4-4e94-8139-8024756659a7'}
+
+In [3]: dice.throw()
+Out[3]: 3
+```
+
+This is a great option when you want to pass parameters to a function.
+
+### `unique`
+
+If True, this field's value must be unique among all entities. 
+
+```python hl_lines="10"
+{! docs_src/guides/domain-definition/fields/006.py !}
+```
+
+Obviously, this field's integrity is enforced at the database layer when an
+entity is persisted. If an entity instance specifies a duplicate value in a
+field marked `unique`, a `ValidationError` will be raised:
+
+```shell hl_lines="11"
+In [1]: p1 = Person(name='John Doe', email='john.doe@example.com')
+
+In [2]: domain.repository_for(Person).add(p1)
+Out[2]: <Person: Person object (id: b2c592d5-bd78-4e1e-a9d1-eea20ab5374a)>
+
+In [3]: p2 = Person(name= 'Jane Doe', email='john.doe@example.com')
+
+In [4]: domain.repository_for(Person).add(p2)
+ERROR: Failed saving entity because {'email': ["Person with email 'john.doe@example.com' is already present."]}
+...
+ValidationError: {'email': ["Person with email 'john.doe@example.com' is already present."]}
+```
+
+We will explore more about persistence in the Application Layer.
+<!-- FIXME Add link to database persistence and aggregate lifecycle -->
+
+## Simple Fields
+
+## Container Fields
+
+## Associations
+
+## Embedded Fields
+
+## Custom Fields
 
 <!-- Be careful not to choose field names that conflict with the
 [Data Container API](../../api/data-containers) like `clean`, `clone`, or

--- a/docs/guides/domain-definition/index.md
+++ b/docs/guides/domain-definition/index.md
@@ -51,3 +51,5 @@ Brokers
 
 CQRS
 Event Sourcing
+
+## Data Container Elements

--- a/docs_src/guides/domain-definition/008.py
+++ b/docs_src/guides/domain-definition/008.py
@@ -13,7 +13,7 @@ def utc_now():
 @publishing.aggregate
 class Post:
     title = String(max_length=50)
-    created_on = DateTime(default=utc_now)
+    created_at = DateTime(default=utc_now)
 
     stats = HasOne("Statistic")
     comments = HasMany("Comment")

--- a/docs_src/guides/domain-definition/fields/001.py
+++ b/docs_src/guides/domain-definition/fields/001.py
@@ -1,0 +1,9 @@
+from protean import Domain
+from protean.fields import String
+
+domain = Domain(__file__)
+
+
+@domain.aggregate
+class Person:
+    name = String(required=True)

--- a/docs_src/guides/domain-definition/fields/002.py
+++ b/docs_src/guides/domain-definition/fields/002.py
@@ -1,0 +1,10 @@
+from protean import Domain
+from protean.fields import String
+
+domain = Domain(__file__)
+
+
+@domain.aggregate
+class Person:
+    email = String(identifier=True)
+    name = String(required=True)

--- a/docs_src/guides/domain-definition/fields/003.py
+++ b/docs_src/guides/domain-definition/fields/003.py
@@ -1,0 +1,16 @@
+from datetime import datetime, timezone
+
+from protean.domain import Domain
+from protean.fields import DateTime, String
+
+publishing = Domain(__name__)
+
+
+def utc_now():
+    return datetime.now(timezone.utc)
+
+
+@publishing.aggregate
+class Post:
+    title = String(max_length=50)
+    created_at = DateTime(default=utc_now)

--- a/docs_src/guides/domain-definition/fields/004.py
+++ b/docs_src/guides/domain-definition/fields/004.py
@@ -1,0 +1,14 @@
+from protean.domain import Domain
+from protean.fields import List, String
+
+domain = Domain(__name__)
+
+
+def standard_topics():
+    return ["Music", "Cinema", "Politics"]
+
+
+@domain.aggregate
+class Adult:
+    name = String(max_length=255)
+    topics = List(default=standard_topics)

--- a/docs_src/guides/domain-definition/fields/005.py
+++ b/docs_src/guides/domain-definition/fields/005.py
@@ -1,0 +1,16 @@
+import random
+
+from protean.domain import Domain
+from protean.fields import Integer
+
+domain = Domain(__name__)
+
+dice_sides = [4, 6, 8, 10, 12, 20]
+
+
+@domain.aggregate
+class Dice:
+    sides = Integer(default=lambda: random.choice(dice_sides))
+
+    def throw(self):
+        return random.randint(1, self.sides)

--- a/docs_src/guides/domain-definition/fields/006.py
+++ b/docs_src/guides/domain-definition/fields/006.py
@@ -1,0 +1,10 @@
+from protean import Domain
+from protean.fields import String
+
+domain = Domain(__file__)
+
+
+@domain.aggregate
+class Person:
+    name = String(required=True)
+    email = String(unique=True)

--- a/src/protean/fields/base.py
+++ b/src/protean/fields/base.py
@@ -99,7 +99,9 @@ class Field(FieldBase, FieldDescriptorMixin, metaclass=ABCMeta):
     def _generic_param_values_for_repr(self):
         """Return the generic parameter values for the Field's repr"""
         values = []
-        if self.required:
+        if self.identifier:
+            values.append("identifier=True")
+        if not self.identifier and self.required:
             values.append("required=True")
         if self.default is not None:
             # If default is a callable, use its name

--- a/src/protean/fields/base.py
+++ b/src/protean/fields/base.py
@@ -23,21 +23,32 @@ class FieldBase:
 
 
 class Field(FieldBase, FieldDescriptorMixin, metaclass=ABCMeta):
-    """Abstract field from which other fields should extend.
+    """
+    Base class for all fields in the Protean framework.
 
-    :param default: If set, this value will be used during entity loading
-    if the field value is missing.
-    :param required: if `True`, Raise a :exc:`ValidationError` if the field
-    value is `None`.
-    :param unique: Indicate if this field needs to be checked for uniqueness.
-    :param choices: Valid choices for this field, if value is not one of the
-    choices a `ValidationError` is raised.
-    :param validators: Optional list of validators to be applied for this field.
-    :param error_messages: Optional list of validators to be applied for
-    this field.
+    Fields are used to define the structure and behavior of attributes in an entity or aggregate.
+    They handle the validation, conversion, and storage of attribute values.
+
+    :param referenced_as: The name of the field as referenced in the database or external systems.
+    :type referenced_as: str, optional
+    :param description: A description of the field.
+    :type description: str, optional
+    :param identifier: Indicates if the field is an identifier for the entity or aggregate.
+    :type identifier: bool, optional
+    :param default: The default value for the field if no value is provided.
+    :type default: Any, optional
+    :param required: Indicates if the field is required (must have a value).
+    :type required: bool, optional
+    :param unique: Indicates if the field values must be unique within the repository.
+    :type unique: bool, optional
+    :param choices: A set of allowed choices for the field value.
+    :type choices: enum.Enum, optional
+    :param validators: Additional validators to apply to the field value.
+    :type validators: Iterable, optional
+    :param error_messages: Custom error messages for different kinds of errors.
+    :type error_messages: dict, optional
     """
 
-    # Default error messages for various kinds of errors.
     default_error_messages = {
         "invalid": "Value is not a valid type for this field.",
         "unique": "{entity_name} with {field_name} '{value}' is already present.",
@@ -99,10 +110,14 @@ class Field(FieldBase, FieldDescriptorMixin, metaclass=ABCMeta):
     def _generic_param_values_for_repr(self):
         """Return the generic parameter values for the Field's repr"""
         values = []
+        if self.description:
+            values.append(f"description='{self.description}'")
         if self.identifier:
             values.append("identifier=True")
         if not self.identifier and self.required:
             values.append("required=True")
+        if self.referenced_as:
+            values.append(f"referenced_as='{self.referenced_as}'")
         if self.default is not None:
             # If default is a callable, use its name
             if callable(self.default):

--- a/tests/dao/test_basics.py
+++ b/tests/dao/test_basics.py
@@ -18,19 +18,6 @@ class TestDAO:
         conn = provider.get_connection()
         assert isinstance(conn._db["data"], dict)
 
-    @pytest.mark.xfail
-    def test_that_fields_can_have_custom_attribute_names(self, test_domain):
-        dao = test_domain.repository_for(Person)._dao
-        person1 = dao.create(id=1, first_name="Athos", last_name="Musketeer", age=2)
-
-        model = dao.model_cls.from_entity(person1)
-        assert all(attribute in model for attribute in ["prenom", "nom_de_famille"])
-
-        entity = dao.model_cls.to_entity(model)
-        assert all(
-            field_name in entity.to_dict() for field_name in ["first_name", "last_name"]
-        )
-
     def test_that_escaped_quotes_in_values_are_handled_properly(self, test_domain):
         test_domain.repository_for(Person)._dao.create(
             id=1, first_name="Athos", last_name="Musketeer", age=2

--- a/tests/field/test_identifier.py
+++ b/tests/field/test_identifier.py
@@ -3,13 +3,15 @@ from uuid import UUID, uuid4
 
 import pytest
 
+from protean import Domain
 from protean.exceptions import ValidationError
 from protean.fields import Identifier
+from protean.utils import IdentityType
 
 
 def test_UUID_identifiers_are_converted_into_strings_in_as_dict():
     uuid_val = uuid4()
-    identifier = Identifier()
+    identifier = Identifier(identity_type=IdentityType.UUID.value)
 
     value = identifier._load(uuid_val)
 
@@ -18,7 +20,7 @@ def test_UUID_identifiers_are_converted_into_strings_in_as_dict():
 
 
 def test_int_identifiers_are_preserved_as_ints_in_as_dict():
-    identifier = Identifier()
+    identifier = Identifier(identity_type=IdentityType.INTEGER.value)
 
     value = identifier._load(42)
 
@@ -42,3 +44,95 @@ def test_that_only_ints_or_strings_are_allowed_in_identifiers():
     for value in invalid_values:
         with pytest.raises(ValidationError):
             identifier._load(value)
+
+
+class TestIdentityType:
+    def test_with_identity_type_as_uuid(self):
+        identifier = Identifier(identity_type=IdentityType.UUID.value)
+        value = identifier._load(uuid4())
+
+        assert isinstance(value, UUID)
+        assert isinstance(identifier.as_dict(value), str)
+
+    def test_with_identity_type_as_int(self):
+        identifier = Identifier(identity_type=IdentityType.INTEGER.value)
+        value = identifier._load(42)
+
+        assert isinstance(value, int)
+        assert identifier.as_dict(value) == 42
+
+    def test_with_identity_type_as_string(self):
+        identifier = Identifier(identity_type=IdentityType.STRING.value)
+        value = identifier._load("42")
+
+        assert isinstance(value, str)
+        assert identifier.as_dict(value) == "42"
+
+    def test_with_identity_type_as_invalid(self):
+        with pytest.raises(ValidationError):
+            Identifier(identity_type="invalid")
+
+    def test_with_invalid_value_for_uuid_identity_type(self):
+        identifier = Identifier(identity_type=IdentityType.UUID.value)
+        with pytest.raises(ValidationError):
+            identifier._load(42)
+
+        with pytest.raises(ValidationError):
+            identifier._load("42")
+
+    def test_with_string_value_for_uuid_identity_type(self):
+        identifier = Identifier(identity_type=IdentityType.UUID.value)
+        uuid_val = uuid4()
+        assert identifier._load(str(uuid_val)) == uuid_val
+
+    def test_with_invalid_value_for_int_identity_type(self):
+        identifier = Identifier(identity_type=IdentityType.INTEGER.value)
+
+        # With INTEGER, Strings that have valid integers or UUIDs should be allowed
+        uuid_val = uuid4()
+        assert identifier._load(uuid_val) == int(uuid_val)
+        assert identifier._load("42") == 42
+
+        with pytest.raises(ValidationError):
+            identifier._load("ABC")
+
+    def test_int_and_uuid_values_for_string_identity_type(self):
+        identifier = Identifier(identity_type=IdentityType.STRING.value)
+
+        # With STRING, a valid UUID will be allowed
+        uuid_val = uuid4()
+        assert identifier._load(uuid_val) == str(uuid_val)
+
+        # With STRING, an INTEGER will be converted to a string
+        identifier._load(42) == "42"
+
+    def test_that_default_is_picked_from_domain_config(self):
+        domain = Domain(__file__)
+
+        # By default, IdentityType is UUID
+        with domain.domain_context():
+            uuid_val = uuid4()
+            identifier = Identifier()
+
+            # Can load UUIDs as Strings
+            assert identifier.identity_type == IdentityType.STRING.value
+            assert identifier._load(str(uuid_val)) == str(uuid_val)
+
+            # Can load arbitrary strings as well
+            assert identifier._load("42") == "42"
+            assert identifier.as_dict("42") == "42"
+
+        domain.config["IDENTITY_TYPE"] = IdentityType.INTEGER.value
+        with domain.domain_context():
+            identifier = Identifier()
+            assert identifier.identity_type == IdentityType.INTEGER.value
+            assert identifier._load(42) == 42
+            assert identifier.as_dict(42) == 42
+
+        domain.config["IDENTITY_TYPE"] = IdentityType.UUID.value
+        with domain.domain_context():
+            uuid_val = uuid4()
+            identifier = Identifier()
+            assert identifier.identity_type == IdentityType.UUID.value
+            assert identifier._load(uuid_val) == uuid_val
+            assert identifier.as_dict(uuid_val) == str(uuid_val)

--- a/tests/field/test_repr.py
+++ b/tests/field/test_repr.py
@@ -1,0 +1,63 @@
+from protean.fields import String, Text
+
+
+def test_identifier_in_repr():
+    email = String(identifier=True)
+    ssn = String(identifier=True, required=True)
+
+    assert repr(email) == str(email) == "String(identifier=True)"
+    assert repr(ssn) == str(ssn) == "String(identifier=True)"
+
+
+def test_required_in_repr():
+    name = String(required=True)
+    email = String(required=True, default="John Doe")
+
+    assert repr(name) == str(name) == "String(required=True)"
+    assert repr(email) == str(email) == "String(required=True, default='John Doe')"
+
+
+def test_string_repr_and_str():
+    str_obj1 = String(max_length=50)
+    str_obj2 = String(min_length=50)
+    str_obj3 = String(sanitize=False)
+    str_obj4 = String(max_length=50, min_length=50, sanitize=False)
+    str_obj5 = String(required=True, default="John Doe")
+    str_obj6 = String(
+        required=True, default="John Doe", min_length=50, max_length=50, sanitize=False
+    )
+
+    assert repr(str_obj1) == str(str_obj1) == "String(max_length=50)"
+    assert repr(str_obj2) == str(str_obj2) == "String(min_length=50)"
+    assert repr(str_obj3) == str(str_obj3) == "String(sanitize=False)"
+    assert (
+        repr(str_obj4)
+        == str(str_obj4)
+        == "String(max_length=50, min_length=50, sanitize=False)"
+    )
+    assert (
+        repr(str_obj5) == str(str_obj5) == "String(required=True, default='John Doe')"
+    )
+    assert (
+        repr(str_obj6)
+        == str(str_obj6)
+        == "String(required=True, default='John Doe', max_length=50, min_length=50, sanitize=False)"
+    )
+
+
+def test_text_repr_and_str():
+    text_obj1 = Text(sanitize=False)
+    text_obj2 = Text(required=True, default="John Doe")
+    text_obj3 = Text(required=True, sanitize=False)
+    text_obj4 = Text(required=True, default="John Doe", sanitize=False)
+
+    assert repr(text_obj1) == str(text_obj1) == "Text(sanitize=False)"
+    assert (
+        repr(text_obj2) == str(text_obj2) == "Text(required=True, default='John Doe')"
+    )
+    assert repr(text_obj3) == str(text_obj3) == "Text(required=True, sanitize=False)"
+    assert (
+        repr(text_obj4)
+        == str(text_obj4)
+        == "Text(required=True, default='John Doe', sanitize=False)"
+    )

--- a/tests/field/test_repr.py
+++ b/tests/field/test_repr.py
@@ -17,6 +17,30 @@ def test_required_in_repr():
     assert repr(email) == str(email) == "String(required=True, default='John Doe')"
 
 
+def test_referenced_as_in_repr():
+    name = String(referenced_as="fullname")
+    email = String(required=True, referenced_as="email_address")
+
+    assert repr(name) == str(name) == "String(referenced_as='fullname')"
+    assert (
+        repr(email)
+        == str(email)
+        == "String(required=True, referenced_as='email_address')"
+    )
+
+
+def test_description_in_repr():
+    permit = String(description="Licences and Approvals", required=True)
+    name = String(description="Full Name", required=True)
+
+    assert (
+        repr(permit)
+        == str(permit)
+        == "String(description='Licences and Approvals', required=True)"
+    )
+    assert repr(name) == str(name) == "String(description='Full Name', required=True)"
+
+
 def test_string_repr_and_str():
     str_obj1 = String(max_length=50)
     str_obj2 = String(min_length=50)

--- a/tests/field/test_string.py
+++ b/tests/field/test_string.py
@@ -1,34 +1,6 @@
 from protean.fields import String
 
 
-def test_string_repr_and_str():
-    str_obj1 = String(max_length=50)
-    str_obj2 = String(min_length=50)
-    str_obj3 = String(sanitize=False)
-    str_obj4 = String(max_length=50, min_length=50, sanitize=False)
-    str_obj5 = String(required=True, default="John Doe")
-    str_obj6 = String(
-        required=True, default="John Doe", min_length=50, max_length=50, sanitize=False
-    )
-
-    assert repr(str_obj1) == str(str_obj1) == "String(max_length=50)"
-    assert repr(str_obj2) == str(str_obj2) == "String(min_length=50)"
-    assert repr(str_obj3) == str(str_obj3) == "String(sanitize=False)"
-    assert (
-        repr(str_obj4)
-        == str(str_obj4)
-        == "String(max_length=50, min_length=50, sanitize=False)"
-    )
-    assert (
-        repr(str_obj5) == str(str_obj5) == "String(required=True, default='John Doe')"
-    )
-    assert (
-        repr(str_obj6)
-        == str(str_obj6)
-        == "String(required=True, default='John Doe', max_length=50, min_length=50, sanitize=False)"
-    )
-
-
 def test_sanitization_option_for_string_fields():
     str_field1 = String()
     assert str_field1.sanitize is True

--- a/tests/field/test_text.py
+++ b/tests/field/test_text.py
@@ -1,24 +1,6 @@
 from protean.fields import Text
 
 
-def test_text_repr_and_str():
-    text_obj1 = Text(sanitize=False)
-    text_obj2 = Text(required=True, default="John Doe")
-    text_obj3 = Text(required=True, sanitize=False)
-    text_obj4 = Text(required=True, default="John Doe", sanitize=False)
-
-    assert repr(text_obj1) == str(text_obj1) == "Text(sanitize=False)"
-    assert (
-        repr(text_obj2) == str(text_obj2) == "Text(required=True, default='John Doe')"
-    )
-    assert repr(text_obj3) == str(text_obj3) == "Text(required=True, sanitize=False)"
-    assert (
-        repr(text_obj4)
-        == str(text_obj4)
-        == "Text(required=True, default='John Doe', sanitize=False)"
-    )
-
-
 def test_sanitization_option_for_text_fields():
     text_field1 = Text()
     assert text_field1.sanitize is True

--- a/tests/views/tests.py
+++ b/tests/views/tests.py
@@ -151,7 +151,7 @@ class TestProperties:
     def test_conversion_of_view_values_to_dict(self):
         person = Person(person_id=12, first_name="John", last_name="Doe")
         assert person.to_dict() == {
-            "person_id": 12,
+            "person_id": "12",
             "first_name": "John",
             "last_name": "Doe",
             "age": 21,
@@ -162,11 +162,11 @@ class TestProperties:
 
         assert (
             str(person)
-            == "Person object ({'person_id': 12, 'first_name': 'John', 'last_name': None, 'age': 21})"
+            == "Person object ({'person_id': '12', 'first_name': 'John', 'last_name': None, 'age': 21})"
         )
         assert (
             repr(person)
-            == "<Person: Person object ({'person_id': 12, 'first_name': 'John', 'last_name': None, 'age': 21})>"
+            == "<Person: Person object ({'person_id': '12', 'first_name': 'John', 'last_name': None, 'age': 21})>"
         )
 
 
@@ -349,7 +349,7 @@ class TestEquivalence:
 
     def test_generated_aggregate_hash(self):
         """Test that the entity's hash is based on its identity"""
-        hashed_id = hash(12345)
+        hashed_id = hash("12345")
 
         person = Person(person_id=12345, first_name="John", last_name="Doe")
         assert hashed_id == hash(


### PR DESCRIPTION
- Accept a parameter called `identity_type` per Entity, that helps customize the type of identifier for itself
- Consider the default `IDENTITY_TYPE` configured at the domain level
- Auto-transform identifiers to relevant identity type value
  - **UUID** and **STRING** (with numerals) to **INT**
  - **INT** and **UUID** to **STRING**
  - **STRING** (with valid UUID string) to **UUID**