### PR TITLE
Add @invariant decorator to explicitly configure invariants

### DIFF
--- a/docs/guides/compose-a-domain/object-model.md
+++ b/docs/guides/compose-a-domain/object-model.md
@@ -9,6 +9,10 @@ document outlines generic aspects that apply to every domain element.
 `Element` is a base class inherited by all domain elements. Currently, it does
 not have any data structures or behavior associated with it.
 
+## Element Type
+
+<Element>.element_type
+
 ## Data Containers
 
 Protean provides data container elements, aligned with DDD principles to model

--- a/docs/guides/domain-definition/fields/simple-fields.md
+++ b/docs/guides/domain-definition/fields/simple-fields.md
@@ -74,6 +74,26 @@ Out[2]:
  'id': '88a21815-7d9b-4138-9cac-5a06889d4318'}
 ```
 
+Protean will intelligently convert a valid date string into a date object, with
+the help of the venerable
+[`dateutil`](https://dateutil.readthedocs.io/en/stable/) module.
+
+```shell
+In [1]: post = Post(title='Foo', published_on="2020-01-01")
+
+In [2]: post.to_dict()
+Out[2]: 
+{'title': 'Foo',
+ 'published_on': '2020-01-01',
+ 'id': 'ffcb3b26-71f0-45d0-8ca0-b71a9603f792'}
+
+In [3]: Post(title='Foo', published_on="2019-02-29")
+ERROR: Error during initialization: {'published_on': ['"2019-02-29" has an invalid date format.']}
+...
+ValidationError: {'published_on': ['"2019-02-29" has an invalid date format.']}
+```
+
+
 ## DateTime
 
 A date and time, represented in Python by a `datetime.datetime` instance.

--- a/src/protean/__init__.py
+++ b/src/protean/__init__.py
@@ -1,6 +1,6 @@
 __version__ = "0.11.0"
 
-from .core.aggregate import BaseAggregate
+from .core.aggregate import BaseAggregate, atomic_change
 from .core.application_service import BaseApplicationService
 from .core.command import BaseCommand
 from .core.command_handler import BaseCommandHandler
@@ -54,4 +54,5 @@ __all__ = [
     "get_version",
     "handle",
     "invariant",
+    "atomic_change",
 ]

--- a/src/protean/__init__.py
+++ b/src/protean/__init__.py
@@ -6,7 +6,7 @@ from .core.command import BaseCommand
 from .core.command_handler import BaseCommandHandler
 from .core.domain_service import BaseDomainService
 from .core.email import BaseEmail
-from .core.entity import BaseEntity
+from .core.entity import BaseEntity, invariant
 from .core.event import BaseEvent
 from .core.event_handler import BaseEventHandler
 from .core.event_sourced_aggregate import BaseEventSourcedAggregate, apply
@@ -53,4 +53,5 @@ __all__ = [
     "current_uow",
     "get_version",
     "handle",
+    "invariant",
 ]

--- a/src/protean/container.py
+++ b/src/protean/container.py
@@ -195,6 +195,7 @@ class BaseContainer(metaclass=ContainerMeta):
         This initialization technique supports keyword arguments as well as dictionaries. You
             can even use a template for initial data.
         """
+        self._initialized = False
 
         if self.meta_.abstract is True:
             raise NotSupportedError(
@@ -265,6 +266,8 @@ class BaseContainer(metaclass=ContainerMeta):
 
         self.defaults()
 
+        self._initialized = True
+
         # `clean()` will return a `defaultdict(list)` if errors are to be raised
         custom_errors = self.clean() or {}
         for field in custom_errors:
@@ -329,6 +332,7 @@ class BaseContainer(metaclass=ContainerMeta):
                 "_initialized",  # Flag to indicate if the entity has been initialized
                 "_root",  # Root entity in the hierarchy
                 "_owner",  # Owner entity in the hierarchy
+                "_disable_invariant_checks",  # Flag to disable invariant checks
             ]
             or name.startswith(("add_", "remove_"))
         ):

--- a/src/protean/container.py
+++ b/src/protean/container.py
@@ -320,7 +320,16 @@ class BaseContainer(metaclass=ContainerMeta):
         if (
             name in attributes(self)
             or name in fields(self)
-            or name in ["errors", "state_", "_temp_cache", "_events", "_initialized"]
+            or name
+            in [
+                "errors",  # Errors in state transition
+                "state_",  # Tracking dirty state of the entity
+                "_temp_cache",  # Temporary cache (Assocations) for storing data befor persisting
+                "_events",  # Temp placeholder for events raised by the entity
+                "_initialized",  # Flag to indicate if the entity has been initialized
+                "_root",  # Root entity in the hierarchy
+                "_owner",  # Owner entity in the hierarchy
+            ]
             or name.startswith(("add_", "remove_"))
         ):
             super().__setattr__(name, value)

--- a/src/protean/core/aggregate.py
+++ b/src/protean/core/aggregate.py
@@ -50,6 +50,10 @@ class BaseAggregate(EventedMixin, BaseEntity):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        # Set root in all child elements
+        #   This is where we kick-off the process of setting the owner and root
+        self._set_root_and_owner(self, self)
+
     @classmethod
     def _default_options(cls):
         return [

--- a/src/protean/core/aggregate.py
+++ b/src/protean/core/aggregate.py
@@ -1,5 +1,6 @@
 """Aggregate Functionality and Classes"""
 
+import inspect
 import logging
 
 from protean.container import EventedMixin
@@ -65,4 +66,14 @@ class BaseAggregate(EventedMixin, BaseEntity):
 
 
 def aggregate_factory(element_cls, **kwargs):
-    return derive_element_class(element_cls, BaseAggregate, **kwargs)
+    element_cls = derive_element_class(element_cls, BaseAggregate, **kwargs)
+
+    # Iterate through methods marked as `@invariant` and record them for later use
+    methods = inspect.getmembers(element_cls, predicate=inspect.isroutine)
+    for method_name, method in methods:
+        if not (
+            method_name.startswith("__") and method_name.endswith("__")
+        ) and hasattr(method, "_invariant"):
+            element_cls._invariants.append(method)
+
+    return element_cls

--- a/src/protean/core/command.py
+++ b/src/protean/core/command.py
@@ -24,17 +24,10 @@ class BaseCommand(BaseContainer, OptionsMixin):
             subclass.__track_id_field()
 
     def __init__(self, *args, **kwargs):
-        # Set the flag to prevent any further modifications
-        self._initialized = False
-
         try:
             super().__init__(*args, **kwargs)
         except ValidationError as exception:
             raise InvalidDataError(exception.messages)
-
-        # If we made it this far, the Value Object is initialized
-        #   and should be marked as such
-        self._initialized = True
 
     def __setattr__(self, name, value):
         if not hasattr(self, "_initialized") or not self._initialized:

--- a/src/protean/core/event.py
+++ b/src/protean/core/event.py
@@ -27,16 +27,6 @@ class BaseEvent(BaseContainer, OptionsMixin):  # FIXME Remove OptionsMixin
         if not subclass.meta_.abstract:
             subclass.__track_id_field()
 
-    def __init__(self, *args, **kwargs):
-        # Set the flag to prevent any further modifications
-        self._initialized = False
-
-        super().__init__(*args, **kwargs)
-
-        # If we made it this far, the Value Object is initialized
-        #   and should be marked as such
-        self._initialized = True
-
     def __setattr__(self, name, value):
         if not hasattr(self, "_initialized") or not self._initialized:
             return super().__setattr__(name, value)

--- a/src/protean/fields/association.py
+++ b/src/protean/fields/association.py
@@ -437,6 +437,9 @@ class HasOne(Association):
                     elif isinstance(field_obj, HasOne):
                         setattr(old_value, field_name, None)
 
+        if instance._initialized and instance._root is not None:
+            instance._root.clean()  # Trigger validations from the top
+
     def _fetch_objects(self, instance, key, identifier):
         """Fetch single linked object"""
         try:
@@ -526,6 +529,10 @@ class HasMany(Association):
 
         current_value_ids = [value.id for value in data]
 
+        # Remove items when set to empty
+        if len(items) == 0 and len(current_value_ids) > 0:
+            self.remove(instance, data)
+
         for item in items:
             # Items to add
             if item.id not in current_value_ids:
@@ -562,6 +569,9 @@ class HasMany(Association):
 
                 # Reset Cache
                 self.delete_cached_value(instance)
+
+        if instance._initialized and instance._root is not None:
+            instance._root.clean()  # Trigger validations from the top
 
     def remove(self, instance, items) -> None:
         """
@@ -608,6 +618,9 @@ class HasMany(Association):
                         field_obj.remove(item, getattr(item, field_name))
                     elif isinstance(field_obj, HasOne):
                         setattr(item, field_name, None)
+
+        if instance._initialized and instance._root is not None:
+            instance._root.clean()  # Trigger validations from the top
 
     def _fetch_objects(self, instance, key, value) -> list:
         """

--- a/src/protean/fields/base.py
+++ b/src/protean/fields/base.py
@@ -140,7 +140,16 @@ class Field(FieldBase, FieldDescriptorMixin, metaclass=ABCMeta):
 
     def __set__(self, instance, value):
         value = self._load(value)
+
         instance.__dict__[self.field_name] = value
+
+        # The hasattr check is necessary to avoid running clean on unrelated elements
+        if (
+            instance._initialized
+            and hasattr(instance, "_root")
+            and instance._root is not None
+        ):
+            instance._root.clean()  # Trigger validations from the top
 
         # Mark Entity as Dirty
         if hasattr(instance, "state_"):

--- a/src/protean/fields/basic.py
+++ b/src/protean/fields/basic.py
@@ -421,12 +421,7 @@ class Identifier(Field):
             if existing_value is not None and value != existing_value:
                 raise InvalidOperationError("Identifiers cannot be changed once set")
 
-        value = self._load(value)
-        instance.__dict__[self.field_name] = value
-
-        if hasattr(instance, "state_"):
-            # Mark Entity as Dirty
-            instance.state_.mark_changed()
+        super().__set__(instance, value)
 
     def as_dict(self, value):
         """Return JSON-compatible value of self"""

--- a/tests/aggregate/test_atomic_change.py
+++ b/tests/aggregate/test_atomic_change.py
@@ -1,0 +1,45 @@
+"""Test `atomic_change` context manager"""
+
+import pytest
+
+from protean import BaseAggregate, atomic_change, invariant
+from protean.fields import Integer
+from protean.exceptions import ValidationError
+
+
+class TestAtomicChange:
+    def test_atomic_change_context_manager(self):
+        class TestAggregate(BaseAggregate):
+            pass
+
+        aggregate = TestAggregate()
+
+        with atomic_change(aggregate):
+            assert aggregate._disable_invariant_checks is True
+
+        assert aggregate._disable_invariant_checks is False
+
+    def test_clean_is_not_triggered_within_context_manager(self, test_domain):
+        class TestAggregate(BaseAggregate):
+            value1 = Integer()
+            value2 = Integer()
+
+            @invariant
+            def raise_error(self):
+                if self.value2 != self.value1 + 1:
+                    raise ValidationError({"_entity": ["Invariant error"]})
+
+        test_domain.register(TestAggregate)
+        test_domain.init(traverse=False)
+
+        aggregate = TestAggregate(value1=1, value2=2)
+
+        # This raises an error because of the invariant
+        with pytest.raises(ValidationError):
+            aggregate.value1 = 2
+            aggregate.value2 = 3
+
+        # This should not raise an error because of the context manager
+        with atomic_change(aggregate):
+            aggregate.value1 = 2
+            aggregate.value2 = 3

--- a/tests/entity/associations/test_owner_and_root.py
+++ b/tests/entity/associations/test_owner_and_root.py
@@ -1,0 +1,187 @@
+import pytest
+
+from protean import BaseAggregate, BaseEntity
+from protean.fields import Integer, String, HasOne, HasMany
+
+
+class University(BaseAggregate):
+    name = String(max_length=50)
+    departments = HasMany("Department")
+
+
+class Department(BaseEntity):
+    name = String(max_length=50)
+    dean = HasOne("Dean")
+
+    class Meta:
+        part_of = University
+
+
+class Dean(BaseEntity):
+    name = String(max_length=50)
+    age = Integer(min_value=21)
+    office = HasOne("Office")
+
+    class Meta:
+        part_of = Department
+
+
+class Office(BaseEntity):
+    building = String(max_length=25)
+    room = Integer(min_value=1)
+
+    class Meta:
+        part_of = Dean
+
+
+@pytest.fixture(autouse=True)
+def register_elements(test_domain):
+    test_domain.register(University)
+    test_domain.register(Department)
+    test_domain.register(Dean)
+    test_domain.register(Office)
+    test_domain.init(traverse=False)
+
+
+def test_owner_linkage():
+    office = Office(building="Main", room=101)
+    dean = Dean(name="John Doe", age=45, office=office)
+    department = Department(name="Computer Science", dean=dean)
+    university = University(name="MIT", departments=[department])
+
+    assert university._owner == university
+    assert department._owner == university
+    assert dean._owner == department
+    assert office._owner == dean
+
+
+def test_root_linkage_when_entities_are_constructed_in_advance():
+    office = Office(building="Main", room=101)
+    dean = Dean(name="John Doe", age=45, office=office)
+    department = Department(name="Computer Science", dean=dean)
+    university = University(name="MIT", departments=[department])
+
+    assert university._root == university
+    assert department._root == university
+    assert dean._root == university
+    assert office._root == university
+
+
+def test_root_linkage_when_aggregate_and_entities_are_constructed_together():
+    university = University(
+        name="MIT",
+        departments=[
+            Department(
+                name="Computer Science",
+                dean=Dean(
+                    name="John Doe", age=45, office=Office(building="Main", room=101)
+                ),
+            )
+        ],
+    )
+
+    # Test owner linkages
+    assert university._owner == university
+    assert university.departments[0]._owner == university
+    assert university.departments[0].dean._owner == university.departments[0]
+    assert (
+        university.departments[0].dean.office._owner == university.departments[0].dean
+    )
+
+    # Test root linkages
+    assert university._root == university
+    assert university.departments[0]._root == university
+    assert university.departments[0].dean._root == university
+    assert university.departments[0].dean.office._root == university
+
+
+def test_root_linkage_is_preserved_after_persistence_and_retrieval(test_domain):
+    university = University(
+        name="MIT",
+        departments=[
+            Department(
+                name="Computer Science",
+                dean=Dean(
+                    name="John Doe", age=45, office=Office(building="Main", room=101)
+                ),
+            )
+        ],
+    )
+
+    test_domain.repository_for(University).add(university)
+
+    refreshed_university = test_domain.repository_for(University).get(university.id)
+
+    # Test owner linkages
+    assert refreshed_university._owner == university
+    assert refreshed_university.departments[0]._owner == refreshed_university
+    assert (
+        refreshed_university.departments[0].dean._owner
+        == refreshed_university.departments[0]
+    )
+    assert (
+        refreshed_university.departments[0].dean.office._owner
+        == refreshed_university.departments[0].dean
+    )
+
+    # Test root linkages
+    assert refreshed_university._root == refreshed_university
+    assert refreshed_university.departments[0]._root == refreshed_university
+    assert refreshed_university.departments[0].dean._root == refreshed_university
+    assert refreshed_university.departments[0].dean.office._root == refreshed_university
+
+
+def test_root_linkage_on_newly_added_entity(test_domain):
+    university = University(
+        name="MIT",
+        departments=[
+            Department(
+                name="Computer Science",
+                dean=Dean(
+                    name="John Doe", age=45, office=Office(building="Main", room=101)
+                ),
+            )
+        ],
+    )
+
+    new_department = Department(
+        name="Electrical Engineering",
+        dean=Dean(name="Jane Doe", age=42, office=Office(building="Main", room=102)),
+    )
+
+    assert new_department._root is None
+    assert new_department.dean._root is None
+    assert new_department.dean.office._root is None
+
+    university.add_departments(new_department)
+
+    # Test owner linkages
+    assert new_department._owner == university
+    assert new_department.dean._owner == new_department
+    assert new_department.dean.office._owner == new_department.dean
+
+    # Test root linkages
+    assert new_department._root == university
+    assert new_department.dean._root == university
+    assert new_department.dean.office._root == university
+
+    assert university.departments[1]._root == university
+    assert university.departments[1].dean._root == university
+    assert university.departments[1].dean.office._root == university
+
+    test_domain.repository_for(University).add(university)
+
+    refreshed_university = test_domain.repository_for(University).get(university.id)
+
+    # Test owner linkages
+    assert refreshed_university._owner == refreshed_university
+    assert refreshed_university.departments[0]._owner == refreshed_university
+    assert (
+        refreshed_university.departments[0].dean._owner
+        == refreshed_university.departments[0]
+    )
+
+    # Test root linkages
+    assert refreshed_university.departments[1]._root == university
+    assert refreshed_university.departments[1].dean._root == university
+    assert refreshed_university.departments[1].dean.office._root == university

--- a/tests/entity/elements.py
+++ b/tests/entity/elements.py
@@ -1,7 +1,7 @@
-from collections import defaultdict
 from enum import Enum
 
-from protean import BaseAggregate, BaseEntity
+from protean import BaseAggregate, BaseEntity, invariant
+from protean.exceptions import ValidationError
 from protean.fields import Auto, HasOne, Integer, String
 
 
@@ -149,10 +149,9 @@ class Building(BaseEntity):
             else:
                 self.status = BuildingStatus.WIP.value
 
-    def clean(self):
-        errors = defaultdict(list)
-
+    @invariant
+    def test_building_status_to_be_done_if_floors_above_4(self):
         if self.floors >= 4 and self.status != BuildingStatus.DONE.value:
-            errors["status"].append("should be DONE")
-
-        return errors
+            raise ValidationError(
+                {"_entity": ["Building status should be DONE if floors are above 4"]}
+            )

--- a/tests/entity/invariants/test_invariant_decorator.py
+++ b/tests/entity/invariants/test_invariant_decorator.py
@@ -47,9 +47,9 @@ def test_that_entity_has_recorded_invariants(test_domain):
 
     assert len(Order._invariants) == 3
     # Methods are presented in ascending order (alphabetical order) of member names.
-    assert Order._invariants[0].__name__ == "item_quantities_should_be_positive"
-    assert Order._invariants[1].__name__ == "must_have_at_least_one_item"
-    assert Order._invariants[2].__name__ == "total_should_be_sum_of_item_prices"
+    assert "item_quantities_should_be_positive" in Order._invariants
+    assert "must_have_at_least_one_item" in Order._invariants
+    assert "total_should_be_sum_of_item_prices" in Order._invariants
 
     assert len(OrderItem._invariants) == 1
-    assert OrderItem._invariants[0].__name__ == "price_should_be_non_negative"
+    assert "price_should_be_non_negative" in OrderItem._invariants

--- a/tests/entity/invariants/test_invariant_triggerring.py
+++ b/tests/entity/invariants/test_invariant_triggerring.py
@@ -1,0 +1,287 @@
+import pytest
+
+from datetime import date
+from enum import Enum
+
+from protean import BaseAggregate, BaseEntity, invariant, atomic_change
+from protean.exceptions import ValidationError
+from protean.fields import Date, Float, Identifier, Integer, String, HasMany
+
+
+class OrderStatus(Enum):
+    PENDING = "PENDING"
+    SHIPPED = "SHIPPED"
+    DELIVERED = "DELIVERED"
+
+
+class Order(BaseAggregate):
+    customer_id = Identifier()
+    order_date = Date()
+    total_amount = Float()
+    status = String(max_length=50, choices=OrderStatus)
+    items = HasMany("OrderItem")
+
+    @invariant
+    def total_amount_of_order_must_equal_sum_of_subtotal_of_all_items(self):
+        if self.total_amount != sum(item.subtotal for item in self.items):
+            raise ValidationError({"_entity": ["Total should be sum of item prices"]})
+
+    @invariant
+    def order_date_must_be_within_the_last_30_days_if_status_is_pending(self):
+        if self.status == OrderStatus.PENDING.value and self.order_date < date(
+            2020, 1, 1
+        ):
+            raise ValidationError(
+                {
+                    "_entity": [
+                        "Order date must be within the last 30 days if status is PENDING"
+                    ]
+                }
+            )
+
+    @invariant
+    def customer_id_must_be_non_null_and_the_order_must_contain_at_least_one_item(self):
+        if not self.customer_id or not self.items:
+            raise ValidationError(
+                {
+                    "_entity": [
+                        "Customer ID must be non-null and the order must contain at least one item"
+                    ]
+                }
+            )
+
+
+class OrderItem(BaseEntity):
+    product_id = Identifier()
+    quantity = Integer()
+    price = Float()
+    subtotal = Float()
+
+    class Meta:
+        part_of = Order
+
+    @invariant
+    def the_quantity_must_be_a_positive_integer_and_the_subtotal_must_be_correctly_calculated(
+        self,
+    ):
+        if self.quantity <= 0 or self.subtotal != self.quantity * self.price:
+            raise ValidationError(
+                {
+                    "_entity": [
+                        "Quantity must be a positive integer and the subtotal must be correctly calculated"
+                    ]
+                }
+            )
+
+
+@pytest.fixture(autouse=True)
+def register_elements(test_domain):
+    test_domain.register(OrderItem)
+    test_domain.register(Order)
+    test_domain.init(traverse=False)
+
+
+class TestEntityInvariantsOnInitialization:
+    def test_with_valid_data(self):
+        order = Order(
+            customer_id="1",
+            order_date="2020-01-01",
+            total_amount=100.0,
+            status="PENDING",
+            items=[
+                OrderItem(product_id="1", quantity=4, price=10.0, subtotal=40.0),
+                OrderItem(product_id="2", quantity=3, price=20.0, subtotal=60.0),
+            ],
+        )
+        assert order is not None
+
+    def test_when_total_amount_is_not_sum_of_item_subtotals(self):
+        with pytest.raises(ValidationError) as exc:
+            Order(
+                customer_id="1",
+                order_date="2020-01-01",
+                total_amount=100.0,
+                status="PENDING",
+                items=[
+                    OrderItem(product_id="1", quantity=2, price=10.0, subtotal=20.0),
+                    OrderItem(product_id="2", quantity=3, price=20.0, subtotal=60.0),
+                ],
+            )
+
+        assert exc.value.messages["_entity"] == ["Total should be sum of item prices"]
+
+    def test_when_order_date_is_not_within_the_last_30_days(self):
+        with pytest.raises(ValidationError) as exc:
+            Order(
+                customer_id="1",
+                order_date="2019-12-01",
+                total_amount=100.0,
+                status="PENDING",
+                items=[
+                    OrderItem(product_id="1", quantity=4, price=10.0, subtotal=40.0),
+                    OrderItem(product_id="2", quantity=3, price=20.0, subtotal=60.0),
+                ],
+            )
+
+        assert exc.value.messages["_entity"] == [
+            "Order date must be within the last 30 days if status is PENDING"
+        ]
+
+    def test_when_customer_ID_is_null(self):
+        with pytest.raises(ValidationError) as exc:
+            Order(
+                customer_id=None,
+                order_date="2020-01-01",
+                total_amount=100.0,
+                status="PENDING",
+                items=[
+                    OrderItem(product_id="1", quantity=4, price=10.0, subtotal=40.0),
+                    OrderItem(product_id="2", quantity=3, price=20.0, subtotal=60.0),
+                ],
+            )
+
+        assert exc.value.messages["_entity"] == [
+            "Customer ID must be non-null and the order must contain at least one item"
+        ]
+
+    def test_when_items_are_empty(self):
+        with pytest.raises(ValidationError) as exc:
+            Order(
+                customer_id="1",
+                order_date="2020-01-01",
+                total_amount=100.0,
+                status="PENDING",
+                items=[],
+            )
+
+        assert exc.value.messages["_entity"] == [
+            "Customer ID must be non-null and the order must contain at least one item",
+            "Total should be sum of item prices",
+        ]
+
+    def test_when_quantity_is_negative(self):
+        with pytest.raises(ValidationError) as exc:
+            Order(
+                customer_id="1",
+                order_date="2020-01-01",
+                total_amount=100.0,
+                status="PENDING",
+                items=[
+                    OrderItem(product_id="1", quantity=-1, price=10.0, subtotal=10.0),
+                    OrderItem(product_id="2", quantity=3, price=20.0, subtotal=60.0),
+                ],
+            )
+
+        assert exc.value.messages["_entity"] == [
+            "Quantity must be a positive integer and the subtotal must be correctly calculated"
+        ]
+
+    def test_when_subtotal_is_incorrect(self):
+        with pytest.raises(ValidationError) as exc:
+            Order(
+                customer_id="1",
+                order_date="2020-01-01",
+                total_amount=100.0,
+                status="PENDING",
+                items=[
+                    OrderItem(product_id="1", quantity=1, price=10.0, subtotal=20.0),
+                    OrderItem(product_id="2", quantity=3, price=20.0, subtotal=60.0),
+                ],
+            )
+
+        assert exc.value.messages["_entity"] == [
+            "Quantity must be a positive integer and the subtotal must be correctly calculated"
+        ]
+
+
+@pytest.fixture
+def order():
+    return Order(
+        customer_id="1",
+        order_date="2020-01-01",
+        total_amount=100.0,
+        status="PENDING",
+        items=[
+            OrderItem(product_id="1", quantity=4, price=10.0, subtotal=40.0),
+            OrderItem(product_id="2", quantity=3, price=20.0, subtotal=60.0),
+        ],
+    )
+
+
+class TestEntityInvariantsOnAttributeChanges:
+    def test_when_total_amount_is_not_sum_of_item_subtotals(self, order):
+        with pytest.raises(ValidationError) as exc:
+            order.total_amount = 50.0
+
+        assert exc.value.messages["_entity"] == ["Total should be sum of item prices"]
+
+    def test_when_order_date_is_not_within_the_last_30_days(self, order):
+        with pytest.raises(ValidationError) as exc:
+            order.order_date = "2019-12-01"
+
+        assert exc.value.messages["_entity"] == [
+            "Order date must be within the last 30 days if status is PENDING"
+        ]
+
+    def test_when_customer_ID_is_null(self, order):
+        with pytest.raises(ValidationError) as exc:
+            order.customer_id = None
+
+        assert exc.value.messages["_entity"] == [
+            "Customer ID must be non-null and the order must contain at least one item"
+        ]
+
+    def test_when_items_are_empty(self, order):
+        with pytest.raises(ValidationError) as exc:
+            order.items = []
+
+        assert exc.value.messages["_entity"] == [
+            "Customer ID must be non-null and the order must contain at least one item",
+            "Total should be sum of item prices",
+        ]
+
+    def test_when_invalid_item_is_added(self, order):
+        with pytest.raises(ValidationError) as exc:
+            order.add_items(
+                OrderItem(product_id="3", quantity=2, price=10.0, subtotal=40.0)
+            )
+
+        assert exc.value.messages["_entity"] == [
+            "Quantity must be a positive integer and the subtotal must be correctly calculated"
+        ]
+
+    def test_when_item_is_added_along_with_total_amount(self, order):
+        try:
+            with atomic_change(order):
+                order.total_amount = 120.0
+                order.add_items(
+                    OrderItem(product_id="3", quantity=2, price=10.0, subtotal=20.0)
+                )
+        except ValidationError:
+            pytest.fail("Failed to batch update attributes")
+
+    def test_when_quantity_is_negative(self, order):
+        with pytest.raises(ValidationError) as exc:
+            order.items[0].quantity = -1
+
+        assert exc.value.messages["_entity"] == [
+            "Quantity must be a positive integer and the subtotal must be correctly calculated"
+        ]
+
+    def test_when_invalid_item_is_added_after_initialization(self, order):
+        with pytest.raises(ValidationError) as exc:
+            order.add_items(
+                OrderItem(product_id="3", quantity=2, price=10.0, subtotal=40.0)
+            )
+
+        assert exc.value.messages["_entity"] == [
+            "Quantity must be a positive integer and the subtotal must be correctly calculated"
+        ]
+
+    def test_when_item_price_is_changed_to_negative(self, order):
+        with pytest.raises(ValidationError) as exc:
+            order.items[0].price = -10.0
+
+        assert exc.value.messages["_entity"] == [
+            "Quantity must be a positive integer and the subtotal must be correctly calculated"
+        ]

--- a/tests/entity/test_invariants.py
+++ b/tests/entity/test_invariants.py
@@ -1,0 +1,55 @@
+from protean import BaseAggregate, BaseEntity, invariant
+from protean.exceptions import ValidationError
+from protean.fields import Date, Float, Integer, String, HasMany
+
+
+class Order(BaseAggregate):
+    ordered_on = Date()
+    total = Float()
+    items = HasMany("OrderItem")
+
+    @invariant
+    def total_should_be_sum_of_item_prices(self):
+        if self.items:
+            if self.total != sum([item.price for item in self.items]):
+                raise ValidationError("Total should be sum of item prices")
+
+    @invariant
+    def must_have_at_least_one_item(self):
+        if not self.items or len(self.items) == 0:
+            raise ValidationError("Order must contain at least one item")
+
+    @invariant
+    def item_quantities_should_be_positive(self):
+        for item in self.items:
+            if item.quantity <= 0:
+                raise ValidationError("Item quantities should be positive")
+
+
+class OrderItem(BaseEntity):
+    product_id = String(max_length=50)
+    quantity = Integer()
+    price = Float()
+
+    class Meta:
+        part_of = Order
+
+    @invariant
+    def price_should_be_non_negative(self):
+        if self.price < 0:
+            raise ValidationError("Item price should be non-negative")
+
+
+def test_that_entity_has_recorded_invariants(test_domain):
+    test_domain.register(OrderItem)
+    test_domain.register(Order)
+    test_domain.init(traverse=False)
+
+    assert len(Order._invariants) == 3
+    # Methods are presented in ascending order (alphabetical order) of member names.
+    assert Order._invariants[0].__name__ == "item_quantities_should_be_positive"
+    assert Order._invariants[1].__name__ == "must_have_at_least_one_item"
+    assert Order._invariants[2].__name__ == "total_should_be_sum_of_item_prices"
+
+    assert len(OrderItem._invariants) == 1
+    assert OrderItem._invariants[0].__name__ == "price_should_be_non_negative"

--- a/tests/entity/test_lifecycle_methods.py
+++ b/tests/entity/test_lifecycle_methods.py
@@ -2,7 +2,7 @@ import pytest
 
 from protean.exceptions import ValidationError
 
-from .elements import Building, BuildingStatus
+from .elements import Area, Building, BuildingStatus
 
 
 class TestDefaults:
@@ -18,6 +18,10 @@ class TestDefaults:
 
 
 class TestClean:
-    def test_that_building_cannot_be_WIP_if_above_4_floors(self):
+    def test_that_building_cannot_be_WIP_if_above_4_floors(self, test_domain):
+        test_domain.register(Building)
+        test_domain.register(Area)
+        test_domain.init(traverse=False)
+
         with pytest.raises(ValidationError):
             Building(name="Foo", floors=4, status=BuildingStatus.WIP.value)

--- a/tests/value_object/test_vo_field_properties.py
+++ b/tests/value_object/test_vo_field_properties.py
@@ -1,8 +1,8 @@
 import pytest
 
-from protean import BaseValueObject
+from protean import BaseEntity, BaseValueObject
 from protean.exceptions import IncorrectUsageError
-from protean.fields import Float, String
+from protean.fields import Float, HasMany, String
 
 
 def test_vo_cannot_contain_fields_marked_unique():
@@ -32,6 +32,24 @@ def test_vo_cannot_contain_fields_marked_as_identifiers():
         {
             "_value_object": [
                 "Value Objects cannot contain fields marked 'identifier' (field 'currency')"
+            ]
+        }
+    )
+
+
+def test_vo_cannot_have_association_fields():
+    with pytest.raises(IncorrectUsageError) as exception:
+
+        class Address(BaseEntity):
+            street_address = String()
+
+        class Office(BaseValueObject):
+            addresses = HasMany(Address)
+
+    assert str(exception.value) == str(
+        {
+            "_value_object": [
+                "Value Objects can only contain basic field types. Remove addresses (HasMany) from class Office"
             ]
         }
     )


### PR DESCRIPTION
Invariants are usually buried deep in business logic, making them more complex to maintain over time and difficult to document. This PR introduces the `@invariant` decorator to configure invariants in an aggregate cluster explicitly.

All methods marked `@invariant` are invoked once an aggregate/entity object is initialized and triggered when an
attribute is updated across the board. Explicit invariants ensure that the entire aggregate cluster remains valid at all times.

Two additional changes are present in this PR:
1. There will be scenarios where multiple attributes must be changed before the aggregate becomes valid. A new context manager, `atomic_change`, has been introduced, which temporarily turns off validations and runs them on the exit of the context manager.
2. All aggregates and entities maintain linkages to their hierarchy, especially their immediate parent and the root aggregate. This linkage helps trigger validations across the aggregate cluster recursively.