### PR TITLE
Support `List` of of Value Objects

### DIFF
--- a/docs_src/guides/domain-definition/fields/container-fields/004.py
+++ b/docs_src/guides/domain-definition/fields/container-fields/004.py
@@ -1,0 +1,24 @@
+from protean import Domain
+from protean.fields import HasOne, String, List, ValueObject
+
+domain = Domain(__file__, load_toml=False)
+
+
+@domain.value_object
+class Address:
+    street = String(max_length=100)
+    city = String(max_length=25)
+    state = String(max_length=25)
+    country = String(max_length=25)
+
+
+@domain.entity(part_of="Order")
+class Customer:
+    name = String(max_length=50, required=True)
+    email = String(max_length=254, required=True)
+    addresses = List(content_type=ValueObject(Address))
+
+
+@domain.aggregate
+class Order:
+    customer = HasOne(Customer)

--- a/src/protean/fields/embedded.py
+++ b/src/protean/fields/embedded.py
@@ -100,14 +100,19 @@ class ValueObject(Field):
                 referenced_as=field_obj.referenced_as,
             )
 
-        # Refresh underlying embedded field names
         for embedded_field in self.embedded_fields.values():
             if embedded_field.referenced_as:
                 embedded_field.attribute_name = embedded_field.referenced_as
             else:
-                embedded_field.attribute_name = (
-                    self.field_name + "_" + embedded_field.field_name
-                )
+                # VO is associated with an aggregate/entity
+                if self.field_name is not None:
+                    # Refresh underlying embedded field names
+                    embedded_field.attribute_name = (
+                        self.field_name + "_" + embedded_field.field_name
+                    )
+                else:
+                    # VO is being used standalone
+                    embedded_field.attribute_name = embedded_field.field_name
 
     def __set_name__(self, entity_cls, name):
         super().__set_name__(entity_cls, name)

--- a/tests/adapters/model/sqlalchemy_model/postgresql/test_array_datatype.py
+++ b/tests/adapters/model/sqlalchemy_model/postgresql/test_array_datatype.py
@@ -112,9 +112,10 @@ def test_array_content_type_validation(test_domain):
         {"email": "john.doe@gmail.com", "roles": [1.0, 2.0]},
         {"email": "john.doe@gmail.com", "roles": [datetime.now(UTC)]},
     ]:
-        with pytest.raises(ValidationError) as exception:
+        try:
             ArrayUser(**kwargs)
-        assert exception.value.messages["roles"][0].startswith("Invalid value")
+        except ValidationError:
+            pytest.fail("Failed to convert integers into strings in List field type")
 
     model_cls = test_domain.repository_for(IntegerArrayUser)._model
     user = IntegerArrayUser(email="john.doe@gmail.com", roles=[1, 2])
@@ -126,7 +127,6 @@ def test_array_content_type_validation(test_domain):
 
     for kwargs in [
         {"email": "john.doe@gmail.com", "roles": ["ADMIN", "USER"]},
-        {"email": "john.doe@gmail.com", "roles": ["1", "2"]},
         {"email": "john.doe@gmail.com", "roles": [datetime.now(UTC)]},
     ]:
         with pytest.raises(ValidationError) as exception:

--- a/tests/adapters/model/sqlalchemy_model/postgresql/test_list_datatype.py
+++ b/tests/adapters/model/sqlalchemy_model/postgresql/test_list_datatype.py
@@ -42,9 +42,10 @@ def test_array_content_type_validation(test_domain):
         {"email": "john.doe@gmail.com", "roles": [1.0, 2.0]},
         {"email": "john.doe@gmail.com", "roles": [datetime.now(UTC)]},
     ]:
-        with pytest.raises(ValidationError) as exception:
+        try:
             ListUser(**kwargs)
-        assert exception.value.messages["roles"][0].startswith("Invalid value")
+        except ValidationError:
+            pytest.fail("Failed to convert integers into strings in List field type")
 
     model_cls = test_domain.repository_for(IntegerListUser)._model
     user = IntegerListUser(email="john.doe@gmail.com", roles=[1, 2])
@@ -56,7 +57,6 @@ def test_array_content_type_validation(test_domain):
 
     for kwargs in [
         {"email": "john.doe@gmail.com", "roles": ["ADMIN", "USER"]},
-        {"email": "john.doe@gmail.com", "roles": ["1", "2"]},
         {"email": "john.doe@gmail.com", "roles": [datetime.now(UTC)]},
     ]:
         with pytest.raises(ValidationError) as exception:

--- a/tests/adapters/model/sqlalchemy_model/sqlite/test_array_datatype.py
+++ b/tests/adapters/model/sqlalchemy_model/sqlite/test_array_datatype.py
@@ -62,9 +62,10 @@ def test_array_content_type_validation(test_domain):
         {"email": "john.doe@gmail.com", "roles": [1.0, 2.0]},
         {"email": "john.doe@gmail.com", "roles": [datetime.now(UTC)]},
     ]:
-        with pytest.raises(ValidationError) as exception:
+        try:
             ArrayUser(**kwargs)
-        assert exception.value.messages["roles"][0].startswith("Invalid value")
+        except ValidationError:
+            pytest.fail("Failed to convert integers into strings in List field type")
 
     model_cls = test_domain.repository_for(IntegerArrayUser)._model
     user = IntegerArrayUser(email="john.doe@gmail.com", roles=[1, 2])
@@ -76,7 +77,6 @@ def test_array_content_type_validation(test_domain):
 
     for kwargs in [
         {"email": "john.doe@gmail.com", "roles": ["ADMIN", "USER"]},
-        {"email": "john.doe@gmail.com", "roles": ["1", "2"]},
         {"email": "john.doe@gmail.com", "roles": [datetime.now(UTC)]},
     ]:
         with pytest.raises(ValidationError) as exception:

--- a/tests/adapters/repository/sqlalchemy_repo/postgresql/conftest.py
+++ b/tests/adapters/repository/sqlalchemy_repo/postgresql/conftest.py
@@ -19,6 +19,7 @@ def setup_db():
         from .elements import Alien, ComplexUser, Person, User
         from .test_associations import Audit, Comment, Post
         from .test_persistence import Event
+        from .test_persisting_list_of_value_objects import Customer, Order
 
         domain.register(Alien)
         domain.register(ComplexUser)
@@ -28,6 +29,8 @@ def setup_db():
         domain.register(Post)
         domain.register(Comment)
         domain.register(Audit)
+        domain.register(Customer)
+        domain.register(Order)
 
         domain.repository_for(Alien)._dao
         domain.repository_for(ComplexUser)._dao
@@ -37,6 +40,8 @@ def setup_db():
         domain.repository_for(Post)._dao
         domain.repository_for(Comment)._dao
         domain.repository_for(Audit)._dao
+        domain.repository_for(Customer)._dao
+        domain.repository_for(Order)._dao
 
         domain.providers["default"]._metadata.create_all()
 

--- a/tests/adapters/repository/sqlalchemy_repo/postgresql/test_persisting_list_of_value_objects.py
+++ b/tests/adapters/repository/sqlalchemy_repo/postgresql/test_persisting_list_of_value_objects.py
@@ -1,0 +1,59 @@
+import pytest
+
+from protean import BaseAggregate, BaseEntity, BaseValueObject
+from protean.fields import HasOne, List, String, ValueObject
+
+
+class Address(BaseValueObject):
+    street = String(max_length=100)
+    city = String(max_length=25)
+    state = String(max_length=25)
+    country = String(max_length=25)
+
+
+class Customer(BaseEntity):
+    name = String(max_length=50, required=True)
+    email = String(max_length=254, required=True)
+    addresses = List(content_type=ValueObject(Address))
+
+    class Meta:
+        part_of = "Order"
+
+
+# Aggregate that encloses Customer Entity
+class Order(BaseAggregate):
+    customer = HasOne(Customer)
+
+
+@pytest.mark.postgresql
+def test_persisting_and_retrieving_list_of_value_objects(test_domain):
+    test_domain.register(Order)
+    test_domain.register(Customer)
+    test_domain.register(Address)
+
+    order = Order(
+        customer=Customer(
+            name="John",
+            email="john@doe.com",
+            addresses=[
+                Address(
+                    street="123 Main St", city="Anytown", state="CA", country="USA"
+                ),
+                Address(
+                    street="321 Side St", city="Anytown", state="CA", country="USA"
+                ),
+            ],
+        )
+    )
+
+    test_domain.repository_for(Order).add(order)
+
+    retrieved_order = test_domain.repository_for(Order).get(order.id)
+
+    assert retrieved_order is not None
+    assert retrieved_order.customer is not None
+    assert retrieved_order.customer.id == order.customer.id
+    assert retrieved_order.customer.addresses == [
+        Address(street="123 Main St", city="Anytown", state="CA", country="USA"),
+        Address(street="321 Side St", city="Anytown", state="CA", country="USA"),
+    ]

--- a/tests/entity/fields/test_generic_field_behavior.py
+++ b/tests/entity/fields/test_generic_field_behavior.py
@@ -1,6 +1,6 @@
 import pytest
 
-from protean import BaseAggregate
+from protean import BaseEntity
 from protean.exceptions import ValidationError
 from protean.fields import Boolean, Dict, Integer, List
 from protean.reflection import fields
@@ -8,7 +8,7 @@ from protean.reflection import fields
 
 class TestFields:
     def test_lists_can_be_mandatory(self):
-        class Lottery(BaseAggregate):
+        class Lottery(BaseEntity):
             jackpot = Boolean()
             numbers = List(content_type=Integer, required=True)
 
@@ -18,7 +18,7 @@ class TestFields:
         assert exc.value.messages == {"numbers": ["is required"]}
 
     def test_dicts_can_be_mandatory(self):
-        class Lottery(BaseAggregate):
+        class Lottery(BaseEntity):
             jackpot = Boolean()
             numbers = Dict(required=True)
 
@@ -28,13 +28,13 @@ class TestFields:
         assert exc.value.messages == {"numbers": ["is required"]}
 
     def test_field_description(self):
-        class Lottery(BaseAggregate):
+        class Lottery(BaseEntity):
             jackpot = Boolean(description="Jackpot won or not")
 
         assert fields(Lottery)["jackpot"].description == "Jackpot won or not"
 
     def test_field_default_description(self):
-        class Lottery(BaseAggregate):
+        class Lottery(BaseEntity):
             jackpot = Boolean()
 
         # By default, description is not auto-set.

--- a/tests/entity/fields/test_list_of_value_objects.py
+++ b/tests/entity/fields/test_list_of_value_objects.py
@@ -1,0 +1,135 @@
+import pytest
+
+from protean import BaseAggregate, BaseEntity, BaseValueObject
+from protean.fields import HasOne, List, String, ValueObject
+
+
+class Address(BaseValueObject):
+    street = String(max_length=100)
+    city = String(max_length=25)
+    state = String(max_length=25)
+    country = String(max_length=25)
+
+
+class Customer(BaseEntity):
+    name = String(max_length=50, required=True)
+    email = String(max_length=254, required=True)
+    addresses = List(content_type=ValueObject(Address))
+
+    class Meta:
+        part_of = "Order"
+
+
+# Aggregate that encloses Customer Entity
+class Order(BaseAggregate):
+    customer = HasOne(Customer)
+
+
+@pytest.fixture(autouse=True)
+def register_elements(test_domain):
+    test_domain.register(Order)
+    test_domain.register(Customer)
+    test_domain.register(Address)
+
+
+def test_that_list_of_value_objects_can_be_assigned_during_initialization(test_domain):
+    customer = Customer(
+        name="John Doe",
+        email="john@doe.com",
+        addresses=[
+            Address(street="123 Main St", city="Anytown", state="CA", country="USA"),
+            Address(street="321 Side St", city="Anytown", state="CA", country="USA"),
+        ],
+    )
+
+    assert customer is not None
+    assert customer.addresses == [
+        Address(street="123 Main St", city="Anytown", state="CA", country="USA"),
+        Address(street="321 Side St", city="Anytown", state="CA", country="USA"),
+    ]
+
+
+def test_that_entity_with_list_of_value_objects_is_persisted_and_retrieved(test_domain):
+    order = Order(
+        customer=Customer(
+            name="John Doe",
+            email="john@doe.com",
+            addresses=[
+                Address(
+                    street="123 Main St", city="Anytown", state="CA", country="USA"
+                ),
+                Address(
+                    street="321 Side St", city="Anytown", state="CA", country="USA"
+                ),
+            ],
+        )
+    )
+
+    test_domain.repository_for(Order).add(order)
+
+    retrieved_order = test_domain.repository_for(Order).get(order.id)
+
+    assert retrieved_order is not None
+    assert retrieved_order.customer is not None
+    assert retrieved_order.customer.id == order.customer.id
+    assert retrieved_order.customer.addresses == [
+        Address(street="123 Main St", city="Anytown", state="CA", country="USA"),
+        Address(street="321 Side St", city="Anytown", state="CA", country="USA"),
+    ]
+
+
+def test_that_a_value_object_can_be_updated(test_domain):
+    customer = Customer(
+        name="John Doe",
+        email="john@doe.com",
+        addresses=[
+            Address(street="123 Main St", city="Anytown", state="CA", country="USA"),
+            Address(street="321 Side St", city="Anytown", state="CA", country="USA"),
+        ],
+    )
+
+    customer.addresses.append(
+        Address(street="123 Side St", city="Anytown", state="CA", country="USA")
+    )
+
+    assert len(customer.addresses) == 3
+    assert customer.addresses == [
+        Address(street="123 Main St", city="Anytown", state="CA", country="USA"),
+        Address(street="321 Side St", city="Anytown", state="CA", country="USA"),
+        Address(street="123 Side St", city="Anytown", state="CA", country="USA"),
+    ]
+
+
+def test_that_a_persisted_entity_with_list_of_value_objects_can_be_updated(test_domain):
+    order = Order(
+        customer=Customer(
+            name="John Doe",
+            email="john@doe.com",
+            addresses=[
+                Address(
+                    street="123 Main St", city="Anytown", state="CA", country="USA"
+                ),
+                Address(
+                    street="321 Side St", city="Anytown", state="CA", country="USA"
+                ),
+            ],
+        )
+    )
+
+    test_domain.repository_for(Order).add(order)
+
+    retrieved_order = test_domain.repository_for(Order).get(order.id)
+
+    # [].append does not work.
+    retrieved_order.customer.addresses = [
+        Address(street="123 Main St", city="Anytown", state="CA", country="USA"),
+        Address(street="321 Side St", city="Anytown", state="CA", country="USA"),
+        Address(street="456 Side St", city="Anytown", state="CA", country="USA"),
+    ]
+    assert len(retrieved_order.customer.addresses) == 3
+
+    test_domain.repository_for(Order).add(retrieved_order)
+
+    retrieved_order = test_domain.repository_for(Order).get(order.id)
+
+    assert len(retrieved_order.customer.addresses) == 3

--- a/tests/field/test_list.py
+++ b/tests/field/test_list.py
@@ -1,0 +1,144 @@
+import pytest
+
+from datetime import datetime, date
+
+from protean import BaseValueObject
+from protean.exceptions import ValidationError
+from protean.fields.basic import (
+    List,
+    String,
+    Integer,
+    Boolean,
+    Date,
+    DateTime,
+    Float,
+    Dict,
+)
+from protean.fields.embedded import ValueObject
+
+
+class TestListFieldContentType:
+    def test_list_field_with_string_content_type(self):
+        field = List(content_type=String)
+        value = ["hello", "world"]
+        assert field._cast_to_type(value) == value
+
+        value = ["hello", 123]
+        assert field._cast_to_type(value) == ["hello", "123"]
+
+    def test_list_field_with_integer_content_type(self):
+        field = List(content_type=Integer)
+        value = [1, 2, 3]
+        assert field._cast_to_type(value) == value
+
+        value = [1, "hello"]
+        with pytest.raises(ValidationError):
+            field._cast_to_type(value)
+
+    def test_list_field_with_boolean_content_type(self):
+        field = List(content_type=Boolean)
+        value = [True, False, True]
+        assert field._cast_to_type(value) == value
+
+        value = [True, "hello"]
+        with pytest.raises(ValidationError):
+            field._cast_to_type(value)
+
+    def test_list_field_with_date_content_type(self):
+        field = List(content_type=Date)
+        value = ["2023-05-01", "2023-06-15"]
+        assert field._cast_to_type(value) == [date.fromisoformat(d) for d in value]
+
+        value = ["2023-05-01", "invalid"]
+        with pytest.raises(ValidationError):
+            field._cast_to_type(value)
+
+    def test_list_field_with_datetime_content_type(self):
+        field = List(content_type=DateTime)
+        value = ["2023-05-01T12:00:00", "2023-06-15T18:30:00"]
+        assert field._cast_to_type(value) == [datetime.fromisoformat(d) for d in value]
+
+        value = ["2023-05-01T12:00:00", "invalid"]
+        with pytest.raises(ValidationError):
+            field._cast_to_type(value)
+
+    def test_list_field_with_float_content_type(self):
+        field = List(content_type=Float)
+        value = [1.2, 3.4, 5.6]
+        assert field._cast_to_type(value) == value
+
+        value = [1.2, "hello"]
+        with pytest.raises(ValidationError):
+            field._cast_to_type(value)
+
+    def test_list_field_with_dict_content_type(self):
+        field = List(content_type=Dict)
+        value = [{"a": 1}, {"b": 2}]
+        assert field._cast_to_type(value) == value
+
+        value = [{"a": 1}, "hello"]
+        with pytest.raises(ValidationError):
+            field._cast_to_type(value)
+
+    def test_list_field_with_invalid_content_type(self):
+        with pytest.raises(ValidationError):
+            List(content_type=int)
+
+    def test_list_field_with_non_list_value(self):
+        field = List(content_type=String)
+        value = "hello"
+        with pytest.raises(ValidationError):
+            field._cast_to_type(value)
+
+    def test_list_field_with_value_object_content_type(self):
+        class VO(BaseValueObject):
+            foo = String()
+
+        field = List(content_type=ValueObject(VO))
+        value = [VO(foo="bar"), VO(foo="baz")]
+        assert field._cast_to_type(value) == value
+
+
+class TestListFieldAsDictWithDifferentContentTypes:
+    def test_list_as_dict_with_string_content_type(self):
+        field = List(content_type=String)
+        value = ["hello", "world"]
+        assert field.as_dict(value) == value
+
+    def test_list_as_dict_with_integer_content_type(self):
+        field = List(content_type=Integer)
+        value = [1, 2, 3]
+        assert field.as_dict(value) == value
+
+    def test_list_as_dict_with_float_content_type(self):
+        field = List(content_type=Float)
+        value = [1.2, 3.4, 5.6]
+        assert field.as_dict(value) == value
+
+    def test_list_as_dict_with_boolean_content_type(self):
+        field = List(content_type=Boolean)
+        value = [True, False, True]
+        assert field.as_dict(value) == value
+
+    def test_list_as_dict_with_date_content_type(self):
+        field = List(content_type=Date)
+        value = [date(2023, 4, 1), date(2023, 4, 2)]
+        assert field.as_dict(value) == [str(d) for d in value]
+
+    def test_list_as_dict_with_datetime_content_type(self):
+        field = List(content_type=DateTime)
+        value = [datetime(2023, 4, 1, 10, 30), datetime(2023, 4, 2, 11, 45)]
+        assert field.as_dict(value) == [str(dt) for dt in value]
+
+    def test_list_field_with_dict_content_type(self):
+        field = List(content_type=Dict)
+        value = [{"a": 1}, {"b": 2}]
+        assert field.as_dict(value) == value
+
+    def test_list_as_dict_with_value_object_content_type(self):
+        class VO(BaseValueObject):
+            foo = String()
+
+        field = List(content_type=ValueObject(VO))
+        value = [VO(foo="bar"), VO(foo="baz")]
+        assert field.as_dict(value) == [{"foo": "bar"}, {"foo": "baz"}]


### PR DESCRIPTION
Specific changes:
- Update `List` field to support `ValueObject` content type
- Allow ValueObjects to output `dict` even when outside an entity or aggregate
- Support serialization of Value Objects in `SQLAlchemy` with a custom JSON serializer

This functionality will come in handy when embedding List of Value Objects in containers like Events, which need to enclose all information related to the event within themselves.

Fixes #422 