### PR TITLE
Explicitly control automatic addition of identity field

### DIFF
--- a/docs/guides/compose-a-domain/object-model.md
+++ b/docs/guides/compose-a-domain/object-model.md
@@ -54,3 +54,9 @@ You can also pass options as parameters to the decorator:
 ```python hl_lines="7"
 {! docs_src/guides/composing-a-domain/021.py !}
 ```
+
+
+### `abstract`
+
+
+### `auto_add_id_field`

--- a/docs/guides/domain-definition/aggregates.md
+++ b/docs/guides/domain-definition/aggregates.md
@@ -114,7 +114,7 @@ Available options are:
 
 ### `abstract`
 
-When specified marks an Aggregate as abstract. If abstract, the aggregate
+Marks an Aggregate as abstract if `True`. If abstract, the aggregate
 cannot be instantiated and needs to be subclassed.
 
 ```python hl_lines="12"
@@ -129,6 +129,13 @@ NotSupportedError                         Traceback (most recent call last)
 ...
 NotSupportedError: TimeStamped class has been marked abstract and cannot be instantiated
 ```
+
+### `auto_add_id_field`
+
+If `True`, the aggregate will not contain an identifier field (acting as
+primary key) added by default. This option is usually combined with
+`abstract` to create classes that are meant to be subclassed by other
+aggregates.
 
 ### `provider`
 

--- a/docs_src/guides/domain-definition/003.py
+++ b/docs_src/guides/domain-definition/003.py
@@ -10,7 +10,7 @@ def utc_now():
     return datetime.now(timezone.utc)
 
 
-@domain.aggregate(abstract=True)
+@domain.aggregate(abstract=True, auto_add_id_field=False)
 class TimeStamped:
     created_at = DateTime(default=utc_now)
     updated_at = DateTime(default=utc_now)

--- a/src/protean/core/aggregate.py
+++ b/src/protean/core/aggregate.py
@@ -58,6 +58,7 @@ class BaseAggregate(EventedMixin, BaseEntity):
     @classmethod
     def _default_options(cls):
         return [
+            ("auto_add_id_field", True),
             ("provider", "default"),
             ("model", None),
             ("stream_name", inflection.underscore(cls.__name__)),

--- a/src/protean/core/entity.py
+++ b/src/protean/core/entity.py
@@ -77,7 +77,7 @@ class _EntityState:
     fields_cache = _FieldsCacheDescriptor()
 
 
-class BaseEntity(IdentityMixin, OptionsMixin, BaseContainer):
+class BaseEntity(OptionsMixin, IdentityMixin, BaseContainer):
     """The Base class for Protean-Compliant Domain Entities.
 
     Provides helper methods to custom define entity attributes, and query attribute names
@@ -122,6 +122,7 @@ class BaseEntity(IdentityMixin, OptionsMixin, BaseContainer):
     @classmethod
     def _default_options(cls):
         return [
+            ("auto_add_id_field", True),
             ("provider", "default"),
             ("model", None),
             ("part_of", None),

--- a/src/protean/core/event_sourced_aggregate.py
+++ b/src/protean/core/event_sourced_aggregate.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 class BaseEventSourcedAggregate(
-    IdentityMixin, EventedMixin, OptionsMixin, BaseContainer
+    OptionsMixin, IdentityMixin, EventedMixin, BaseContainer
 ):
     """Base Event Sourced Aggregate class that all EventSourced Aggregates should inherit from.
 
@@ -40,6 +40,7 @@ class BaseEventSourcedAggregate(
     @classmethod
     def _default_options(cls):
         return [
+            ("auto_add_id_field", True),
             ("stream_name", inflection.underscore(cls.__name__)),
         ]
 


### PR DESCRIPTION
Entities and Aggregates in Protean are automatically augmented with an identity field (named `id`), when one has not been explicitly provided. Until now, the assumption was the abstract aggregates will not need to have identifier fields, which was incorrect.

This commit allows control of automatic addition of identity field with an explicit flag named `auto_add_id_field`. With this change, even abstract aggregates can have identity fields.