### PR TITLE
Sync event version during event fetch in DAO

### DIFF
--- a/src/protean/adapters/repository/elasticsearch.py
+++ b/src/protean/adapters/repository/elasticsearch.py
@@ -310,8 +310,12 @@ class ESProvider(BaseProvider):
     def __init__(self, name, domain, conn_info: dict):
         """Initialize Provider with Connection/Adapter details"""
 
-        # In case of `ESProvider`, the `database` value will always be `ELASTICSEARCH`.
-        conn_info["database_uri"] = json.loads(conn_info["database_uri"])
+        # Use database_uri as is if it's a json, otherwise convert it to json
+        if isinstance(conn_info["database_uri"], str):
+            conn_info["database_uri"] = json.loads(conn_info["database_uri"])
+        else:
+            conn_info["database_uri"] = conn_info["database_uri"]
+
         super().__init__(name, domain, conn_info)
 
         # A temporary cache of already constructed model classes

--- a/src/protean/core/email.py
+++ b/src/protean/core/email.py
@@ -25,13 +25,7 @@ class BaseEmailProvider:
 
     @abstractmethod
     def send_email(self, email_message):
-        """
-        Send EmailMessage object via registered email provider.
-        """
-        raise NotImplementedError(
-            "Concrete implementations of BaseEmailBackend "
-            "must override send_email() method"
-        )
+        """Send EmailMessage object via registered email provider."""
 
 
 class BaseEmail(BaseContainer, OptionsMixin):  # FIXME Remove OptionsMixin

--- a/src/protean/core/subscriber.py
+++ b/src/protean/core/subscriber.py
@@ -35,7 +35,6 @@ class BaseSubscriber(Element, OptionsMixin):
     @abstractmethod
     def __call__(self, payload: dict) -> None:
         """Placeholder method for receiving notifications on event"""
-        raise NotImplementedError
 
 
 def subscriber_factory(element_cls: Type[Element], domain: "Domain", **opts):

--- a/src/protean/fields/association.py
+++ b/src/protean/fields/association.py
@@ -322,12 +322,10 @@ class Association(FieldBase, FieldDescriptorMixin, FieldCacheMixin):
     @abstractmethod
     def _fetch_objects(self, instance, key, value):
         """Placeholder method for customized Association query methods"""
-        raise NotImplementedError
 
     @abstractmethod
     def as_dict(self):
         """Return JSON-compatible value of field"""
-        raise NotImplementedError
 
     def __set__(self, instance, value):
         """Set the value of the association field"""

--- a/src/protean/port/dao.py
+++ b/src/protean/port/dao.py
@@ -571,4 +571,3 @@ class BaseLookup(metaclass=ABCMeta):
 
         Concrete implementation for this method varies from database to database.
         """
-        raise NotImplementedError

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -14,6 +14,11 @@ def initialize_domain(file_path, name="Tests"):
     """Initialize a Protean Domain with configuration from a file"""
     domain = Domain(file_path, name=name)
 
+    # We initialize and load default configuration into the domain here
+    #   so that test cases that don't need explicit domain setup can
+    #   still function.
+    domain._initialize()
+
     return domain
 
 


### PR DESCRIPTION
This commit moves the event position sync mechanism to a central place in `queryset.all`, so that the event position is up-to-date no matter the mechanism used to retrieve the record.

Fixes #461