### PR TITLE
Accept optional config during Domain initialization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,4 @@ test-full: up
 	protean test
 
 cov: up
-    pytest --slow --sqlite --postgresql --elasticsearch --redis --message_db --cov=protean --cov-config .coveragerc tests
+	pytest --slow --sqlite --postgresql --elasticsearch --redis --message_db --cov=protean --cov-config .coveragerc tests

--- a/docs_src/adapters/001.py
+++ b/docs_src/adapters/001.py
@@ -1,6 +1,6 @@
 from protean import Domain
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 # Non-existent database
 domain.config["databases"]["default"] = {

--- a/docs_src/adapters/database/postgresql/001.py
+++ b/docs_src/adapters/database/postgresql/001.py
@@ -4,7 +4,7 @@ from protean import Domain
 from protean.adapters.repository.sqlalchemy import SqlalchemyModel
 from protean.fields import Integer, String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 domain.config["databases"]["default"] = {
     "provider": "postgresql",
     "database_uri": "postgresql://postgres:postgres@localhost:5432/postgres",

--- a/docs_src/guides/change_state_001.py
+++ b/docs_src/guides/change_state_001.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate

--- a/docs_src/guides/change_state_002.py
+++ b/docs_src/guides/change_state_002.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Float, HasMany, String, Text
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate

--- a/docs_src/guides/change_state_003.py
+++ b/docs_src/guides/change_state_003.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Boolean, Identifier, String, Text
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate

--- a/docs_src/guides/change_state_004.py
+++ b/docs_src/guides/change_state_004.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Integer, String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate

--- a/docs_src/guides/change_state_005.py
+++ b/docs_src/guides/change_state_005.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Integer, String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate

--- a/docs_src/guides/change_state_006.py
+++ b/docs_src/guides/change_state_006.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 from protean import Domain
 from protean.fields import DateTime, Identifier
 
-publishing = Domain(__file__, "Publishing", load_toml=False)
+publishing = Domain(__file__, "Publishing")
 
 
 def utc_now():

--- a/docs_src/guides/change_state_007.py
+++ b/docs_src/guides/change_state_007.py
@@ -5,7 +5,7 @@ from protean import Domain, handle
 from protean.fields import DateTime, Identifier, String
 from protean.utils.globals import current_domain
 
-publishing = Domain(__file__, "Publishing", load_toml=False)
+publishing = Domain(__file__, "Publishing")
 
 
 def utc_now():

--- a/docs_src/guides/change_state_008.py
+++ b/docs_src/guides/change_state_008.py
@@ -1,7 +1,7 @@
 from protean import Domain, current_domain, use_case
 from protean.fields import Identifier, String
 
-auth = Domain(__file__, "Auth", load_toml=False)
+auth = Domain(__file__, "Auth")
 
 
 @auth.aggregate

--- a/docs_src/guides/composing-a-domain/001.py
+++ b/docs_src/guides/composing-a-domain/001.py
@@ -1,3 +1,3 @@
 from protean import Domain
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)

--- a/docs_src/guides/composing-a-domain/002.py
+++ b/docs_src/guides/composing-a-domain/002.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Integer, String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate

--- a/docs_src/guides/composing-a-domain/003.py
+++ b/docs_src/guides/composing-a-domain/003.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Integer, String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate

--- a/docs_src/guides/composing-a-domain/004.py
+++ b/docs_src/guides/composing-a-domain/004.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Integer, String, ValueObject
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.value_object

--- a/docs_src/guides/composing-a-domain/005.py
+++ b/docs_src/guides/composing-a-domain/005.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Identifier, Integer, String, ValueObject
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate

--- a/docs_src/guides/composing-a-domain/006.py
+++ b/docs_src/guides/composing-a-domain/006.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Integer, String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.event_sourced_aggregate

--- a/docs_src/guides/composing-a-domain/007.py
+++ b/docs_src/guides/composing-a-domain/007.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Identifier, String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate

--- a/docs_src/guides/composing-a-domain/008.py
+++ b/docs_src/guides/composing-a-domain/008.py
@@ -1,7 +1,7 @@
 from protean import Domain, handle
 from protean.fields import Identifier, String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.event_sourced_aggregate

--- a/docs_src/guides/composing-a-domain/009.py
+++ b/docs_src/guides/composing-a-domain/009.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Identifier, String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate

--- a/docs_src/guides/composing-a-domain/010.py
+++ b/docs_src/guides/composing-a-domain/010.py
@@ -1,7 +1,7 @@
 from protean import Domain, handle
 from protean.fields import Identifier, String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate

--- a/docs_src/guides/composing-a-domain/011.py
+++ b/docs_src/guides/composing-a-domain/011.py
@@ -6,7 +6,7 @@ from sqlalchemy.dialects.postgresql import UUID
 from protean import Domain
 from protean.fields import Identifier, String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate

--- a/docs_src/guides/composing-a-domain/012.py
+++ b/docs_src/guides/composing-a-domain/012.py
@@ -4,7 +4,7 @@ from protean import Domain
 from protean.fields import Integer, String
 from protean.utils.globals import current_domain
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate

--- a/docs_src/guides/composing-a-domain/013.py
+++ b/docs_src/guides/composing-a-domain/013.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Identifier, Integer, String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate

--- a/docs_src/guides/composing-a-domain/014.py
+++ b/docs_src/guides/composing-a-domain/014.py
@@ -2,7 +2,7 @@ from protean.core.aggregate import BaseAggregate
 from protean.domain import Domain
 from protean.fields import Integer, String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 class User(BaseAggregate):

--- a/docs_src/guides/composing-a-domain/015.py
+++ b/docs_src/guides/composing-a-domain/015.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Integer, String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate(stream_category="account")

--- a/docs_src/guides/composing-a-domain/016.py
+++ b/docs_src/guides/composing-a-domain/016.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Identifier, String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate

--- a/docs_src/guides/composing-a-domain/017.py
+++ b/docs_src/guides/composing-a-domain/017.py
@@ -1,6 +1,6 @@
 from protean import Domain
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 domain.config["databases"]["default"] = {
     "provider": "sqlalchemy",

--- a/docs_src/guides/composing-a-domain/018.py
+++ b/docs_src/guides/composing-a-domain/018.py
@@ -2,7 +2,7 @@ from protean import Domain
 from protean.fields import Integer, String
 from protean.utils.globals import current_domain
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate

--- a/docs_src/guides/composing-a-domain/019.py
+++ b/docs_src/guides/composing-a-domain/019.py
@@ -6,7 +6,7 @@ from protean import Domain
 from protean.domain.context import has_domain_context
 from protean.fields import Integer, String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate

--- a/docs_src/guides/composing-a-domain/020.py
+++ b/docs_src/guides/composing-a-domain/020.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Integer, String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate(stream_category="account")

--- a/docs_src/guides/composing-a-domain/021.py
+++ b/docs_src/guides/composing-a-domain/021.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Integer, String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate(stream_category="account")

--- a/docs_src/guides/composing-a-domain/022.py
+++ b/docs_src/guides/composing-a-domain/022.py
@@ -9,7 +9,7 @@ def gen_ids(prefix="id"):
     return f"{prefix}-{timestamp}-{random.randint(0, 1000)}"
 
 
-domain = Domain(__file__, load_toml=False, identity_function=gen_ids)
+domain = Domain(__file__, identity_function=gen_ids)
 
 # or you can pass parameters too
 # domain = Domain(__file__, identity_function=lambda: gen_ids("foo"))

--- a/docs_src/guides/composing-a-domain/023.py
+++ b/docs_src/guides/composing-a-domain/023.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Auto, String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate

--- a/docs_src/guides/composing-a-domain/024.py
+++ b/docs_src/guides/composing-a-domain/024.py
@@ -3,7 +3,7 @@ import time
 from protean import Domain
 from protean.fields import Auto, String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 def gen_id():  # (1)

--- a/docs_src/guides/consume-state/001.py
+++ b/docs_src/guides/consume-state/001.py
@@ -1,7 +1,7 @@
 from protean import Domain, handle
 from protean.fields import Identifier, Integer, String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 domain.config["event_processing"] = "sync"
 
 

--- a/docs_src/guides/consume-state/002.py
+++ b/docs_src/guides/consume-state/002.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 from protean import Domain, handle, invariant
 from protean.fields import Float, Identifier, Integer, String, Text
 
-domain = Domain("__file__", load_toml=False)
+domain = Domain("__file__")
 
 # Process events and commands synchronously
 domain.config["command_processing"] = "sync"

--- a/docs_src/guides/domain-behavior/001.py
+++ b/docs_src/guides/domain-behavior/001.py
@@ -5,7 +5,7 @@ from protean import Domain, invariant
 from protean.exceptions import ValidationError
 from protean.fields import Date, Float, HasMany, Identifier, Integer, String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 class OrderStatus(Enum):

--- a/docs_src/guides/domain-behavior/002.py
+++ b/docs_src/guides/domain-behavior/002.py
@@ -1,7 +1,7 @@
 from protean import Domain, invariant
 from protean.fields import Float, Identifier
 
-banking = Domain(__file__, load_toml=False)
+banking = Domain(__file__)
 
 
 class InsufficientFundsException(Exception):

--- a/docs_src/guides/domain-behavior/003.py
+++ b/docs_src/guides/domain-behavior/003.py
@@ -4,7 +4,7 @@ from enum import Enum
 from protean import Domain
 from protean.fields import DateTime, Float, Integer, String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 def utc_now():

--- a/docs_src/guides/domain-behavior/004.py
+++ b/docs_src/guides/domain-behavior/004.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Integer, String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-behavior/005.py
+++ b/docs_src/guides/domain-behavior/005.py
@@ -3,7 +3,7 @@ import re
 from protean import Domain
 from protean.fields import String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 class EmailValidator:

--- a/docs_src/guides/domain-behavior/006.py
+++ b/docs_src/guides/domain-behavior/006.py
@@ -13,7 +13,7 @@ from protean.fields import (
     ValueObject,
 )
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 class OrderStatus(Enum):

--- a/docs_src/guides/domain-behavior/007.py
+++ b/docs_src/guides/domain-behavior/007.py
@@ -13,7 +13,7 @@ from protean.fields import (
     ValueObject,
 )
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 class OrderStatus(Enum):

--- a/docs_src/guides/domain-behavior/008.py
+++ b/docs_src/guides/domain-behavior/008.py
@@ -13,7 +13,7 @@ from protean.fields import (
     ValueObject,
 )
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 class OrderStatus(Enum):

--- a/docs_src/guides/domain-behavior/009.py
+++ b/docs_src/guides/domain-behavior/009.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 from protean import Domain, fields, invariant
 from protean.exceptions import ValidationError
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.event(part_of="Order")

--- a/docs_src/guides/domain-behavior/010.py
+++ b/docs_src/guides/domain-behavior/010.py
@@ -3,7 +3,7 @@ from datetime import date
 from protean import Domain
 from protean.fields import Date, HasMany, Identifier, String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-definition/001.py
+++ b/docs_src/guides/domain-definition/001.py
@@ -1,7 +1,7 @@
 from protean.domain import Domain
 from protean.fields import Date, String
 
-publishing = Domain(__file__, load_toml=False)
+publishing = Domain(__file__)
 
 
 @publishing.aggregate

--- a/docs_src/guides/domain-definition/002.py
+++ b/docs_src/guides/domain-definition/002.py
@@ -3,7 +3,7 @@ import json
 from protean.domain import Domain
 from protean.fields import Date, String
 
-publishing = Domain(__file__, name="Publishing", load_toml=False)
+publishing = Domain(__file__, name="Publishing")
 
 
 @publishing.aggregate

--- a/docs_src/guides/domain-definition/003.py
+++ b/docs_src/guides/domain-definition/003.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 from protean import Domain
 from protean.fields import DateTime, String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 def utc_now():

--- a/docs_src/guides/domain-definition/004.py
+++ b/docs_src/guides/domain-definition/004.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 domain.config["DATABASES"] = {
     "default": {
         "PROVIDER": "protean.adapters.repository.sqlalchemy.SAProvider",

--- a/docs_src/guides/domain-definition/005.py
+++ b/docs_src/guides/domain-definition/005.py
@@ -3,7 +3,7 @@ import sqlalchemy
 from protean import Domain
 from protean.fields import String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 domain.config["DATABASES"] = {
     "default": {
         "PROVIDER": "protean.adapters.repository.sqlalchemy.SAProvider",

--- a/docs_src/guides/domain-definition/006.py
+++ b/docs_src/guides/domain-definition/006.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-definition/012.py
+++ b/docs_src/guides/domain-definition/012.py
@@ -2,7 +2,7 @@ from protean import Domain, invariant
 from protean.exceptions import ValidationError
 from protean.fields import Float, String
 
-domain = Domain(__name__, load_toml=False)
+domain = Domain(__name__)
 
 
 @domain.value_object

--- a/docs_src/guides/domain-definition/events/001.py
+++ b/docs_src/guides/domain-definition/events/001.py
@@ -3,7 +3,7 @@ from enum import Enum
 from protean import Domain
 from protean.fields import Identifier, String
 
-domain = Domain(__file__, name="Authentication", load_toml=False)
+domain = Domain(__file__, name="Authentication")
 
 
 class UserStatus(Enum):

--- a/docs_src/guides/domain-definition/events/002.py
+++ b/docs_src/guides/domain-definition/events/002.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 from protean import BaseEvent, Domain
 from protean.fields import DateTime, Identifier, String
 
-domain = Domain(__name__, name="Authentication", load_toml=False)
+domain = Domain(__name__, name="Authentication")
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-definition/events/003.py
+++ b/docs_src/guides/domain-definition/events/003.py
@@ -4,7 +4,7 @@ from protean import Domain
 from protean.fields import HasOne, String
 from protean.utils.mixins import Message
 
-domain = Domain(__file__, name="Authentication", load_toml=False)
+domain = Domain(__file__, name="Authentication")
 
 
 @domain.aggregate(fact_events=True)

--- a/docs_src/guides/domain-definition/fields/association-fields/001.py
+++ b/docs_src/guides/domain-definition/fields/association-fields/001.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import HasOne, String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-definition/fields/association-fields/002.py
+++ b/docs_src/guides/domain-definition/fields/association-fields/002.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Float, HasMany, String, Text
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-definition/fields/container-fields/001.py
+++ b/docs_src/guides/domain-definition/fields/container-fields/001.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import List, String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-definition/fields/container-fields/002.py
+++ b/docs_src/guides/domain-definition/fields/container-fields/002.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Dict, String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-definition/fields/container-fields/003.py
+++ b/docs_src/guides/domain-definition/fields/container-fields/003.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Float, String, ValueObject
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.value_object

--- a/docs_src/guides/domain-definition/fields/container-fields/004.py
+++ b/docs_src/guides/domain-definition/fields/container-fields/004.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import HasOne, List, String, ValueObject
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.value_object

--- a/docs_src/guides/domain-definition/fields/options/001.py
+++ b/docs_src/guides/domain-definition/fields/options/001.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-definition/fields/options/002.py
+++ b/docs_src/guides/domain-definition/fields/options/002.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-definition/fields/options/006.py
+++ b/docs_src/guides/domain-definition/fields/options/006.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-definition/fields/options/007.py
+++ b/docs_src/guides/domain-definition/fields/options/007.py
@@ -3,7 +3,7 @@ from enum import Enum
 from protean import Domain
 from protean.fields import Integer, String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 class BuildingStatus(Enum):

--- a/docs_src/guides/domain-definition/fields/options/008.py
+++ b/docs_src/guides/domain-definition/fields/options/008.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-definition/fields/options/009.py
+++ b/docs_src/guides/domain-definition/fields/options/009.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import List, String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-definition/fields/options/010.py
+++ b/docs_src/guides/domain-definition/fields/options/010.py
@@ -4,7 +4,7 @@ from protean import Domain
 from protean.exceptions import ValidationError
 from protean.fields import String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 class EmailDomainValidator:

--- a/docs_src/guides/domain-definition/fields/options/011.py
+++ b/docs_src/guides/domain-definition/fields/options/011.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Integer
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-definition/fields/simple-fields/001.py
+++ b/docs_src/guides/domain-definition/fields/simple-fields/001.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-definition/fields/simple-fields/002.py
+++ b/docs_src/guides/domain-definition/fields/simple-fields/002.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import String, Text
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-definition/fields/simple-fields/003.py
+++ b/docs_src/guides/domain-definition/fields/simple-fields/003.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Integer, String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-definition/fields/simple-fields/004.py
+++ b/docs_src/guides/domain-definition/fields/simple-fields/004.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Float, String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-definition/fields/simple-fields/005.py
+++ b/docs_src/guides/domain-definition/fields/simple-fields/005.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from protean import Domain
 from protean.fields import Date, String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-definition/fields/simple-fields/006.py
+++ b/docs_src/guides/domain-definition/fields/simple-fields/006.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 from protean import Domain
 from protean.fields import DateTime, String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-definition/fields/simple-fields/007.py
+++ b/docs_src/guides/domain-definition/fields/simple-fields/007.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Boolean, String
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-definition/fields/simple-fields/008.py
+++ b/docs_src/guides/domain-definition/fields/simple-fields/008.py
@@ -2,7 +2,7 @@ from protean import Domain
 from protean.fields import Boolean, Identifier, String
 from protean.utils import IdentityType
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)
 
 # Customize Identity Strategy and Type and activate
 domain.config["IDENTITY_TYPE"] = IdentityType.INTEGER.value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,8 @@ asyncio_mode = "auto"
 testpaths = ["tests"]
 filterwarnings = [
     "ignore::sqlalchemy.exc.SAWarning",
-    "ignore::sqlalchemy.exc.SADeprecationWarning"
+    "ignore::sqlalchemy.exc.SADeprecationWarning",
+    "ignore:No configuration file found.*Using default configuration.*:UserWarning"
 ]
 python_files = [
     "test_*.py",

--- a/src/protean/domain/__init__.py
+++ b/src/protean/domain/__init__.py
@@ -101,7 +101,7 @@ class Domain:
         self,
         root_path: str,
         name: str = "",
-        load_toml: bool = True,
+        config: Optional[Dict] = None,
         identity_function: Optional[Callable] = None,
     ):
         self.root_path = root_path
@@ -122,7 +122,7 @@ class Domain:
         #: The configuration dictionary as :class:`Config`.  This behaves
         #: exactly like a regular dictionary but supports additional methods
         #: to load a config from files.
-        self.config = self.load_config(load_toml)
+        self.config = self.load_config(config)
 
         # The function to invoke to generate identity
         self._identity_function = identity_function
@@ -315,19 +315,19 @@ class Domain:
         self.brokers._initialize()
         self.event_store._initialize()
 
-    def load_config(self, load_toml=True):
-        """Load configuration from dist or a .toml file."""
-        if load_toml:
-            config = Config2.load_from_path(self.root_path)
+    def load_config(self, config=None):
+        """Load configuration from a dict or a .toml file."""
+        if config is not None:
+            config_obj = Config2.load_from_dict(config)
         else:
-            config = Config2.load_from_dict()
+            config_obj = Config2.load_from_path(self.root_path)
 
         # Load Constants
-        if "custom" in config:
-            for constant, value in config["custom"].items():
+        if "custom" in config_obj:
+            for constant, value in config_obj["custom"].items():
                 setattr(self, constant, value)
 
-        return config
+        return config_obj
 
     def domain_context(self, **kwargs):
         """Create an :class:`~protean.context.DomainContext`. Use as a ``with``

--- a/src/protean/domain/config.py
+++ b/src/protean/domain/config.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import re
+import warnings
 
 import tomllib
 
@@ -98,9 +99,12 @@ class Config2(dict):
             current_dir = os.path.dirname(current_dir)  # Move to the parent directory
 
         if not config_file_name:
-            raise ConfigurationError(
+            warnings.warn(
                 f"No configuration file found in {os.path.dirname(path)}"
+                f" or its immediate 2 parent directories. Using default configuration."
             )
+            # Return default config when no config file is found
+            return cls(**_default_config())
 
         config = {}
         if config_file_name:

--- a/tests/adapters/repository/elasticsearch_repo/test_provider.py
+++ b/tests/adapters/repository/elasticsearch_repo/test_provider.py
@@ -46,7 +46,7 @@ class TestProviders:
     @pytest.mark.no_test_domain
     def test_exception_on_invalid_provider(self):
         """Test exception on invalid provider"""
-        domain = Domain(__file__, load_toml=False)
+        domain = Domain(__file__)
         domain.config["databases"]["default"] = {
             "provider": "elasticsearch",
             "database_uri": '{"hosts": ["imaginary"]}',

--- a/tests/adapters/repository/sqlalchemy_repo/postgresql/test_provider.py
+++ b/tests/adapters/repository/sqlalchemy_repo/postgresql/test_provider.py
@@ -48,7 +48,7 @@ class TestProviders:
     @pytest.mark.no_test_domain
     def test_exception_on_invalid_provider(self):
         """Test exception on invalid provider"""
-        domain = Domain(__file__, load_toml=False)
+        domain = Domain(__file__)
         domain.config["databases"]["default"] = {
             "provider": "postgresql",
             "database_uri": "postgresql://postgres:postgres@localhost:5444/foobar",

--- a/tests/adapters/repository/sqlalchemy_repo/sqlite/test_provider.py
+++ b/tests/adapters/repository/sqlalchemy_repo/sqlite/test_provider.py
@@ -49,7 +49,7 @@ class TestProviders:
     @pytest.mark.no_test_domain
     def test_exception_on_invalid_provider(self):
         """Test exception on invalid provider"""
-        domain = Domain(__file__, load_toml=False)
+        domain = Domain(__file__)
         domain.config["databases"]["default"] = {
             "provider": "sqlite",
             "database_uri": "sqlite:////C:/Users/username/foobar.db",

--- a/tests/cli/test_domain_loading.py
+++ b/tests/cli/test_domain_loading.py
@@ -14,17 +14,17 @@ from tests.shared import change_working_directory_to
 
 def test_find_domain_in_module():
     class Module:
-        domain = Domain(__file__, "name", load_toml=False)
+        domain = Domain(__file__, "name")
 
     assert find_domain_in_module(Module) == Module.domain
 
     class Module:
-        subdomain = Domain(__file__, "name", load_toml=False)
+        subdomain = Domain(__file__, "name")
 
     assert find_domain_in_module(Module) == Module.subdomain
 
     class Module:
-        my_domain = Domain(__file__, "name", load_toml=False)
+        my_domain = Domain(__file__, "name")
 
     assert find_domain_in_module(Module) == Module.my_domain
 
@@ -34,8 +34,8 @@ def test_find_domain_in_module():
     pytest.raises(NoDomainException, find_domain_in_module, Module)
 
     class Module:
-        my_domain1 = Domain(__file__, "name1", load_toml=False)
-        my_domain2 = Domain(__file__, "name2", load_toml=False)
+        my_domain1 = Domain(__file__, "name1")
+        my_domain2 = Domain(__file__, "name2")
 
     pytest.raises(NoDomainException, find_domain_in_module, Module)
 

--- a/tests/cli/test_find_domain_by_string.py
+++ b/tests/cli/test_find_domain_by_string.py
@@ -16,7 +16,7 @@ def mock_module():
     module = MagicMockWithName()
 
     # Configure the module for different test scenarios
-    module.valid_domain = Domain(__file__, load_toml=False)
+    module.valid_domain = Domain(__file__)
     module.not_a_domain = "not a domain instance"
     return module
 
@@ -30,7 +30,7 @@ def test_find_domain_by_string_with_empty_domain_name(mock_module):
 
 
 def test_find_domain_by_string_with_whitespace_domain_name(mock_module):
-    mock_module.valid_domain = Domain(__file__, load_toml=False)
+    mock_module.valid_domain = Domain(__file__)
     domain = find_domain_by_string(mock_module, " valid_domain ")
     assert isinstance(
         domain, Domain
@@ -70,9 +70,7 @@ def test_find_domain_by_string_with_nonexistent_attribute(mock_module):
 
 
 def test_find_domain_by_string_with_function_call(mock_module):
-    mock_module.domain_function = MagicMock(
-        return_value=Domain(__file__, load_toml=False)
-    )
+    mock_module.domain_function = MagicMock(return_value=Domain(__file__))
     domain = find_domain_by_string(mock_module, "domain_function()")
     assert isinstance(domain, Domain), "Should handle function calls correctly"
 
@@ -86,7 +84,7 @@ def test_find_domain_by_string_with_function_call_with_arguments(mock_module):
 
 
 def test_find_domain_by_string_returns_correct_domain_instance(mock_module):
-    expected_domain = Domain(__file__, load_toml=False)
+    expected_domain = Domain(__file__)
     mock_module.specific_domain = expected_domain
     actual_domain = find_domain_by_string(mock_module, "specific_domain")
     assert (

--- a/tests/config/domain.toml
+++ b/tests/config/domain.toml
@@ -5,6 +5,7 @@ identity_strategy = "uuid"
 identity_type = "string"
 event_processing = "sync"
 command_processing = "sync"
+message_processing = "sync"
 
 [databases.default]
 provider = "memory"

--- a/tests/config/test_custom_constants.py
+++ b/tests/config/test_custom_constants.py
@@ -30,6 +30,6 @@ class TestConstantsOnDomain:
         domain.FOO == "bar"
 
     def test_when_no_constants_are_defined(self):
-        domain = Domain(__file__, load_toml=False)
+        domain = Domain(__file__)
         assert domain is not None
         assert hasattr(domain, "FOO") is False

--- a/tests/config/test_load.py
+++ b/tests/config/test_load.py
@@ -101,13 +101,11 @@ class TestLoadingTOML:
             domain.config["custom"]["FOO"] = "baz"
 
     @pytest.mark.no_test_domain
-    def test_domain_throws_error_if_config_file_not_found(self):
+    def test_warning_if_config_file_not_found(self):
         change_working_directory_to("test19")
 
-        with pytest.raises(ConfigurationError) as exc:
+        with pytest.warns(UserWarning, match="No configuration file found in"):
             derive_domain("domain19")
-
-        assert "No configuration file found in" in str(exc.value)
 
 
 class TestLoadingDefaults:

--- a/tests/config/test_optional_config.py
+++ b/tests/config/test_optional_config.py
@@ -1,0 +1,26 @@
+# Test that the optional config is loaded correctly into Domain object
+
+from protean.domain import Domain
+
+
+def test_domain_loads_config_from_toml_file():
+    domain = Domain(__file__, "dummy")
+    config = domain.load_config()
+    assert config["debug"] is True
+    assert config["testing"] is True
+    assert config["secret_key"] == "tvTpk3PAfkGr5x9!2sFU%XpW7bR8cwKA"
+    assert config["custom"]["foo"] == "bar"
+
+
+def test_domain_loads_config_from_dict():
+    test_config = {
+        "debug": False,
+        "testing": False,
+        "custom": {"test_key": "test_value"},
+    }
+    domain = Domain(__file__, "dummy")
+    config = domain.load_config(test_config)
+    assert config["debug"] is False
+    assert config["testing"] is False
+    assert config["custom"]["test_key"] == "test_value"
+    assert domain.test_key == "test_value"

--- a/tests/domain/test_config_immutability.py
+++ b/tests/domain/test_config_immutability.py
@@ -3,10 +3,10 @@ from protean.utils import IdentityStrategy
 
 
 def test_that_config_is_unique_to_each_domain():
-    domain1 = Domain(__file__, load_toml=False)
+    domain1 = Domain(__file__)
     assert domain1.config["identity_strategy"] == IdentityStrategy.UUID.value
 
     domain1.config["identity_strategy"] = "FOO"
 
-    domain2 = Domain(__file__, load_toml=False)
+    domain2 = Domain(__file__)
     assert domain2.config["identity_strategy"] == IdentityStrategy.UUID.value

--- a/tests/domain/test_domain_config.py
+++ b/tests/domain/test_domain_config.py
@@ -7,7 +7,7 @@ from protean.fields import Auto
 
 
 def test_invalid_identity_strategy():
-    domain = Domain(__file__, load_toml=False)
+    domain = Domain(__file__)
     domain.config["identity_strategy"] = "invalid"
 
     class AutoTest(BaseAggregate):
@@ -23,7 +23,7 @@ def test_invalid_identity_strategy():
 
 
 def test_error_on_no_identity_function_if_strategy_is_function():
-    domain = Domain(__file__, load_toml=False)
+    domain = Domain(__file__)
     domain.config["identity_strategy"] = "function"
 
     class AutoTest(BaseAggregate):

--- a/tests/domain/tests.py
+++ b/tests/domain/tests.py
@@ -16,13 +16,13 @@ from .elements import UserAggregate, UserEntity, UserFoo, UserVO
 
 
 def test_domain_name():
-    domain = Domain(__file__, "Foo", load_toml=False)
+    domain = Domain(__file__, "Foo")
 
     assert domain.name == "Foo"
 
 
 def test_domain_name_string():
-    domain = Domain(__file__, "Foo", load_toml=False)
+    domain = Domain(__file__, "Foo")
 
     assert str(domain) == "Domain: Foo"
 
@@ -48,7 +48,7 @@ def test_normalized_domain_name():
         ("My Domain 1.0", "my_domain_1_0"),
     ]
     for name, result in data:
-        domain = Domain(__file__, name, load_toml=False)
+        domain = Domain(__file__, name)
         assert domain.normalized_name == result, f"Failed for {name}"
 
 
@@ -73,7 +73,7 @@ def test_camel_case_domain_name():
         ("My Domain 1.0", "MyDomain10"),
     ]
     for name, result in data:
-        domain = Domain(__file__, name, load_toml=False)
+        domain = Domain(__file__, name)
         assert domain.camel_case_name == result, f"Failed for {name}"
 
 
@@ -206,12 +206,12 @@ class TestDomainLevelClassResolution:
         def test_domain(self):
             from protean.domain import Domain
 
-            domain = Domain(__file__, "Test", load_toml=False)
+            domain = Domain(__file__, "Test")
             domain.config["databases"]["memory"] = {"provider": "memory"}
             yield domain
 
         def test_that_class_reference_is_tracked_at_the_domain_level(self):
-            domain = Domain(__file__, load_toml=False)
+            domain = Domain(__file__)
 
             class Post(BaseAggregate):
                 content = Text(required=True)
@@ -237,7 +237,7 @@ class TestDomainLevelClassResolution:
             )
 
         def test_that_class_reference_is_resolved_on_domain_initialization(self):
-            domain = Domain(__file__, "Inline Domain", load_toml=False)
+            domain = Domain(__file__, "Inline Domain")
 
             class Post(BaseAggregate):
                 content = Text(required=True)
@@ -268,7 +268,7 @@ class TestDomainLevelClassResolution:
         def test_that_domain_throws_exception_on_unknown_class_references_during_activation(
             self,
         ):
-            domain = Domain(__file__, "Inline Domain", load_toml=False)
+            domain = Domain(__file__, "Inline Domain")
 
             class Post(BaseAggregate):
                 content = Text(required=True)

--- a/tests/field/test_identifier.py
+++ b/tests/field/test_identifier.py
@@ -109,7 +109,7 @@ class TestIdentityType:
         identifier._load(42) == "42"
 
     def test_invalid_identity_type_in_domain_config(self):
-        domain = Domain(__file__, load_toml=False)
+        domain = Domain(__file__)
         domain.config["identity_type"] = "invalid"
 
         with domain.domain_context():
@@ -122,7 +122,7 @@ class TestIdentityType:
             }
 
     def test_that_default_is_picked_from_domain_config(self):
-        domain = Domain(__file__, load_toml=False)
+        domain = Domain(__file__)
 
         # By default, IdentityType is UUID
         with domain.domain_context():

--- a/tests/identity/conftest.py
+++ b/tests/identity/conftest.py
@@ -6,7 +6,7 @@ from protean.utils import IdentityType
 
 @pytest.fixture
 def domain():
-    return Domain(__file__, "Test", load_toml=False)
+    return Domain(__file__, "Test")
 
 
 @pytest.fixture

--- a/tests/server/test_engine_exits.py
+++ b/tests/server/test_engine_exits.py
@@ -12,7 +12,7 @@ def test_engine_exits_if_no_subscriptions(caplog):
     logger = logging.getLogger("protean.server.engine")
     logger.setLevel(logging.INFO)
 
-    domain = Domain("dummy", load_toml=False)
+    domain = Domain(__file__, "dummy")
     engine = Engine(domain, test_mode=True)
     engine.run()
 

--- a/tests/server/test_engine_handle_exception.py
+++ b/tests/server/test_engine_handle_exception.py
@@ -8,7 +8,7 @@ from protean.server.engine import Engine
 
 @pytest.fixture
 def engine():
-    domain = Domain(__file__, load_toml=False)
+    domain = Domain(__file__)
     return Engine(domain, test_mode=True, debug=True)
 
 

--- a/tests/support/domains/test1/basic.py
+++ b/tests/support/domains/test1/basic.py
@@ -1,3 +1,3 @@
 from protean import Domain
 
-domain = Domain(__file__, "BASIC", load_toml=False)
+domain = Domain(__file__, "BASIC")

--- a/tests/support/domains/test10/domain.py
+++ b/tests/support/domains/test10/domain.py
@@ -4,4 +4,4 @@ when no file/package and attribute name were provided
 
 from protean.domain import Domain
 
-domain = Domain(__file__, "TEST10", load_toml=False)
+domain = Domain(__file__, "TEST10")

--- a/tests/support/domains/test11/subdomain.py
+++ b/tests/support/domains/test11/subdomain.py
@@ -4,4 +4,4 @@ when no file/package and attribute name were provided
 
 from protean.domain import Domain
 
-domain = Domain(__file__, "TEST11", load_toml=False)
+domain = Domain(__file__, "TEST11")

--- a/tests/support/domains/test12/foo12.py
+++ b/tests/support/domains/test12/foo12.py
@@ -2,5 +2,5 @@
 
 from protean.domain import Domain
 
-subdomain = Domain(__file__, "TEST12", load_toml=False)
-specific = Domain(__file__, "TEST12_SPECIFIC", load_toml=False)
+subdomain = Domain(__file__, "TEST12")
+specific = Domain(__file__, "TEST12_SPECIFIC")

--- a/tests/support/domains/test13/publishing13.py
+++ b/tests/support/domains/test13/publishing13.py
@@ -5,4 +5,4 @@ The test is to check if the name is initialized to the module containing the dom
 
 from protean.domain import Domain
 
-domain = Domain(__file__, load_toml=False)
+domain = Domain(__file__)

--- a/tests/support/domains/test2/src/folder.py
+++ b/tests/support/domains/test2/src/folder.py
@@ -1,3 +1,3 @@
 from protean import Domain
 
-domain = Domain(__file__, "FOLDER", load_toml=False)
+domain = Domain(__file__, "FOLDER")

--- a/tests/support/domains/test3/nested/web.py
+++ b/tests/support/domains/test3/nested/web.py
@@ -1,3 +1,3 @@
 from protean import Domain
 
-domain = Domain(__file__, "WEB", load_toml=False)
+domain = Domain(__file__, "WEB")

--- a/tests/support/domains/test4/instance.py
+++ b/tests/support/domains/test4/instance.py
@@ -1,3 +1,3 @@
 from protean import Domain
 
-dom2 = Domain(__file__, "INSTANCE", load_toml=False)
+dom2 = Domain(__file__, "INSTANCE")

--- a/tests/support/domains/test6/publishing6.py
+++ b/tests/support/domains/test6/publishing6.py
@@ -1,3 +1,3 @@
 from protean.domain import Domain
 
-domain = Domain(__file__, "TEST6", load_toml=False)
+domain = Domain(__file__, "TEST6")

--- a/tests/support/domains/test7/publishing7.py
+++ b/tests/support/domains/test7/publishing7.py
@@ -1,3 +1,3 @@
 from protean.domain import Domain
 
-domain = Domain(__file__, "TEST7", load_toml=False)
+domain = Domain(__file__, "TEST7")

--- a/tests/support/domains/test8/sqlite_domain.py
+++ b/tests/support/domains/test8/sqlite_domain.py
@@ -4,7 +4,7 @@ for further testing, like docker file generation
 
 from protean.domain import Domain
 
-domain = Domain(__file__, "SQLite-Domain", load_toml=False)
+domain = Domain(__file__, "SQLite-Domain")
 
 
 domain.config["databases"] = {

--- a/tests/support/domains/test9/publishing9.py
+++ b/tests/support/domains/test9/publishing9.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from protean.domain import Domain
 from protean.fields import DateTime, HasMany, Reference, String
 
-domain = Domain(__file__, "TEST9", load_toml=False)
+domain = Domain(__file__, "TEST9")
 
 
 @domain.aggregate


### PR DESCRIPTION
- Refactor Domain initialization to remove load_toml parameter
- Domain will now accept an optional config parameter which will be used to decide whether to look for a TOML file or just use the supplied config.
- Protean will now display a warning if no config was specified and no TOML was found, instead of throwing a ConfigurationError Exception.
- Updated Domain initialization across multiple files to remove the load_toml parameter, simplifying the instantiation process.
- Adjusted related tests and documentation to reflect this change.