### PR TITLE
Explicitly control query result limits

### DIFF
--- a/docs/guides/change-state/retrieve-aggregates.md
+++ b/docs/guides/change-state/retrieve-aggregates.md
@@ -70,7 +70,7 @@ Out[8]:
    A repository can be connected to a specific persistence store by specifying
    the `database` parameter.
 
-## Data Acsess Objects (DAO)
+## Data Access Objects (DAO)
 
 You would have observed the query in the repository above was performed on a
 `_dao` object. This is a DAO object that is automatically generated for every
@@ -82,6 +82,152 @@ methods and implementations that clearly identify what the domain is trying to
 ask/do with the persistence store. Data Access Objects, on the other hand,
 talk the language of the database. A repository works in conjunction with the
 DAO layer to access and manipulate on the persistence store.
+
+## QuerySet
+
+A QuerySet represents a collection of objects from your database that can be filtered and ordered. When you perform a query through the DAO layer, it returns a QuerySet object that provides convenient methods to work with the results.
+
+QuerySets are lazy, meaning they don't access the database until you actually need the data. This allows you to chain multiple filtering operations efficiently without hitting the database repeatedly.
+
+### Basic QuerySet Operations
+
+Here's an example of using QuerySet methods:
+
+```python
+# Get a reference to the DAO through the repository
+dao = repository._dao
+
+# Create a queryset
+queryset = dao.query
+
+# Chain operations on the queryset
+filtered_query = queryset.filter(country="CA")
+ordered_query = filtered_query.order_by("age")
+
+# Execute the query and get results
+results = ordered_query.all().items
+
+# Print the names of people from Canada, ordered by age
+for person in results:
+    print(f"{person.name}, {person.age}")
+```
+
+### QuerySet Attributes and Methods
+
+QuerySets expose several attributes and methods:
+
+- **`filter()`**: Narrows down the query results based on specified conditions
+- **`exclude()`**: Removes matching objects from the queryset
+- **`all()`**: Returns a ResultSet containing all objects
+- **`order_by()`**: Orders the queryset results by specified fields
+- **`first()`**: Returns the first object matching the query
+- **`count()`**: Returns the number of objects matching the query
+
+### Chaining Operations
+
+One of the most powerful features of QuerySets is the ability to chain operations:
+
+```shell
+In [1]: adults_in_ca = repository._dao.query.filter(age__gte=18).filter(country="CA").order_by("name").all().items
+
+In [2]: [f"{person.name}, {person.age}" for person in adults_in_ca]
+Out[2]: ['Jane Doe, 36', 'John Doe, 38']
+```
+
+### Using QuerySets in Repository Methods
+
+In a real application, you would typically wrap these QuerySet operations in repository methods:
+
+```python hl_lines="5-7 10-12"
+class PersonRepository(Repository):
+    part_of = Person
+    
+    def adults_in_country(self, country_code):
+        """Find all adults in the specified country."""
+        return self._dao.query.filter(
+            age__gte=18, country=country_code).all().items
+    
+    def children_by_age(self, country_code=None):
+        """Find all children ordered by age."""
+        query = self._dao.query.filter(age__lt=18)
+        if country_code:
+            query = query.filter(country=country_code)
+        return query.order_by("age").all().items
+```
+
+### Controlling Result Size with Limits
+
+By default, Protean limits the number of records returned by a query to 100. You can control this behavior in several ways:
+
+#### Setting Default Limit During Element Registration
+
+You can override the default limit when registering an element:
+
+```python hl_lines="2"
+@domain.aggregate(limit=50)
+class Person:
+    # This aggregate's queries will return at most 50 records by default
+    id = field.Integer(identifier=True)
+    name = field.String(required=True, max_length=50)
+```
+
+Setting the limit to `None` or a negative number removes the limit entirely:
+
+```python hl_lines="2"
+@domain.entity(part_of=Person, limit=None)  # No limit
+class Address:
+    id = field.Integer(identifier=True)
+    street = field.String(required=True)
+    person = field.Reference(Person)
+```
+
+#### Applying Limit to a QuerySet
+
+You can also control the limit at query time using the `limit()` method:
+
+```python
+# Limit to 10 records
+limited_query = repository._dao.query.limit(10).all()
+
+# Remove limit entirely
+unlimited_query = repository._dao.query.limit(None).all()
+```
+
+Here's a complete example:
+
+```python
+# Repository method that retrieves records with flexible limit
+def find_people_by_country(self, country_code, max_results=None):
+    """Find people from a specific country with optional limit."""
+    query = self._dao.query.filter(country=country_code)
+    
+    if max_results is not None:
+        query = query.limit(max_results)
+        
+    return query.all().items
+```
+
+#### Combining Limit with Offset for Pagination
+
+You can combine `limit` with `offset` for implementing pagination:
+
+```python
+def get_page(self, page_number, page_size=10):
+    """Get a specific page of results."""
+    offset = (page_number - 1) * page_size
+    return self._dao.query.offset(offset).limit(page_size).all()
+```
+
+!!!note
+    If you set a limit during element registration, it becomes the default for all queries on that element. You can always override it at query time using the `limit()` method.
+
+### Optimization Considerations
+
+!!!note
+    QuerySets are evaluated when you iterate over them, slice them, or convert them to lists. This is when the database query actually executes.
+
+!!!note
+    When working with large datasets, be mindful of query performance. Use specific filters early in your query chain to reduce the data being processed.
 
 ## Filtering
 

--- a/docs/guides/consume-state/views.md
+++ b/docs/guides/consume-state/views.md
@@ -16,6 +16,87 @@ Views are defined with the `Domain.view` decorator.
 --8<-- "guides/consume-state/002.py:68:74"
 ```
 
+## View Configuration Options
+
+Views in Protean can be configured with several options passed directly to the view decorator:
+
+```python
+@domain.view(
+    provider="postgres",      # Database provider to use
+    schema_name="product_inventory",  # Custom schema/table name
+    limit=50                  # Default limit for queries
+)
+class ProductInventory:
+    # View fields and methods
+    pass
+```
+
+### Storage Options
+
+Views can be stored in either a database or a cache, but not both simultaneously:
+
+- **Database Storage**: Use the `provider` parameter to specify which database provider to use.
+  ```python
+  @domain.view(provider="postgres")  # Connect to a PostgreSQL database
+  class ProductInventory:
+      # View fields and methods
+      pass
+  ```
+
+- **Cache Storage**: Use the `cache` parameter to specify which cache provider to use.
+  ```python
+  @domain.view(cache="redis")  # Store view data in Redis cache
+  class ProductInventory:
+      # View fields and methods
+      pass
+  ```
+
+When both `cache` and `provider` parameters are specified, the `cache` parameter takes precedence
+and the `provider` parameter is ignored.
+
+### Additional Options
+
+All options are passed directly to the view decorator:
+
+```python
+@domain.view(
+    abstract=False,          # If True, indicates this view is an abstract base class
+    model="custom_model",    # Custom model name for storage
+    order_by=("name",),      # Default ordering for query results
+    schema_name="inventory", # Custom schema/table name
+    limit=100                # Default query result limit (set to None for no limit)
+)
+class ProductInventory:
+    # View fields and methods
+    pass
+```
+
+## Querying Views
+
+Views are optimized for querying. You can use the repository pattern to query views:
+
+```python
+# Get a single view record by ID
+inventory = repository.get(ProductInventory, id=1)
+
+# Query view with filters
+low_stock_items = repository._dao.filter(
+    ProductInventory, 
+    quantity__lt=10,
+    limit=20
+)
+```
+
+## View Projection Strategies
+
+There are different strategies for keeping views up-to-date with your domain model:
+
+1. **Event-driven**: Respond to domain events to update views (recommended)
+2. **Periodic Refresh**: Schedule periodic rebuilding of views from source data
+3. **On-demand Calculation**: Generate views when they are requested 
+
+The event-driven approach is usually preferred as it ensures views are updated in near real-time.
+
 ## Workflow
 
 `ManageInventory` Command Handler handles `AdjustStock` command, loads the
@@ -34,7 +115,7 @@ sequenceDiagram
   Repository->>Broker: Publish events
 ```
 
-The events are then consumend by the event handler that loads the view record
+The events are then consumed by the event handler that loads the view record
 and updates it.
 
 ```mermaid
@@ -47,6 +128,12 @@ sequenceDiagram
   inventory-->>Sync Inventory: 
   Sync Inventory->>Repository: Persist inventory record
 ```
+
+## Supported Field Types
+
+Views can only contain basic field types. References, Associations, and ValueObjects 
+are not supported in views. This is because views are designed to be flattened, 
+denormalized representations of data.
 
 ## Example
 

--- a/src/protean/adapters/repository/memory.py
+++ b/src/protean/adapters/repository/memory.py
@@ -376,7 +376,8 @@ class DictDAO(BaseDAO):
             offset=offset,
             limit=limit,
             total=len(items),
-            items=items[offset : offset + limit],
+            # When limit is not set, we return all items
+            items=items[offset : offset + limit] if limit else items,
         )
 
         return result

--- a/src/protean/adapters/repository/sqlalchemy.py
+++ b/src/protean/adapters/repository/sqlalchemy.py
@@ -645,8 +645,15 @@ class SAProvider(BaseProvider):
             current_uow.rollback()
 
     def _create_database_artifacts(self):
-        for _, aggregate_record in self.domain.registry.aggregates.items():
-            self.domain.repository_for(aggregate_record.cls)._dao
+        # Create tables for all registered aggregates, entities, and views
+        elements = {
+            **self.domain.registry.aggregates,
+            **self.domain.registry.entities,
+            **self.domain.registry.views,
+        }
+
+        for _, element_record in elements.items():
+            self.domain.repository_for(element_record.cls)._dao
 
         self._metadata.create_all(self._engine)
 

--- a/src/protean/core/aggregate.py
+++ b/src/protean/core/aggregate.py
@@ -100,6 +100,7 @@ class BaseAggregate(BaseEntity):
             ("provider", "default"),
             ("schema_name", inflection.underscore(cls.__name__)),
             ("stream_category", inflection.underscore(cls.__name__)),
+            ("limit", 100),
         ]
 
     def _apply(self, event: BaseEvent) -> None:
@@ -203,6 +204,15 @@ def element_to_fact_event(element_cls):
 
 
 def aggregate_factory(element_cls, domain, **opts):
+    """Factory method to create an aggregate class.
+
+    This method is used to create an aggregate class. It is called during domain registration.
+    """
+    # If opts has a `limit` key and it is negative, set it to None
+    if "limit" in opts and opts["limit"] is not None and opts["limit"] < 0:
+        opts["limit"] = None
+
+    # Derive the aggregate class from the base aggregate class
     element_cls = derive_element_class(element_cls, BaseAggregate, **opts)
 
     # Iterate through methods marked as `@invariant` and record them for later use

--- a/src/protean/core/entity.py
+++ b/src/protean/core/entity.py
@@ -136,6 +136,7 @@ class BaseEntity(OptionsMixin, IdentityMixin, BaseContainer):
             ("part_of", None),
             ("provider", "default"),
             ("schema_name", inflection.underscore(cls.__name__)),
+            ("limit", 100),
         ]
 
     def __init__(self, *template, **kwargs):  # noqa: C901
@@ -617,6 +618,15 @@ class BaseEntity(OptionsMixin, IdentityMixin, BaseContainer):
 
 
 def entity_factory(element_cls, domain, **opts):
+    """Factory method to create an entity class.
+
+    This method is used to create an entity class. It is called during domain registration.
+    """
+    # If opts has a `limit` key and it is negative, set it to None
+    if "limit" in opts and opts["limit"] is not None and opts["limit"] < 0:
+        opts["limit"] = None
+
+    # Derive the entity class from the base entity class
     element_cls = derive_element_class(element_cls, BaseEntity, **opts)
 
     if not element_cls.meta_.part_of:

--- a/src/protean/core/queryset.py
+++ b/src/protean/core/queryset.py
@@ -50,9 +50,7 @@ class QuerySet:
         entity_cls: BaseEntity,
         criteria: Q = None,
         offset: int = 0,
-        # Aggregates should be loaded in entirety
-        # FIXME Should this limit be removed entirely?
-        limit: int = 1000,
+        limit: int = None,  # No limit by default
         order_by: list = None,
     ):
         """Initialize either with empty preferences (when invoked on an Entity)
@@ -64,7 +62,9 @@ class QuerySet:
         self._criteria = criteria or Q()
         self._result_cache = None
         self._offset = offset or 0
-        self._limit = limit or 10
+
+        # If an explicit limit is not provided, use the limit from the entity class
+        self._limit = limit or entity_cls.meta_.limit
 
         # `order_by` could be empty, or a string or a list.
         #   Initialize empty list if `order_by` is None
@@ -124,7 +124,8 @@ class QuerySet:
         """Limit number of records"""
         clone = self._clone()
 
-        if isinstance(limit, int):
+        # Assign limit if it is an integer or None
+        if isinstance(limit, int) or limit is None:
             clone._limit = limit
 
         return clone

--- a/src/protean/utils/container.py
+++ b/src/protean/utils/container.py
@@ -90,9 +90,10 @@ class OptionsMixin:
         # Assign default options for remaining items
         #   with the help of `_default_options()` method defined in the Element's Root.
         #   Element Roots are `Event`, `Subscriber`, `Repository`, and so on.
+        #
+        # Explicit `None` is a valid value set for an option, so we don't discard it.
         for key, default in cls._default_options():
-            # FIXME Should the `None` check be replaced with a SENTINEL check?
-            if not (hasattr(cls.meta_, key) and getattr(cls.meta_, key) is not None):
+            if not hasattr(cls.meta_, key):
                 setattr(cls.meta_, key, default)
 
 

--- a/tests/adapters/repository/sqlalchemy_repo/tests.py
+++ b/tests/adapters/repository/sqlalchemy_repo/tests.py
@@ -1,0 +1,63 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from protean.adapters.repository.sqlalchemy import PostgresqlProvider
+from protean.core.aggregate import BaseAggregate
+from protean.fields import String
+
+
+class Person(BaseAggregate):
+    name = String(required=True)
+
+
+@pytest.fixture
+def provider(test_domain):
+    provider = PostgresqlProvider(
+        domain=test_domain, name="default", conn_info={"database_uri": "sqlite://"}
+    )
+    return provider
+
+
+@patch("protean.adapters.repository.sqlalchemy.create_engine")
+def test_create_database_artifacts_creates_tables(
+    mock_create_engine, test_domain, provider
+):
+    # Setup
+    provider.domain = test_domain
+    mock_engine = Mock()
+    mock_create_engine.return_value = mock_engine
+    provider._engine = mock_engine
+
+    # Mock metadata methods
+    provider._metadata = Mock()
+
+    # Execute
+    provider._create_database_artifacts()
+
+    # Assert
+    # Verify metadata.create_all was called with engine
+    provider._metadata.create_all.assert_called_with(mock_engine)
+
+
+@patch("protean.adapters.repository.sqlalchemy.create_engine")
+def test_drop_database_artifacts_drops_tables(
+    mock_create_engine, test_domain, provider
+):
+    # Setup
+    provider.domain = test_domain
+    mock_engine = Mock()
+    mock_create_engine.return_value = mock_engine
+    provider._engine = mock_engine
+
+    # Mock metadata methods
+    provider._metadata = Mock()
+
+    # Execute
+    provider._drop_database_artifacts()
+
+    # Assert
+    # Verify metadata.drop_all was called with engine
+    provider._metadata.drop_all.assert_called_with(mock_engine)
+    # Verify metadata was cleared
+    provider._metadata.clear.assert_called()

--- a/tests/adapters/repository/test_queryset.py
+++ b/tests/adapters/repository/test_queryset.py
@@ -1,0 +1,109 @@
+import pytest
+
+from protean.core.aggregate import BaseAggregate
+from protean.core.entity import BaseEntity
+from protean.fields import Float, HasMany, Integer, String
+
+
+class OrderItem(BaseEntity):
+    product_id = String(max_length=50)
+    quantity = Integer()
+    price = Float()
+
+
+class Order(BaseAggregate):
+    items = HasMany(OrderItem)
+
+
+@pytest.mark.database
+class TestQuerySetLimit:
+    @pytest.fixture(autouse=True)
+    def register_elements(self, test_domain):
+        test_domain.register(Order)
+        test_domain.register(OrderItem, part_of=Order)
+
+    def test_default_queryset_limit_is_applied(self, test_domain):
+        # Create an order with 1001 items
+        order = Order(
+            items=[
+                OrderItem(product_id=f"PROD-{i}", quantity=1, price=9.99)
+                for i in range(101)
+            ]
+        )
+        test_domain.repository_for(Order).add(order)
+
+        assert test_domain.repository_for(OrderItem)._dao.query._limit == 100
+
+        # Fetch the order
+        order = test_domain.repository_for(Order).get(order.id)
+
+        # Verify that the order items are limited to 100 by default
+        assert len(order.items) == 100
+
+        # Verify that the order items are not limited when limit is set to None
+        assert (
+            len(test_domain.repository_for(OrderItem)._dao.query.limit(None).all())
+            == 101
+        )
+
+    def test_no_queryset_limit_is_applied_if_limit_is_set_to_none(self, test_domain):
+        test_domain.register(OrderItem, part_of=Order, limit=None)
+
+        # Create an order with 1001 items
+        order = Order(
+            items=[
+                OrderItem(product_id=f"PROD-{i}", quantity=1, price=9.99)
+                for i in range(101)
+            ]
+        )
+        test_domain.repository_for(Order).add(order)
+
+        assert test_domain.repository_for(OrderItem)._dao.query._limit is None
+
+        # Fetch the order
+        order = test_domain.repository_for(Order).get(order.id)
+
+        # Verify that the order items are not limited when limit is set to None
+        assert len(order.items) == 101
+
+    def test_queryset_limit_is_applied_if_limit_is_set(self, test_domain):
+        test_domain.register(OrderItem, part_of=Order, limit=10)
+
+        # Create an order with 1001 items
+        order = Order(
+            items=[
+                OrderItem(product_id=f"PROD-{i}", quantity=1, price=9.99)
+                for i in range(101)
+            ]
+        )
+        test_domain.repository_for(Order).add(order)
+
+        assert test_domain.repository_for(OrderItem)._dao.query._limit == 10
+
+        # Fetch the order
+        order = test_domain.repository_for(Order).get(order.id)
+
+        # Verify that the order items are limited to 10
+        assert len(order.items) == 10
+
+    def test_no_queryset_limit_is_applied_if_limit_is_set_to_negative_value(
+        self, test_domain
+    ):
+        test_domain.register(OrderItem, part_of=Order, limit=-1)
+
+        # Create an order with 1001 items
+        order = Order(
+            items=[
+                OrderItem(product_id=f"PROD-{i}", quantity=1, price=9.99)
+                for i in range(101)
+            ]
+        )
+        test_domain.repository_for(Order).add(order)
+
+        assert test_domain.repository_for(OrderItem)._dao.query._limit is None
+
+        # Fetch the order
+        order = test_domain.repository_for(Order).get(order.id)
+
+        # Verify that the order items are not limited when limit is set to None
+        assert len(order.items) == 101

--- a/tests/aggregate/test_aggregate_query_limit_option.py
+++ b/tests/aggregate/test_aggregate_query_limit_option.py
@@ -1,0 +1,41 @@
+# Test that limit provided in Aggregate options is respected
+
+import pytest
+
+from protean.core.aggregate import BaseAggregate
+from protean.fields import Date
+
+
+class Order(BaseAggregate):
+    ordered_on = Date()
+
+
+@pytest.fixture(autouse=True)
+def register_elements(test_domain):
+    test_domain.register(Order)
+
+
+def test_entity_query_limit_is_100_by_default(test_domain):
+    test_domain.register(Order)
+
+    assert Order.meta_.limit == 100
+
+
+def test_entity_query_limit_can_be_explicitly_set_in_entity_config(test_domain):
+    test_domain.register(Order, limit=500)
+
+    assert Order.meta_.limit == 500
+
+
+def test_entity_query_limit_can_be_unlimited(test_domain):
+    test_domain.register(Order, limit=None)
+
+    assert Order.meta_.limit is None
+
+
+def test_entity_query_limit_is_unlimited_when_limit_is_set_to_negative_value(
+    test_domain,
+):
+    test_domain.register(Order, limit=-1)
+
+    assert Order.meta_.limit is None

--- a/tests/entity/test_entity_query_limit_option.py
+++ b/tests/entity/test_entity_query_limit_option.py
@@ -1,0 +1,50 @@
+# Test that limit provided in Entity options is respected
+
+from protean.core.aggregate import BaseAggregate
+from protean.core.entity import BaseEntity
+from protean.fields import Date, Float, HasMany, Integer, String
+
+
+class Order(BaseAggregate):
+    ordered_on = Date()
+    items = HasMany("OrderItem")
+
+
+class OrderItem(BaseEntity):
+    product_id = String(max_length=50)
+    quantity = Integer()
+    price = Float()
+
+
+def test_entity_query_limit_is_1000_by_default(test_domain):
+    test_domain.register(Order)
+    test_domain.register(OrderItem, part_of=Order)
+
+    assert Order.meta_.limit == 100
+    assert OrderItem.meta_.limit == 100
+
+
+def test_entity_query_limit_can_be_explicitly_set_in_entity_config(test_domain):
+    test_domain.register(Order)
+    test_domain.register(OrderItem, part_of=Order, limit=5000)
+
+    assert Order.meta_.limit == 100
+    assert OrderItem.meta_.limit == 5000
+
+
+def test_entity_query_limit_can_be_unlimited(test_domain):
+    test_domain.register(Order)
+    test_domain.register(OrderItem, part_of=Order, limit=None)
+
+    assert Order.meta_.limit == 100
+    assert OrderItem.meta_.limit is None
+
+
+def test_entity_query_limit_is_unlimited_when_limit_is_set_to_negative_value(
+    test_domain,
+):
+    test_domain.register(Order)
+    test_domain.register(OrderItem, part_of=Order, limit=-1)
+
+    assert Order.meta_.limit == 100
+    assert OrderItem.meta_.limit is None

--- a/tests/query/test_limit_from_entity_options.py
+++ b/tests/query/test_limit_from_entity_options.py
@@ -1,0 +1,46 @@
+# Test that limit option provided in Entity config is respected
+
+from protean.core.aggregate import BaseAggregate
+from protean.core.entity import BaseEntity
+from protean.fields import Date, Float, HasMany, Integer, String
+
+
+class Order(BaseAggregate):
+    ordered_on = Date()
+    items = HasMany("OrderItem")
+
+
+class OrderItem(BaseEntity):
+    product_id = String(max_length=50)
+    quantity = Integer()
+    price = Float()
+
+
+def test_entity_query_limit_is_100_by_default(test_domain):
+    test_domain.register(Order)
+    test_domain.register(OrderItem, part_of=Order)
+
+    assert test_domain.repository_for(OrderItem)._dao.query._limit == 100
+
+
+def test_entity_query_limit_can_be_explicitly_set_in_entity_config(test_domain):
+    test_domain.register(Order)
+    test_domain.register(OrderItem, part_of=Order, limit=500)
+
+    assert test_domain.repository_for(OrderItem)._dao.query._limit == 500
+
+
+def test_entity_query_limit_is_unlimited_when_limit_is_set_to_none(test_domain):
+    test_domain.register(Order)
+    test_domain.register(OrderItem, part_of=Order, limit=None)
+
+    assert test_domain.repository_for(OrderItem)._dao.query._limit is None
+
+
+def test_entity_query_limit_is_unlimited_when_limit_is_set_to_negative_value(
+    test_domain,
+):
+    test_domain.register(Order)
+    test_domain.register(OrderItem, part_of=Order, limit=-1)
+
+    assert test_domain.repository_for(OrderItem)._dao.query._limit is None

--- a/tests/query/test_properties.py
+++ b/tests/query/test_properties.py
@@ -1,0 +1,34 @@
+from protean.core.aggregate import BaseAggregate
+from protean.fields import Integer, String
+
+
+class Person(BaseAggregate):
+    name = String(max_length=255)
+    age = Integer()
+
+
+class TestQueryLimitProperty:
+    def test_query_limit_property(self, test_domain):
+        test_domain.register(Person)
+        person_repo = test_domain.repository_for(Person)
+        assert person_repo._dao.query._limit == 100
+
+    def test_cloning_with_explicit_limit(self, test_domain):
+        test_domain.register(Person)
+        person_repo = test_domain.repository_for(Person)
+        query = person_repo._dao.query.limit(500)
+        assert query._limit == 500
+
+    def test_cloning_and_removing_limit(self, test_domain):
+        test_domain.register(Person)
+        person_repo = test_domain.repository_for(Person)
+        query = person_repo._dao.query.limit(500)
+        assert query._limit == 500
+        query = query.limit(None)
+        assert query._limit is None
+
+    def test_cloning_with_invalid_limit_value(self, test_domain):
+        test_domain.register(Person)
+        person_repo = test_domain.repository_for(Person)
+        query = person_repo._dao.query.limit("invalid")
+        assert query._limit == 100

--- a/tests/query/test_queryset.py
+++ b/tests/query/test_queryset.py
@@ -336,7 +336,7 @@ class TestCriteriaConstruction:
             "<QuerySet: entity: <class 'tests.query.elements.Person'>, "
             "criteria: ('protean.utils.query.Q', (), {'last_name': 'John'}), "
             "offset: 0, "
-            "limit: 1000, order_by: ['age']>"
+            "limit: 100, order_by: ['age']>"
         )
 
     def test_bool_false(self, test_domain):

--- a/tests/views/test_view_query_limit_option.py
+++ b/tests/views/test_view_query_limit_option.py
@@ -1,0 +1,44 @@
+# Test that limit provided in View options is respected
+
+import pytest
+
+from protean.core.view import BaseView
+from protean.fields import Identifier, Integer, String
+
+
+class Person(BaseView):
+    person_id = Identifier(identifier=True)
+    first_name = String(max_length=50, required=True)
+    last_name = String(max_length=50)
+    age = Integer(default=21)
+
+
+@pytest.fixture(autouse=True)
+def register_elements(test_domain):
+    test_domain.register(Person)
+
+
+def test_entity_query_limit_is_100_by_default(test_domain):
+    test_domain.register(Person)
+
+    assert Person.meta_.limit == 100
+
+
+def test_entity_query_limit_can_be_explicitly_set_in_entity_config(test_domain):
+    test_domain.register(Person, limit=500)
+
+    assert Person.meta_.limit == 500
+
+
+def test_entity_query_limit_can_be_unlimited(test_domain):
+    test_domain.register(Person, limit=None)
+
+    assert Person.meta_.limit is None
+
+
+def test_entity_query_limit_is_unlimited_when_limit_is_set_to_negative_value(
+    test_domain,
+):
+    test_domain.register(Person, limit=-1)
+
+    assert Person.meta_.limit is None


### PR DESCRIPTION
- Add `limit` option to Entity, Aggregate, and View elements.
- Allow limit to be set as `None` or negative to specify no limits
- Set default fetch limits to 100
- Adjusted QuerySet to use entity class limit if no explicit limit is provided.
- Updated factory methods for aggregates, entities, and views to handle negative limit values.