### PR TITLE
Fix #455: Enhanced the event sourcing initialization mechanism in the BaseAggregate class

### DIFF
--- a/src/protean/domain/__init__.py
+++ b/src/protean/domain/__init__.py
@@ -1062,7 +1062,7 @@ class Domain:
         ):
             handler_class = self.command_handler_for(command)
             if handler_class:
-                handler_class._handle(command_with_metadata)
+                return handler_class._handle(command_with_metadata)
 
         return position
 


### PR DESCRIPTION
## Description

## What is this PR ?

- Enhancement

## Why this PR ?
- Added a new`_initialize_from_event` class method that aggregates can override to customize how they initialize their state from the first event.
- Updated the`from_events` method to use this new initialization method.
- Added validation to prevent reconstruction from an empty event list.

## What this PR Do?
- This change allows aggregates to handle cases where the first event's payload structure differs from the aggregate's attributes by implementing their own initialization logic in the`_initialize_from_event` method.

## References
- #455 