### PR TITLE
Add in-built FastAPI server

### DIFF
--- a/docs/core-concepts/streams.md
+++ b/docs/core-concepts/streams.md
@@ -17,3 +17,16 @@ Stream name structure.
 
 Stream names are not namespaced within a message store. If the same stream name must be used for different purposes, those streams should either be stored in separate message store databases, or the names of the streams should include some prefix or suffix.
 
+## Event Streams Are Typically Safe
+
+### Immutable, Append-Only Writes
+
+Because all events are appended in chronological order (and never updated in place), a valid history will normally remain intact over time. Each event is written with a version number (often called an “aggregate version”), so the event store can enforce optimistic concurrency and ensure no two updates conflict or overwrite each other.
+
+### Validation at the Aggregate
+
+Each aggregate enforces its own invariants and rejects invalid changes before they can be turned into events. Consequently, only valid events are ever committed to the event store.
+
+### Version Control and Concurrency Checks
+
+When an event is appended, the system checks if the current version of the stream matches the version expected by the command (e.g., “I expect the user-205 stream to be at version 3 before adding a new event”). If they don’t match, the commit is rejected. This helps prevent partial or out-of-sequence writes.

--- a/poetry.lock
+++ b/poetry.lock
@@ -13,6 +13,29 @@ files = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.9.0"
+description = "High level compatibility layer for multiple asynchronous event loop implementations"
+optional = false
+python-versions = ">=3.9"
+groups = ["main", "test"]
+files = [
+    {file = "anyio-4.9.0-py3-none-any.whl", hash = "sha256:9f76d541cad6e36af7beb62e978876f3b41e3e04f2c1fbf0884604c0a9c4d93c"},
+    {file = "anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028"},
+]
+markers = {main = "extra == \"fastapi\""}
+
+[package.dependencies]
+idna = ">=2.8"
+sniffio = ">=1.1"
+typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
+
+[package.extras]
+doc = ["Sphinx (>=8.2,<9.0)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx_rtd_theme"]
+test = ["anyio[trio]", "blockbuster (>=1.5.23)", "coverage[toml] (>=7)", "exceptiongroup (>=1.2.0)", "hypothesis (>=4.0)", "psutil (>=5.9)", "pytest (>=7.0)", "trustme", "truststore (>=0.9.1) ; python_version >= \"3.10\"", "uvloop (>=0.21) ; platform_python_implementation == \"CPython\" and platform_system != \"Windows\" and python_version < \"3.14\""]
+trio = ["trio (>=0.26.1)"]
+
+[[package]]
 name = "asttokens"
 version = "2.4.1"
 description = "Annotate AST trees with source code positions"
@@ -120,7 +143,7 @@ version = "2024.7.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
-groups = ["main", "dev", "docs"]
+groups = ["main", "dev", "docs", "test"]
 files = [
     {file = "certifi-2024.7.4-py3-none-any.whl", hash = "sha256:c198e21b1289c2ab85ee4e67bb4b4ef3ead0892059901a8d5b622f24a1101e90"},
     {file = "certifi-2024.7.4.tar.gz", hash = "sha256:5a1e7645bc0ec61a09e26c36f6106dd4cf40c6db3a1fb6352b0244e7fb057c7b"},
@@ -634,6 +657,28 @@ files = [
 tests = ["asttokens (>=2.1.0)", "coverage", "coverage-enable-subprocess", "ipython", "littleutils", "pytest", "rich ; python_version >= \"3.11\""]
 
 [[package]]
+name = "fastapi"
+version = "0.115.12"
+description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"fastapi\""
+files = [
+    {file = "fastapi-0.115.12-py3-none-any.whl", hash = "sha256:e94613d6c05e27be7ffebdd6ea5f388112e5e430c8f7d6494a9d1d88d43e814d"},
+    {file = "fastapi-0.115.12.tar.gz", hash = "sha256:1e2c2a2646905f9e83d32f04a3f86aff4a286669c6c950ca95b5fd68c2602681"},
+]
+
+[package.dependencies]
+pydantic = ">=1.7.4,<1.8 || >1.8,<1.8.1 || >1.8.1,<2.0.0 || >2.0.0,<2.0.1 || >2.0.1,<2.1.0 || >2.1.0,<3.0.0"
+starlette = ">=0.40.0,<0.47.0"
+typing-extensions = ">=4.8.0"
+
+[package.extras]
+all = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.5)", "httpx (>=0.23.0)", "itsdangerous (>=1.1.0)", "jinja2 (>=3.1.5)", "orjson (>=3.2.1)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "pyyaml (>=5.3.1)", "ujson (>=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0)", "uvicorn[standard] (>=0.12.0)"]
+standard = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.5)", "httpx (>=0.23.0)", "jinja2 (>=3.1.5)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
+
+[[package]]
 name = "filelock"
 version = "3.13.1"
 description = "A platform independent file lock."
@@ -778,6 +823,66 @@ docs = ["Sphinx", "furo"]
 test = ["objgraph", "psutil"]
 
 [[package]]
+name = "h11"
+version = "0.14.0"
+description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
+optional = false
+python-versions = ">=3.7"
+groups = ["main", "test"]
+files = [
+    {file = "h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761"},
+    {file = "h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d"},
+]
+markers = {main = "extra == \"fastapi\""}
+
+[[package]]
+name = "httpcore"
+version = "1.0.8"
+description = "A minimal low-level HTTP client."
+optional = false
+python-versions = ">=3.8"
+groups = ["test"]
+files = [
+    {file = "httpcore-1.0.8-py3-none-any.whl", hash = "sha256:5254cf149bcb5f75e9d1b2b9f729ea4a4b883d1ad7379fc632b727cec23674be"},
+    {file = "httpcore-1.0.8.tar.gz", hash = "sha256:86e94505ed24ea06514883fd44d2bc02d90e77e7979c8eb71b90f41d364a1bad"},
+]
+
+[package.dependencies]
+certifi = "*"
+h11 = ">=0.13,<0.15"
+
+[package.extras]
+asyncio = ["anyio (>=4.0,<5.0)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+trio = ["trio (>=0.22.0,<1.0)"]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+description = "The next generation HTTP client."
+optional = false
+python-versions = ">=3.8"
+groups = ["test"]
+files = [
+    {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
+    {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
+]
+
+[package.dependencies]
+anyio = "*"
+certifi = "*"
+httpcore = "==1.*"
+idna = "*"
+
+[package.extras]
+brotli = ["brotli ; platform_python_implementation == \"CPython\"", "brotlicffi ; platform_python_implementation != \"CPython\""]
+cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+zstd = ["zstandard (>=0.18.0)"]
+
+[[package]]
 name = "identify"
 version = "2.5.35"
 description = "File identification library for Python"
@@ -798,11 +903,12 @@ version = "3.7"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.5"
-groups = ["dev", "docs"]
+groups = ["main", "dev", "docs", "test"]
 files = [
     {file = "idna-3.7-py3-none-any.whl", hash = "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"},
     {file = "idna-3.7.tar.gz", hash = "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc"},
 ]
+markers = {main = "extra == \"fastapi\""}
 
 [[package]]
 name = "importlib-metadata"
@@ -2377,6 +2483,19 @@ files = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+description = "Sniff out which async library your code is running under"
+optional = false
+python-versions = ">=3.7"
+groups = ["main", "test"]
+files = [
+    {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
+    {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
+]
+markers = {main = "extra == \"fastapi\""}
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.30"
 description = "Database Abstraction Library"
@@ -2496,6 +2615,25 @@ markers = "extra == \"sendgrid\""
 files = [
     {file = "starkbank-ecdsa-2.2.0.tar.gz", hash = "sha256:9399c3371b899d4a235b68a1ed7919d202fbf024bd2c863ae8ebdad343c2a63a"},
 ]
+
+[[package]]
+name = "starlette"
+version = "0.46.2"
+description = "The little ASGI library that shines."
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"fastapi\""
+files = [
+    {file = "starlette-0.46.2-py3-none-any.whl", hash = "sha256:595633ce89f8ffa71a015caed34a5b2dc1c0cdb3f0f1fbd1e69339cf2abeec35"},
+    {file = "starlette-0.46.2.tar.gz", hash = "sha256:7f7361f34eed179294600af672f565727419830b54b7b084efe44bb82d2fccd5"},
+]
+
+[package.dependencies]
+anyio = ">=3.6.2,<5"
+
+[package.extras]
+full = ["httpx (>=0.27.0,<0.29.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
 
 [[package]]
 name = "traitlets"
@@ -2652,6 +2790,26 @@ secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress ; py
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
+name = "uvicorn"
+version = "0.34.1"
+description = "The lightning-fast ASGI server."
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"fastapi\""
+files = [
+    {file = "uvicorn-0.34.1-py3-none-any.whl", hash = "sha256:984c3a8c7ca18ebaad15995ee7401179212c59521e67bfc390c07fa2b8d2e065"},
+    {file = "uvicorn-0.34.1.tar.gz", hash = "sha256:af981725fc4b7ffc5cb3b0e9eda6258a90c4b52cb2a83ce567ae0a7ae1757afc"},
+]
+
+[package.dependencies]
+click = ">=7.0"
+h11 = ">=0.8"
+
+[package.extras]
+standard = ["colorama (>=0.4) ; sys_platform == \"win32\"", "httptools (>=0.6.3)", "python-dotenv (>=0.13)", "pyyaml (>=5.1)", "uvloop (>=0.14.0,!=0.15.0,!=0.15.1) ; sys_platform != \"win32\" and sys_platform != \"cygwin\" and platform_python_implementation != \"PyPy\"", "watchfiles (>=0.13)", "websockets (>=10.4)"]
+
+[[package]]
 name = "virtualenv"
 version = "20.26.6"
 description = "Virtual Python Environment builder"
@@ -2774,6 +2932,7 @@ test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-it
 
 [extras]
 elasticsearch = ["elasticsearch", "elasticsearch-dsl"]
+fastapi = ["fastapi", "uvicorn"]
 flask = ["flask"]
 message-db = ["message-db-py"]
 postgresql = ["psycopg2", "sqlalchemy"]
@@ -2784,4 +2943,4 @@ sqlite = ["sqlalchemy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "e2327ac1e4baae04ed70b629f1995d728870efb227dc1f58abf0ddd3222bd78b"
+content-hash = "12882353db32dbf6f932dbc97d5cc4d4de026a71c05455e84cea733f794097cb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,8 @@ psycopg2 = {version = ">=2.9.9", optional = true}
 flask = {version = ">=1.1.1", optional = true}
 sendgrid = {version = ">=6.1.3", optional = true}
 message-db-py = {version = ">=0.2.0", optional = true}
+fastapi = {version = ">=0.110.0", optional = true}
+uvicorn = {version = ">=0.27.1", optional = true}
 
 [tool.poetry.extras]
 elasticsearch = ["elasticsearch", "elasticsearch-dsl"]
@@ -79,6 +81,7 @@ sqlite = ["sqlalchemy"]
 message-db = ["message-db-py"]
 flask = ["flask"]
 sendgrid = ["sendgrid"]
+fastapi = ["fastapi", "uvicorn"]
 
 ############################
 # Development Dependencies *
@@ -105,6 +108,7 @@ pytest-mock = "3.12.0"
 pytest = "^8.2.1"
 mypy = "^1.11.0"
 coverage = "^7.8.0"
+httpx = ">=0.27.0"  # For testing FastAPI
 
 [tool.poetry.group.docs]
 optional = true
@@ -159,6 +163,7 @@ markers = [
     "broker_common",
     "eventstore",
     "no_test_domain",
+    "fastapi",
 ]
 
 [tool.mypy]

--- a/src/protean/cli/__init__.py
+++ b/src/protean/cli/__init__.py
@@ -27,6 +27,7 @@ from typing_extensions import Annotated
 from protean.cli.docs import app as docs_app
 from protean.cli.generate import app as generate_app
 from protean.cli.new import new
+from protean.cli.server2 import app as server2_app
 from protean.cli.shell import shell
 from protean.exceptions import NoDomainException
 from protean.server.engine import Engine
@@ -42,6 +43,7 @@ app.command()(new)
 app.command()(shell)
 app.add_typer(generate_app, name="generate")
 app.add_typer(docs_app, name="docs")
+app.add_typer(server2_app, name="server2")
 
 
 class Category(str, Enum):

--- a/src/protean/cli/server2.py
+++ b/src/protean/cli/server2.py
@@ -1,0 +1,77 @@
+"""CLI command for running the FastAPI server."""
+
+import logging
+from typing import Optional
+
+import typer
+from typing_extensions import Annotated
+
+from protean.exceptions import NoDomainException
+from protean.server.fastapi_server import ProteanFastAPIServer
+from protean.utils.domain_discovery import derive_domain
+
+logger = logging.getLogger(__name__)
+
+app = typer.Typer()
+
+
+@app.callback(invoke_without_command=True)
+def main(
+    ctx: typer.Context,
+    domain: Annotated[str, typer.Option(help="Path to the domain")] = ".",
+    host: Annotated[str, typer.Option(help="Host to bind to")] = "0.0.0.0",
+    port: Annotated[int, typer.Option(help="Port to bind to")] = 8000,
+    debug: Annotated[Optional[bool], typer.Option(help="Enable debug mode")] = False,
+    cors: Annotated[Optional[bool], typer.Option(help="Enable CORS")] = True,
+    cors_origins: Annotated[
+        Optional[str],
+        typer.Option(
+            help="Comma-separated list of allowed CORS origins. Defaults to '*'"
+        ),
+    ] = None,
+):
+    """Run the FastAPI server for Protean applications.
+
+    This command starts a FastAPI server that loads the domain and sets up the necessary
+    context for processing requests.
+    """
+    # Exit if another command is being run
+    if ctx.invoked_subcommand is not None:
+        return
+
+    # Validate that CORS origins are not provided when CORS is disabled
+    if not cors and cors_origins:
+        msg = "Cannot specify CORS origins when CORS is disabled"
+        typer.echo(msg, err=True)
+        logger.error(msg)
+        raise typer.Abort()
+
+    try:
+        domain_instance = derive_domain(domain)
+
+        typer.echo(f"Starting Protean FastAPI server at {host}:{port}...")
+
+        # Parse CORS origins if provided
+        cors_origins_list = cors_origins.split(",") if cors_origins else None
+
+        # Create and run server
+        server = ProteanFastAPIServer(
+            domain=domain_instance,
+            debug=debug,
+            enable_cors=cors,
+            cors_origins=cors_origins_list,
+        )
+        server.run(host=host, port=port)
+
+    except NoDomainException as exc:
+        msg = f"Error loading Protean domain: {exc.args[0]}"
+        typer.echo(msg, err=True)
+        logger.error(msg)
+
+        raise typer.Abort()
+    except Exception as exc:
+        msg = f"Error starting server: {exc}"
+        typer.echo(msg, err=True)
+        logger.error(msg)
+
+        raise typer.Abort()

--- a/src/protean/server/__init__.py
+++ b/src/protean/server/__init__.py
@@ -1,3 +1,9 @@
-from .engine import Engine
+"""Server module for Protean."""
 
-__all__ = ["Engine"]
+from .engine import Engine
+from .fastapi_server import create_app
+
+__all__ = [
+    "Engine",
+    "create_app",
+]

--- a/src/protean/server/fastapi_server.py
+++ b/src/protean/server/fastapi_server.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+import uvicorn
+from fastapi import FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+
+from protean.domain import Domain
+from protean.utils.globals import current_domain
+
+logger = logging.getLogger(__name__)
+
+
+class ProteanFastAPIServer:
+    """
+    FastAPI server implementation for Protean.
+
+    This class provides a FastAPI server that loads the domain and sets up the necessary
+    context for processing requests.
+    """
+
+    def __init__(
+        self,
+        domain: Domain,
+        debug: bool = False,
+        enable_cors: bool = True,
+        cors_origins: list[str] = None,
+    ):
+        """
+        Initialize the FastAPI server.
+
+        Args:
+            domain (Domain): The domain to use for the server.
+            debug (bool, optional): Flag to indicate if debug mode is enabled. Defaults to False.
+            enable_cors (bool, optional): Flag to enable CORS. Defaults to True.
+            cors_origins (list[str], optional): List of allowed CORS origins. Defaults to ["*"].
+        """
+        self.debug = debug
+        self.domain = domain
+        self.enable_cors = enable_cors
+        self.cors_origins = cors_origins or ["*"]
+
+        # Set up logging
+        if self.debug:
+            logger.setLevel(logging.DEBUG)
+        else:
+            logger.setLevel(logging.INFO)
+
+        # Create FastAPI app
+        self.app = FastAPI(
+            title="Protean",
+            description="Protean Server",
+            debug=self.debug,
+        )
+
+        # Add middleware and routes
+        self._setup_middleware()
+        self._setup_routes()
+
+        self.domain.init()
+
+    def _setup_middleware(self) -> None:
+        """
+        Set up middleware for the FastAPI app.
+        """
+        # Add CORS middleware if enabled
+        if self.enable_cors:
+            self.app.add_middleware(
+                CORSMiddleware,
+                allow_origins=self.cors_origins,
+                allow_credentials=True,
+                allow_methods=["*"],
+                allow_headers=["*"],
+            )
+
+        # Add domain context middleware
+        @self.app.middleware("http")
+        async def domain_context_middleware(request: Request, call_next):
+            """
+            Middleware to set up domain context for each request.
+            """
+            # Enter domain context
+            with self.domain.domain_context():
+                # Process request
+                response = await call_next(request)
+            return response
+
+    def _setup_routes(self) -> None:
+        """
+        Set up routes for the FastAPI app.
+        """
+
+        @self.app.get("/", response_class=JSONResponse)
+        async def root() -> Dict[str, Any]:
+            """
+            Root endpoint that returns information about the domain.
+            """
+            return {
+                "status": "success",
+                "message": f"Protean API server running with domain: {current_domain.name}",
+                "data": {
+                    "domain": {
+                        "name": current_domain.name,
+                        "normalized_name": current_domain.normalized_name,
+                    }
+                },
+            }
+
+    def run(self, host: str = "0.0.0.0", port: int = 8000) -> None:
+        """
+        Run the FastAPI server.
+
+        Args:
+            host (str, optional): Host to bind to. Defaults to "0.0.0.0".
+            port (int, optional): Port to bind to. Defaults to 8000.
+        """
+        uvicorn.run(self.app, host=host, port=port)
+
+
+def create_app(
+    domain: Domain,
+    debug: bool = False,
+    enable_cors: bool = True,
+    cors_origins: list[str] = None,
+) -> FastAPI:
+    """
+    Factory function to create a FastAPI app with Protean integration.
+
+    Args:
+        domain (Domain): The domain to use for the server.
+        debug (bool, optional): Flag to indicate if debug mode is enabled. Defaults to False.
+        enable_cors (bool, optional): Flag to enable CORS. Defaults to True.
+        cors_origins (list[str], optional): List of allowed CORS origins. Defaults to ["*"].
+
+    Returns:
+        FastAPI: The configured FastAPI app.
+    """
+    server = ProteanFastAPIServer(
+        domain=domain,
+        debug=debug,
+        enable_cors=enable_cors,
+        cors_origins=cors_origins,
+    )
+    return server.app

--- a/tests/reflection/test_id_field.py
+++ b/tests/reflection/test_id_field.py
@@ -2,11 +2,8 @@ from protean.core.aggregate import BaseAggregate
 from protean.core.command import BaseCommand
 from protean.core.event import BaseEvent
 from protean.core.value_object import BaseValueObject
-from protean.domain import Domain
 from protean.fields import Float, Identifier, String
 from protean.utils.reflection import declared_fields, id_field
-
-domain = Domain(__name__)
 
 
 class Balance(BaseValueObject):

--- a/tests/server2/test_cli_command.py
+++ b/tests/server2/test_cli_command.py
@@ -1,0 +1,192 @@
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from protean.cli import app as cli_app
+from protean.utils.domain_discovery import derive_domain
+from tests.shared import change_working_directory_to
+
+
+class TestServerCliCommand:
+    """Test suite for the server2 CLI command."""
+
+    @pytest.fixture
+    def runner(self):
+        """CLI runner fixture."""
+        return CliRunner()
+
+    @pytest.fixture(autouse=True)
+    def reset_path(self):
+        """Reset sys.path after every test run"""
+        original_path = sys.path[:]
+        cwd = Path.cwd()
+
+        yield
+
+        sys.path[:] = original_path
+        os.chdir(cwd)
+
+    @pytest.mark.fastapi
+    def test_server2_help_command(self, runner):
+        """Test the help command for server2."""
+        result = runner.invoke(cli_app, ["server2", "--help"])
+        assert result.exit_code == 0
+        assert "Run the FastAPI server for Protean applications" in result.stdout
+        assert "--cors-origins" in result.stdout
+
+    @pytest.mark.fastapi
+    @patch("protean.cli.server2.ProteanFastAPIServer")
+    def test_server2_command_with_defaults(self, mock_server, runner):
+        change_working_directory_to("test7")
+
+        # Set up the mock
+        mock_instance = mock_server.return_value
+
+        # Derive the domain for crosscheck
+        domain = derive_domain("publishing7.py")
+
+        # Run the command with early exit to avoid actually starting the server
+        with patch.object(mock_instance, "run"):
+            args = ["server2", "--domain", "publishing7.py"]
+            result = runner.invoke(cli_app, args)
+
+            assert result.exit_code == 0
+
+            # Verify the command tried to start with default settings
+            mock_server.assert_called_once_with(
+                domain=domain,
+                debug=False,
+                enable_cors=True,
+                cors_origins=None,
+            )
+            mock_instance.run.assert_called_once()
+
+    @pytest.mark.fastapi
+    @patch("protean.cli.server2.ProteanFastAPIServer")
+    def test_server2_command_with_custom_args(self, mock_server, runner):
+        change_working_directory_to("test7")
+
+        mock_instance = mock_server.return_value
+
+        domain = derive_domain("publishing7.py")
+
+        # Run the command with early exit to avoid actually starting the server
+        with patch.object(mock_instance, "run") as mock_run:
+            args = [
+                "server2",
+                "--domain",
+                "publishing7.py",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                "5000",
+                "--debug",
+            ]
+            result = runner.invoke(cli_app, args, catch_exceptions=True)
+
+            assert result.exit_code == 0
+
+            # Verify the command tried to start with custom settings
+            mock_server.assert_called_once_with(
+                domain=domain,
+                debug=True,
+                enable_cors=True,
+                cors_origins=None,
+            )
+            mock_instance.run.assert_called_once_with(host="127.0.0.1", port=5000)
+
+    @pytest.mark.fastapi
+    @patch("protean.cli.server2.ProteanFastAPIServer")
+    def test_server2_command_disable_cors(self, mock_server, runner, test_domain):
+        change_working_directory_to("test7")
+
+        mock_instance = mock_server.return_value
+
+        domain = derive_domain("publishing7.py")
+
+        # Run the command with early exit to avoid actually starting the server
+        with patch.object(mock_instance, "run"):
+            result = runner.invoke(
+                cli_app,
+                ["server2", "--domain", "publishing7.py", "--no-cors"],
+                catch_exceptions=True,
+            )
+
+            assert result.exit_code == 0
+
+        # Verify CORS was disabled
+        mock_server.assert_called_once_with(
+            domain=domain,
+            debug=False,
+            enable_cors=False,
+            cors_origins=None,
+        )
+
+    @pytest.mark.fastapi
+    @patch("protean.cli.server2.ProteanFastAPIServer")
+    def test_server2_command_with_cors_origins(self, mock_server, runner):
+        """Test the server2 command with custom CORS origins."""
+        change_working_directory_to("test7")
+
+        mock_instance = mock_server.return_value
+
+        domain = derive_domain("publishing7.py")
+
+        # Run the command with early exit to avoid actually starting the server
+        with patch.object(mock_instance, "run"):
+            result = runner.invoke(
+                cli_app,
+                [
+                    "server2",
+                    "--domain",
+                    "publishing7.py",
+                    "--cors-origins",
+                    "http://localhost:3000,https://example.com",
+                ],
+                catch_exceptions=True,
+            )
+
+            assert result.exit_code == 0
+
+        # Verify CORS origins were set correctly
+        mock_server.assert_called_once_with(
+            domain=domain,
+            debug=False,
+            enable_cors=True,
+            cors_origins=["http://localhost:3000", "https://example.com"],
+        )
+
+    @pytest.mark.fastapi
+    def test_server2_command_cors_origins_with_cors_disabled(self, runner):
+        """Test that specifying CORS origins when CORS is disabled raises an error."""
+        result = runner.invoke(
+            cli_app,
+            [
+                "server2",
+                "--domain",
+                "publishing7.py",
+                "--no-cors",
+                "--cors-origins",
+                "http://localhost:3000",
+            ],
+            catch_exceptions=True,
+        )
+
+        assert result.exit_code != 0
+        assert "Cannot specify CORS origins when CORS is disabled" in result.stdout
+
+    @pytest.mark.fastapi
+    def test_server2_command_domain_error(self, runner):
+        # Run the command
+        result = runner.invoke(cli_app, ["server2", "--domain", "nonexistent.py"])
+
+        # Verify error handling
+        assert result.exit_code != 0
+        assert (
+            "Error loading Protean domain: Could not import 'nonexistent'.\nAborted.\n"
+            in result.stdout
+        )

--- a/tests/server2/test_domain_context.py
+++ b/tests/server2/test_domain_context.py
@@ -1,0 +1,92 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from protean.domain import Domain
+from protean.server.fastapi_server import ProteanFastAPIServer
+from protean.utils.globals import g
+
+
+@pytest.mark.no_test_domain
+class TestDomainContext:
+    """Test suite for domain context availability during requests."""
+
+    @pytest.fixture
+    def custom_domain(self):
+        domain = Domain(__file__, "Custom Domain Context Test")
+        domain._initialize()
+
+        yield domain
+
+    @pytest.fixture
+    def test_route_app(self, custom_domain):
+        """Create a FastAPI app with routes that test domain context availability."""
+        server = ProteanFastAPIServer(domain=custom_domain)
+
+        # Add routes to test domain context
+        @server.app.get("/context")
+        async def get_domain_context():
+            """Return the domain name from the current context."""
+            # The domain context should be available from the middleware.
+            #   We are using the `g` proxy object to verify that the domain context is available.
+            return {"g-class": repr(g)}
+
+        return server.app
+
+    @pytest.fixture
+    def client(self, test_route_app):
+        """Create a test client for the FastAPI app."""
+        return TestClient(test_route_app)
+
+    @pytest.mark.fastapi
+    def test_domain_variables_are_accessible(self, client, custom_domain):
+        # Call the test route that returns the domain context.
+        response = client.get("/context")
+
+        assert response.status_code == 200
+        assert (
+            response.json()["g-class"] == "<protean.g of 'Custom Domain Context Test'>"
+        )
+
+    @pytest.mark.fastapi
+    def test_domain_context_is_set_for_each_request(self, custom_domain):
+        """Test that middleware enters domain context for each request."""
+        # Create app and client
+        server = ProteanFastAPIServer(domain=custom_domain)
+        client = TestClient(server.app)
+
+        # Make a request
+        response = client.get("/")
+
+        assert response.status_code == 200
+
+    @pytest.mark.fastapi
+    def test_domain_context_middleware(self, custom_domain):
+        """Test that domain context middleware is properly set up."""
+        server = ProteanFastAPIServer(domain=custom_domain)
+
+        # Find domain context middleware in app
+        domain_context_middleware_present = False
+        for middleware in server.app.user_middleware:
+            # The middleware is a function, so it's signature looks like this:
+            #   '<function ProteanFastAPIServer._setup_middleware.<locals>.domain_context_middleware at ..>'
+            if "domain_context_middleware" in str(middleware.kwargs["dispatch"]):
+                domain_context_middleware_present = True
+                break
+
+        assert domain_context_middleware_present, "Domain context middleware not found"
+
+    @pytest.mark.fastapi
+    def test_cors_enabled(self, custom_domain):
+        """Test that CORS is enabled by default."""
+        server = ProteanFastAPIServer(domain=custom_domain)
+
+        # Check that CORS middleware is among the registered middleware
+        cors_middleware_present = False
+
+        # Iterate through middleware to find CORS middleware
+        for middleware in server.app.user_middleware:
+            if "CORSMiddleware" in str(middleware.cls):
+                cors_middleware_present = True
+                break
+
+        assert cors_middleware_present

--- a/tests/server2/test_server.py
+++ b/tests/server2/test_server.py
@@ -1,0 +1,133 @@
+import logging
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from protean.server.fastapi_server import ProteanFastAPIServer, create_app, logger
+
+
+class TestServerStartup:
+    """Test suite for server startup and accessibility."""
+
+    @pytest.fixture
+    def client(self, test_domain):
+        """Create a test client for the FastAPI app."""
+        server = ProteanFastAPIServer(domain=test_domain)
+        return TestClient(server.app)
+
+    @pytest.mark.fastapi
+    def test_server_creation(self, test_domain):
+        """Test that the server can be created."""
+        server = ProteanFastAPIServer(domain=test_domain)
+        assert server is not None
+        assert server.app is not None
+        assert server.domain is not None
+        assert server.domain.name == test_domain.name
+
+    @pytest.mark.fastapi
+    def test_server_root_endpoint(self, client, test_domain):
+        """Test that the server's root endpoint is accessible and returns the expected data."""
+        response = client.get("/")
+        assert response.status_code == 200
+
+        # Verify response structure
+        data = response.json()
+        assert data["status"] == "success"
+        assert "message" in data
+        assert test_domain.name in data["message"]
+
+        # Verify domain data
+        assert "data" in data
+        assert "domain" in data["data"]
+        assert data["data"]["domain"]["name"] == test_domain.name
+        assert data["data"]["domain"]["normalized_name"] == test_domain.normalized_name
+
+    @pytest.mark.fastapi
+    def test_create_app_factory(self, test_domain):
+        """Test the create_app factory function."""
+        app = create_app(test_domain)
+        assert app is not None
+
+        client = TestClient(app)
+        response = client.get("/")
+        assert response.status_code == 200
+
+    @pytest.mark.fastapi
+    def test_cors_origins_configuration(self, test_domain):
+        """Test that CORS origins are properly configured."""
+        # Test with default origins
+        server = ProteanFastAPIServer(domain=test_domain)
+        cors_middleware = next(
+            (m for m in server.app.user_middleware if "CORSMiddleware" in str(m.cls)),
+            None,
+        )
+        assert cors_middleware is not None
+        assert cors_middleware.kwargs["allow_origins"] == ["*"]
+
+        # Test with custom origins
+        custom_origins = ["http://localhost:3000", "https://example.com"]
+        server = ProteanFastAPIServer(domain=test_domain, cors_origins=custom_origins)
+        cors_middleware = next(
+            (m for m in server.app.user_middleware if "CORSMiddleware" in str(m.cls)),
+            None,
+        )
+        assert cors_middleware is not None
+        assert cors_middleware.kwargs["allow_origins"] == custom_origins
+
+        # Test with CORS disabled
+        server = ProteanFastAPIServer(domain=test_domain, enable_cors=False)
+        cors_middleware = next(
+            (m for m in server.app.user_middleware if "CORSMiddleware" in str(m.cls)),
+            None,
+        )
+        assert cors_middleware is None
+
+    @pytest.mark.fastapi
+    def test_debug_mode_configuration(self, test_domain):
+        """Test that debug mode is properly configured."""
+        # Test with debug mode disabled (default)
+        server = ProteanFastAPIServer(domain=test_domain)
+        assert server.debug is False
+        assert logger.level == logging.INFO
+
+        # Test with debug mode enabled
+        server = ProteanFastAPIServer(domain=test_domain, debug=True)
+        assert server.debug is True
+        assert logger.level == logging.DEBUG
+
+    @pytest.mark.fastapi
+    @patch("protean.server.fastapi_server.uvicorn.run")
+    def test_server_run_method(self, mock_uvicorn_run, test_domain):
+        """Test the server's run method with different configurations."""
+        # Test with default host and port
+        server = ProteanFastAPIServer(domain=test_domain)
+        server.run()
+        mock_uvicorn_run.assert_called_once_with(server.app, host="0.0.0.0", port=8000)
+        mock_uvicorn_run.reset_mock()
+
+        # Test with custom host and port
+        server.run(host="127.0.0.1", port=5000)
+        mock_uvicorn_run.assert_called_once_with(
+            server.app, host="127.0.0.1", port=5000
+        )
+        mock_uvicorn_run.reset_mock()
+
+        # Test with debug mode enabled
+        server = ProteanFastAPIServer(domain=test_domain, debug=True)
+        server.run()
+        mock_uvicorn_run.assert_called_once_with(server.app, host="0.0.0.0", port=8000)
+        mock_uvicorn_run.reset_mock()
+
+        # Test with CORS disabled
+        server = ProteanFastAPIServer(domain=test_domain, enable_cors=False)
+        server.run()
+        mock_uvicorn_run.assert_called_once_with(server.app, host="0.0.0.0", port=8000)
+        mock_uvicorn_run.reset_mock()
+
+        # Test with custom CORS origins
+        server = ProteanFastAPIServer(
+            domain=test_domain, cors_origins=["http://localhost:3000"]
+        )
+        server.run()
+        mock_uvicorn_run.assert_called_once_with(server.app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
- Started with `protean server2` for now. Will replace existing server soon.
- Loads domain and includes domain context in every request.
- Exposes a root `/` GET API route and returns a JSON response with domain name.

Fixes #503 