### PR TITLE
Auto discover Domain.root_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Protean officially supports Python 3.11+.
 from protean import Domain
 from protean.fields import String, Text
 
-domain = Domain(__file__, "Publishing")
+domain = Domain(name="Publishing")
 
 @domain.aggregate
 class Post:

--- a/docs/guides/compose-a-domain/index.md
+++ b/docs/guides/compose-a-domain/index.md
@@ -6,28 +6,28 @@ In Protean, the Domain serves as the central composition root of your applicatio
 
 The Domain acts as a composition root, bringing together all the essential components of your application. It provides a centralized location where all elements are registered, configured, and made available for use throughout your application. This centralization simplifies dependency management and promotes a more maintainable architecture.
 
-## Key Responsibilities
+### Key Responsibilities
 
-### Element Management
+#### Element Management
 
 The Domain maintains a registry of all domain elements, including entities, value objects, repositories, services, and other components. This registry serves as a catalog that makes these elements discoverable and accessible throughout your application.
 
-### Configuration Storage
+#### Configuration Storage
 
 Your Domain stores configuration settings that define how your application behaves. These settings can include database connection parameters, feature flags, environment-specific values, and other application-wide settings. Read more at [Configuration](../configuration.md).
 
-### Adapter Activation
+#### Adapter Activation
 
 The Domain manages the lifecycle of adapters, which are components that connect your application to external systems and services. This includes activating the appropriate adapters based on your configuration and ensuring they are properly initialized.
 
-### Automatic Element Collection
+#### Automatic Element Collection
 
 Protean's Domain leverages Python decorators to automatically collect and register domain elements. By simply applying the appropriate decorator to your classes, they are automatically discovered and registered with the Domain during initialization.
 
 ```python
 from protean import Domain
 
-domain = Domain(__file__)
+domain = Domain()
 ...
 
 @domain.aggregage
@@ -37,6 +37,96 @@ class User:
 
 This declarative approach reduces boilerplate code and makes your domain model more expressive and maintainable.
 
+## Parameters
+
+The `Domain` constructor accepts several parameters that control how the domain is initialized and configured:
+
+### `root_path`
+
+Optional. Defaults to `None`.
+
+The path to the folder containing the domain file. This parameter is optional and follows a resolution priority:
+
+1. Explicit `root_path` parameter if provided
+2. `DOMAIN_ROOT_PATH` environment variable if set
+3. Auto-detection of caller's file location
+4. Current working directory as last resort
+
+The `root_path` is used for finding configuration files and traversing domain files.
+
+```python
+# Explicit root path
+domain = Domain(root_path="/path/to/domain")
+
+# Using environment variable
+# export DOMAIN_ROOT_PATH="/path/to/domain"
+domain = Domain()  # Will use DOMAIN_ROOT_PATH
+
+# Auto-detection (uses the directory of the file where Domain is instantiated)
+domain = Domain()
+```
+
+This is handled even under various execution contexts:
+
+- Standard Python scripts
+- Jupyter/IPython notebooks
+- REPL/interactive shell
+- Frozen/PyInstaller applications
+
+### `name`
+
+The name of the domain. 
+
+Optional and defaults to the module name where the domain is instantiated.
+
+The domain name is used in various contexts, including event type construction and logging.
+
+```python
+# Explicit name
+domain = Domain(name="ecommerce")
+
+# Default name (uses module name)
+domain = Domain()  # If in module 'my_app', name will be 'my_app'
+```
+
+### `config`
+
+An optional configuration dictionary that overrides the default configuration and any configuration loaded from files.
+
+If not provided, configuration is loaded from `.domain.toml`, `domain.toml`, or `pyproject.toml` files in the domain folder or its parent directories.
+
+```python
+# Explicit configuration
+domain = Domain(config={
+    "identity_strategy": "UUID",
+    "databases": {
+        "default": {"provider": "postgres", "url": "postgresql://user:pass@localhost/db"}
+    }
+})
+
+# Default configuration (loads from TOML files if available)
+domain = Domain()
+```
+
+Refer to [Configuration](../configuration.md) to understand configuration file structure and parameters.
+
+### `identity_function`
+
+An optional function to generate identities for domain objects. This parameter is required when the `identity_strategy` in configuration is set to `FUNCTION`.
+
+```python
+# Custom identity function
+def generate_id():
+    # Custom ID generation logic
+    return "custom-id-" + str(random.randint(1000, 9999))
+
+# Using custom identity function
+domain = Domain(
+    config={"identity_strategy": "FUNCTION"},
+    identity_function=generate_id
+)
+```
+
 ## In This Section
 
 - [Register Elements](./register-elements.md) - Explore methods for registering domain elements
@@ -44,4 +134,3 @@ This declarative approach reduces boilerplate code and makes your domain model m
 - [Element Decorators](./element-decorators.md) - Learn about using decorators to automatically register domain elements
 - [Activate Domain](./activate-domain.md) - Understand how to activate a domain and its components
 - [When to Compose a Domain](./when-to-compose.md) - Learn about the appropriate timing and scenarios for composing a domain
-

--- a/docs/guides/compose-a-domain/initialize-domain.md
+++ b/docs/guides/compose-a-domain/initialize-domain.md
@@ -6,9 +6,11 @@ The domain is initialized by calling the `init` method.
 domain.init()
 ```
 
+## `Domain.init()`
+
 A call to `init` does the following:
 
-## 1. Traverse the domain model
+### 1. Traverse the domain model
 
 By default, Protean traverses the directory structure under the domain file
 to discover domain elements. You can control this behavior with the `traverse`
@@ -22,7 +24,7 @@ If you choose to not traverse, Protean will not be able to detect domain
 elements automatically. ***You are responsible for registering each element
 with the domain explicitly***.
 
-## 2. Construct the object graph
+### 2. Construct the object graph
 
 Protean constructs a graph of all elements registered with a domain and
 exposes them in a registry.
@@ -31,7 +33,7 @@ exposes them in a registry.
 {! docs_src/guides/composing-a-domain/016.py !}
 ```
 
-## 3. Initialize dependencies
+### 3. Initialize dependencies
 
 Calling `domain.init()` establishes connectivity with the underlying infra,
 testing access, and making them available for use by the rest of the system. 
@@ -52,7 +54,7 @@ makes it available for domain elements for further use.
 Refer to [Configuration handling](../configuration.md) to understand the different ways to configure
 the domain.
 
-## 4. Validate Domain Model
+### 4. Validate Domain Model
 
 In the final part of domain initialization, Protean performs additional setup
 tasks on domain elements and also conducts various checks to ensure the domain
@@ -61,17 +63,18 @@ model is specified correctly.
 Examples of checks include:
 
 1. Resolving references that were specified as Strings, like:
+
 ```python
 @domain.entity(part_of="User")
 class Account:
     ...
 ```
 
-2. Setting up Aggregate clusters and their shared settings. The object graph
+1. Setting up Aggregate clusters and their shared settings. The object graph
 constructed earlier is used to homogenize settings across all elements under
 an aggregate, like the stream category and database provider.
 
-3. Constructing a map of command and event types to reference when processing
+1. Constructing a map of command and event types to reference when processing
 incoming messages later.
 
-4. Various checks and validations to ensure the domain structure is valid.
+1. Various checks and validations to ensure the domain structure is valid.

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -2,16 +2,25 @@
 
 Protean's configuration is managed through the Domain object, which can be configured in multiple ways:
 
-1. **Direct Configuration**: Pass a configuration dictionary when initializing the Domain object:
+## Direct Configuration
+
+Pass a configuration dictionary when initializing the Domain object:
+
    ```python
    domain = Domain(config={'debug': True, 'testing': True})
    ```
 
-2. **Configuration Files**: Place configuration in a TOML file in your project directory or up to two levels of parent directories. Protean searches for configuration files in the following order:
+## Configuration Files
 
-   - `.domain.toml`
-   - `domain.toml` 
-   - `pyproject.toml` (under the `[tool.protean]` section)
+Place configuration can be supplied in a TOML file in your project directory or up to two levels of parent directories.
+
+Protean searches for configuration files in the following order:
+
+1. `.domain.toml`
+1. `domain.toml`
+1. `pyproject.toml` (under the `[tool.protean]` section)
+
+### Generating a new configuration file
 
 When initializing a new Protean application using the [`new`](./cli/new.md) command, a `domain.toml` configuration file is automatically generated with sensible defaults.
 
@@ -88,7 +97,7 @@ foo = "quux"
 
 Specifies if the application is running in debug mode.
 
-***Do not enable debug mode when deploying in production.***
+*Do not enable debug mode when deploying in production.*
 
 Default: `False`
 
@@ -112,7 +121,7 @@ You can generate a secret key with the following command:
 c4bf0121035265bf44657217c33a7d041fe9e505961fc7da5d976aa0eaf5cf94
 ```
 
-***Do not reveal the secret key when posting questions or committing code.***
+*Do not reveal your secret key when posting questions or committing code.*
 
 ### `identity_strategy`
 
@@ -272,7 +281,7 @@ FOO = "bar"
 ```
 
 ```shell hl_lines="3-4 6-7"
-In [1]: domain = Domain(__file__)
+In [1]: domain = Domain()
 
 In [2]: domain.config["custom"]["FOO"]
 Out[2]: 'bar'

--- a/docs_src/adapters/001.py
+++ b/docs_src/adapters/001.py
@@ -1,6 +1,6 @@
 from protean import Domain
 
-domain = Domain(__file__)
+domain = Domain()
 
 # Non-existent database
 domain.config["databases"]["default"] = {

--- a/docs_src/adapters/database/postgresql/001.py
+++ b/docs_src/adapters/database/postgresql/001.py
@@ -4,7 +4,7 @@ from protean import Domain
 from protean.adapters.repository.sqlalchemy import SqlalchemyModel
 from protean.fields import Integer, String
 
-domain = Domain(__file__)
+domain = Domain()
 domain.config["databases"]["default"] = {
     "provider": "postgresql",
     "database_uri": "postgresql://postgres:postgres@localhost:5432/postgres",

--- a/docs_src/guides/change_state_001.py
+++ b/docs_src/guides/change_state_001.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate

--- a/docs_src/guides/change_state_002.py
+++ b/docs_src/guides/change_state_002.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Float, HasMany, String, Text
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate

--- a/docs_src/guides/change_state_003.py
+++ b/docs_src/guides/change_state_003.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Boolean, Identifier, String, Text
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate

--- a/docs_src/guides/change_state_004.py
+++ b/docs_src/guides/change_state_004.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Integer, String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate

--- a/docs_src/guides/change_state_005.py
+++ b/docs_src/guides/change_state_005.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Integer, String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate

--- a/docs_src/guides/change_state_006.py
+++ b/docs_src/guides/change_state_006.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 from protean import Domain
 from protean.fields import DateTime, Identifier
 
-publishing = Domain(__file__, "Publishing")
+publishing = Domain(name="Publishing")
 
 
 def utc_now():

--- a/docs_src/guides/change_state_007.py
+++ b/docs_src/guides/change_state_007.py
@@ -5,7 +5,7 @@ from protean import Domain, handle
 from protean.fields import DateTime, Identifier, String
 from protean.utils.globals import current_domain
 
-publishing = Domain(__file__, "Publishing")
+publishing = Domain(name="Publishing")
 
 
 def utc_now():

--- a/docs_src/guides/change_state_008.py
+++ b/docs_src/guides/change_state_008.py
@@ -1,7 +1,7 @@
 from protean import Domain, current_domain, use_case
 from protean.fields import Identifier, String
 
-auth = Domain(__file__, "Auth")
+auth = Domain(name="Auth")
 
 
 @auth.aggregate

--- a/docs_src/guides/composing-a-domain/001.py
+++ b/docs_src/guides/composing-a-domain/001.py
@@ -1,3 +1,3 @@
 from protean import Domain
 
-domain = Domain(__file__)
+domain = Domain()

--- a/docs_src/guides/composing-a-domain/002.py
+++ b/docs_src/guides/composing-a-domain/002.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Integer, String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate

--- a/docs_src/guides/composing-a-domain/003.py
+++ b/docs_src/guides/composing-a-domain/003.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Integer, String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate

--- a/docs_src/guides/composing-a-domain/004.py
+++ b/docs_src/guides/composing-a-domain/004.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Integer, String, ValueObject
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.value_object

--- a/docs_src/guides/composing-a-domain/005.py
+++ b/docs_src/guides/composing-a-domain/005.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Identifier, Integer, String, ValueObject
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate

--- a/docs_src/guides/composing-a-domain/006.py
+++ b/docs_src/guides/composing-a-domain/006.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Integer, String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.event_sourced_aggregate

--- a/docs_src/guides/composing-a-domain/007.py
+++ b/docs_src/guides/composing-a-domain/007.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Identifier, String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate

--- a/docs_src/guides/composing-a-domain/008.py
+++ b/docs_src/guides/composing-a-domain/008.py
@@ -1,7 +1,7 @@
 from protean import Domain, handle
 from protean.fields import Identifier, String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.event_sourced_aggregate

--- a/docs_src/guides/composing-a-domain/009.py
+++ b/docs_src/guides/composing-a-domain/009.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Identifier, String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate

--- a/docs_src/guides/composing-a-domain/010.py
+++ b/docs_src/guides/composing-a-domain/010.py
@@ -1,7 +1,7 @@
 from protean import Domain, handle
 from protean.fields import Identifier, String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate

--- a/docs_src/guides/composing-a-domain/011.py
+++ b/docs_src/guides/composing-a-domain/011.py
@@ -6,7 +6,7 @@ from sqlalchemy.dialects.postgresql import UUID
 from protean import Domain
 from protean.fields import Identifier, String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate

--- a/docs_src/guides/composing-a-domain/012.py
+++ b/docs_src/guides/composing-a-domain/012.py
@@ -4,7 +4,7 @@ from protean import Domain
 from protean.fields import Integer, String
 from protean.utils.globals import current_domain
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate

--- a/docs_src/guides/composing-a-domain/013.py
+++ b/docs_src/guides/composing-a-domain/013.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Identifier, Integer, String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate

--- a/docs_src/guides/composing-a-domain/014.py
+++ b/docs_src/guides/composing-a-domain/014.py
@@ -2,7 +2,7 @@ from protean.core.aggregate import BaseAggregate
 from protean.domain import Domain
 from protean.fields import Integer, String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 class User(BaseAggregate):

--- a/docs_src/guides/composing-a-domain/015.py
+++ b/docs_src/guides/composing-a-domain/015.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Integer, String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate(stream_category="account")

--- a/docs_src/guides/composing-a-domain/016.py
+++ b/docs_src/guides/composing-a-domain/016.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Identifier, String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate

--- a/docs_src/guides/composing-a-domain/017.py
+++ b/docs_src/guides/composing-a-domain/017.py
@@ -1,6 +1,6 @@
 from protean import Domain
 
-domain = Domain(__file__)
+domain = Domain()
 
 domain.config["databases"]["default"] = {
     "provider": "sqlalchemy",

--- a/docs_src/guides/composing-a-domain/018.py
+++ b/docs_src/guides/composing-a-domain/018.py
@@ -2,7 +2,7 @@ from protean import Domain
 from protean.fields import Integer, String
 from protean.utils.globals import current_domain
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate

--- a/docs_src/guides/composing-a-domain/019.py
+++ b/docs_src/guides/composing-a-domain/019.py
@@ -6,7 +6,7 @@ from protean import Domain
 from protean.domain.context import has_domain_context
 from protean.fields import Integer, String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate

--- a/docs_src/guides/composing-a-domain/020.py
+++ b/docs_src/guides/composing-a-domain/020.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Integer, String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate(stream_category="account")

--- a/docs_src/guides/composing-a-domain/021.py
+++ b/docs_src/guides/composing-a-domain/021.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Integer, String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate(stream_category="account")

--- a/docs_src/guides/composing-a-domain/022.py
+++ b/docs_src/guides/composing-a-domain/022.py
@@ -9,7 +9,7 @@ def gen_ids(prefix="id"):
     return f"{prefix}-{timestamp}-{random.randint(0, 1000)}"
 
 
-domain = Domain(__file__, identity_function=gen_ids)
+domain = Domain(identity_function=gen_ids)
 
 # or you can pass parameters too
-# domain = Domain(__file__, identity_function=lambda: gen_ids("foo"))
+# domain = Domain(identity_function=lambda: gen_ids("foo"))

--- a/docs_src/guides/composing-a-domain/023.py
+++ b/docs_src/guides/composing-a-domain/023.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Auto, String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate

--- a/docs_src/guides/composing-a-domain/024.py
+++ b/docs_src/guides/composing-a-domain/024.py
@@ -3,7 +3,7 @@ import time
 from protean import Domain
 from protean.fields import Auto, String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 def gen_id():  # (1)

--- a/docs_src/guides/consume-state/001.py
+++ b/docs_src/guides/consume-state/001.py
@@ -1,7 +1,7 @@
 from protean import Domain, handle
 from protean.fields import Identifier, Integer, String
 
-domain = Domain(__file__)
+domain = Domain()
 domain.config["event_processing"] = "sync"
 
 

--- a/docs_src/guides/consume-state/002.py
+++ b/docs_src/guides/consume-state/002.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 from protean import Domain, handle, invariant
 from protean.fields import Float, Identifier, Integer, String, Text
 
-domain = Domain("__file__")
+domain = Domain()
 
 # Process events and commands synchronously
 domain.config["command_processing"] = "sync"

--- a/docs_src/guides/domain-behavior/001.py
+++ b/docs_src/guides/domain-behavior/001.py
@@ -5,7 +5,7 @@ from protean import Domain, invariant
 from protean.exceptions import ValidationError
 from protean.fields import Date, Float, HasMany, Identifier, Integer, String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 class OrderStatus(Enum):

--- a/docs_src/guides/domain-behavior/002.py
+++ b/docs_src/guides/domain-behavior/002.py
@@ -1,7 +1,7 @@
 from protean import Domain, invariant
 from protean.fields import Float, Identifier
 
-banking = Domain(__file__)
+banking = Domain()
 
 
 class InsufficientFundsException(Exception):

--- a/docs_src/guides/domain-behavior/003.py
+++ b/docs_src/guides/domain-behavior/003.py
@@ -4,7 +4,7 @@ from enum import Enum
 from protean import Domain
 from protean.fields import DateTime, Float, Integer, String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 def utc_now():

--- a/docs_src/guides/domain-behavior/004.py
+++ b/docs_src/guides/domain-behavior/004.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Integer, String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-behavior/005.py
+++ b/docs_src/guides/domain-behavior/005.py
@@ -3,7 +3,7 @@ import re
 from protean import Domain
 from protean.fields import String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 class EmailValidator:

--- a/docs_src/guides/domain-behavior/006.py
+++ b/docs_src/guides/domain-behavior/006.py
@@ -13,7 +13,7 @@ from protean.fields import (
     ValueObject,
 )
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 class OrderStatus(Enum):

--- a/docs_src/guides/domain-behavior/007.py
+++ b/docs_src/guides/domain-behavior/007.py
@@ -13,7 +13,7 @@ from protean.fields import (
     ValueObject,
 )
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 class OrderStatus(Enum):

--- a/docs_src/guides/domain-behavior/008.py
+++ b/docs_src/guides/domain-behavior/008.py
@@ -13,7 +13,7 @@ from protean.fields import (
     ValueObject,
 )
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 class OrderStatus(Enum):

--- a/docs_src/guides/domain-behavior/009.py
+++ b/docs_src/guides/domain-behavior/009.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 from protean import Domain, fields, invariant
 from protean.exceptions import ValidationError
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.event(part_of="Order")

--- a/docs_src/guides/domain-behavior/010.py
+++ b/docs_src/guides/domain-behavior/010.py
@@ -3,7 +3,7 @@ from datetime import date
 from protean import Domain
 from protean.fields import Date, HasMany, Identifier, String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-definition/001.py
+++ b/docs_src/guides/domain-definition/001.py
@@ -1,7 +1,7 @@
 from protean.domain import Domain
 from protean.fields import Date, String
 
-publishing = Domain(__file__)
+publishing = Domain()
 
 
 @publishing.aggregate

--- a/docs_src/guides/domain-definition/002.py
+++ b/docs_src/guides/domain-definition/002.py
@@ -3,7 +3,7 @@ import json
 from protean.domain import Domain
 from protean.fields import Date, String
 
-publishing = Domain(__file__, name="Publishing")
+publishing = Domain(name="Publishing")
 
 
 @publishing.aggregate

--- a/docs_src/guides/domain-definition/003.py
+++ b/docs_src/guides/domain-definition/003.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 from protean import Domain
 from protean.fields import DateTime, String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 def utc_now():

--- a/docs_src/guides/domain-definition/004.py
+++ b/docs_src/guides/domain-definition/004.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import String
 
-domain = Domain(__file__)
+domain = Domain()
 domain.config["DATABASES"] = {
     "default": {
         "PROVIDER": "protean.adapters.repository.sqlalchemy.SAProvider",

--- a/docs_src/guides/domain-definition/005.py
+++ b/docs_src/guides/domain-definition/005.py
@@ -3,7 +3,7 @@ import sqlalchemy
 from protean import Domain
 from protean.fields import String
 
-domain = Domain(__file__)
+domain = Domain()
 domain.config["DATABASES"] = {
     "default": {
         "PROVIDER": "protean.adapters.repository.sqlalchemy.SAProvider",

--- a/docs_src/guides/domain-definition/006.py
+++ b/docs_src/guides/domain-definition/006.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-definition/events/001.py
+++ b/docs_src/guides/domain-definition/events/001.py
@@ -3,7 +3,7 @@ from enum import Enum
 from protean import Domain
 from protean.fields import Identifier, String
 
-domain = Domain(__file__, name="Authentication")
+domain = Domain(name="Authentication")
 
 
 class UserStatus(Enum):

--- a/docs_src/guides/domain-definition/events/003.py
+++ b/docs_src/guides/domain-definition/events/003.py
@@ -4,7 +4,7 @@ from protean import Domain
 from protean.fields import HasOne, String
 from protean.utils.mixins import Message
 
-domain = Domain(__file__, name="Authentication")
+domain = Domain(name="Authentication")
 
 
 @domain.aggregate(fact_events=True)

--- a/docs_src/guides/domain-definition/fields/association-fields/001.py
+++ b/docs_src/guides/domain-definition/fields/association-fields/001.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import HasOne, String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-definition/fields/association-fields/002.py
+++ b/docs_src/guides/domain-definition/fields/association-fields/002.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Float, HasMany, String, Text
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-definition/fields/container-fields/001.py
+++ b/docs_src/guides/domain-definition/fields/container-fields/001.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import List, String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-definition/fields/container-fields/002.py
+++ b/docs_src/guides/domain-definition/fields/container-fields/002.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Dict, String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-definition/fields/container-fields/003.py
+++ b/docs_src/guides/domain-definition/fields/container-fields/003.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Float, String, ValueObject
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.value_object

--- a/docs_src/guides/domain-definition/fields/container-fields/004.py
+++ b/docs_src/guides/domain-definition/fields/container-fields/004.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import HasOne, List, String, ValueObject
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.value_object

--- a/docs_src/guides/domain-definition/fields/options/001.py
+++ b/docs_src/guides/domain-definition/fields/options/001.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-definition/fields/options/002.py
+++ b/docs_src/guides/domain-definition/fields/options/002.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-definition/fields/options/006.py
+++ b/docs_src/guides/domain-definition/fields/options/006.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-definition/fields/options/007.py
+++ b/docs_src/guides/domain-definition/fields/options/007.py
@@ -3,7 +3,7 @@ from enum import Enum
 from protean import Domain
 from protean.fields import Integer, String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 class BuildingStatus(Enum):

--- a/docs_src/guides/domain-definition/fields/options/008.py
+++ b/docs_src/guides/domain-definition/fields/options/008.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-definition/fields/options/009.py
+++ b/docs_src/guides/domain-definition/fields/options/009.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import List, String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-definition/fields/options/010.py
+++ b/docs_src/guides/domain-definition/fields/options/010.py
@@ -4,7 +4,7 @@ from protean import Domain
 from protean.exceptions import ValidationError
 from protean.fields import String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 class EmailDomainValidator:

--- a/docs_src/guides/domain-definition/fields/options/011.py
+++ b/docs_src/guides/domain-definition/fields/options/011.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Integer
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-definition/fields/simple-fields/001.py
+++ b/docs_src/guides/domain-definition/fields/simple-fields/001.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-definition/fields/simple-fields/002.py
+++ b/docs_src/guides/domain-definition/fields/simple-fields/002.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import String, Text
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-definition/fields/simple-fields/003.py
+++ b/docs_src/guides/domain-definition/fields/simple-fields/003.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Integer, String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-definition/fields/simple-fields/004.py
+++ b/docs_src/guides/domain-definition/fields/simple-fields/004.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Float, String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-definition/fields/simple-fields/005.py
+++ b/docs_src/guides/domain-definition/fields/simple-fields/005.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from protean import Domain
 from protean.fields import Date, String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-definition/fields/simple-fields/006.py
+++ b/docs_src/guides/domain-definition/fields/simple-fields/006.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 from protean import Domain
 from protean.fields import DateTime, String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-definition/fields/simple-fields/007.py
+++ b/docs_src/guides/domain-definition/fields/simple-fields/007.py
@@ -1,7 +1,7 @@
 from protean import Domain
 from protean.fields import Boolean, String
 
-domain = Domain(__file__)
+domain = Domain()
 
 
 @domain.aggregate

--- a/docs_src/guides/domain-definition/fields/simple-fields/008.py
+++ b/docs_src/guides/domain-definition/fields/simple-fields/008.py
@@ -2,7 +2,7 @@ from protean import Domain
 from protean.fields import Boolean, Identifier, String
 from protean.utils import IdentityType
 
-domain = Domain(__file__)
+domain = Domain()
 
 # Customize Identity Strategy and Type and activate
 domain.config["IDENTITY_TYPE"] = IdentityType.INTEGER.value

--- a/src/protean/domain/__init__.py
+++ b/src/protean/domain/__init__.py
@@ -114,6 +114,19 @@ class Domain:
     #: :data:`secret_key` configuration key. Defaults to ``None``.
     secret_key = ConfigAttribute("secret_key")
 
+    def _is_interactive_context(self, filename):
+        """Check if the given filename indicates an interactive context like shell or notebook.
+
+        Args:
+            filename: The code filename to check
+
+        Returns:
+            bool: True if filename indicates interactive context, False otherwise
+        """
+        if filename is None:
+            return False
+        return filename in {"<stdin>", "<ipython-input>", "<string>", "<console>"}
+
     def _guess_caller_path(self) -> str:
         """Attempts to determine the path of the caller script or module.
 
@@ -132,7 +145,7 @@ class Domain:
             filename = frame.f_code.co_filename
 
             # Handle special cases
-            if filename in {"<stdin>", "<ipython-input>", "<string>", "<console>"}:
+            if self._is_interactive_context(filename):
                 # Interactive shell or Jupyter notebook
                 return str(Path.cwd())
 

--- a/src/protean/domain/__init__.py
+++ b/src/protean/domain/__init__.py
@@ -5,9 +5,11 @@ to register Domain Elements.
 import inspect
 import json
 import logging
+import os
 import sys
 from collections import defaultdict
 from functools import lru_cache
+from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 from uuid import uuid4
 
@@ -59,9 +61,24 @@ class Domain:
     in the :file:`__init__.py` file of your package like this::
 
         from protean import Domain
-        domain = Domain(__name__)
+        domain = Domain()
 
-    :param domain_name: the name of the domain
+    The Domain will automatically detect the root path of the calling module.
+    You can also specify the root path explicitly::
+
+        domain = Domain(root_path="/path/to/domain")
+
+    The root path resolution follows this priority:
+    1. Explicit `root_path` parameter if provided
+    2. `DOMAIN_ROOT_PATH` environment variable if set
+    3. Auto-detection of caller's file location
+    4. Current working directory as last resort
+
+    :param root_path: the path to the folder containing the domain file
+                      (optional, will auto-detect if not provided)
+    :param name: the name of the domain (optional, will use the module name if not provided)
+    :param config: optional configuration dictionary
+    :param identity_function: optional function to generate identities for domain objects
     """
 
     from protean.utils import IdentityStrategy, IdentityType
@@ -97,14 +114,61 @@ class Domain:
     #: :data:`secret_key` configuration key. Defaults to ``None``.
     secret_key = ConfigAttribute("secret_key")
 
+    def _guess_caller_path(self) -> str:
+        """Attempts to determine the path of the caller script or module.
+
+        Returns the path of the file that called the Domain constructor.
+        Falls back to current working directory if no file path can be determined.
+
+        This handles various execution contexts:
+        - Standard Python scripts
+        - Jupyter/IPython notebooks
+        - REPL/interactive shell
+        - Frozen/PyInstaller applications
+        """
+        try:
+            # Get the frame of the caller of the Domain constructor (2 frames up)
+            frame = sys._getframe(2)
+            filename = frame.f_code.co_filename
+
+            # Handle special cases
+            if filename in {"<stdin>", "<ipython-input>", "<string>", "<console>"}:
+                # Interactive shell or Jupyter notebook
+                return str(Path.cwd())
+
+            # Handle frozen applications (PyInstaller, etc.)
+            if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
+                # PyInstaller creates a temp folder and stores path in _MEIPASS
+                return getattr(sys, "_MEIPASS")
+
+            # Regular Python script
+            try:
+                return str(Path(filename).resolve().parent)
+            except (TypeError, ValueError):
+                # Fallback to CWD if unable to determine path
+                return str(Path.cwd())
+        except Exception:
+            # Final fallback for any other unexpected errors
+            return str(Path.cwd())
+
     def __init__(
         self,
-        root_path: str,
+        root_path: str = None,
         name: str = "",
         config: Optional[Dict] = None,
         identity_function: Optional[Callable] = None,
     ):
-        self.root_path = root_path
+        # Determine root_path based on resolution priority
+        if root_path is None:
+            # Try to get from environment variable
+            env_root_path = os.environ.get("DOMAIN_ROOT_PATH")
+            if env_root_path:
+                self.root_path = env_root_path
+            else:
+                # Auto-detect
+                self.root_path = self._guess_caller_path()
+        else:
+            self.root_path = root_path
 
         # Initialize the domain with the name of the module if not provided
         # Get the stack frame of the caller of the __init__ method
@@ -239,8 +303,14 @@ class Domain:
         import os
         import pathlib
 
-        # Directory containing the domain file
-        root_dir = pathlib.PurePath(pathlib.Path(self.root_path).resolve()).parent
+        # Ensure root_path is a directory path
+        root_path = Path(self.root_path)
+        if root_path.is_file():
+            # If it's a file path (e.g. from __file__), get the parent directory
+            root_dir = root_path.parent
+        else:
+            # It's already a directory
+            root_dir = root_path
 
         # Parent Directory of the directory containing the domain file
         #
@@ -287,7 +357,7 @@ class Domain:
                 if (
                     os.path.isfile(full_file_path)
                     and os.path.splitext(filename)[1] == ".py"
-                    and full_file_path != self.root_path
+                    and not self._is_domain_file(full_file_path)
                 ):
                     # Construct the module path to import from
                     if filename != "__init__.py":
@@ -307,6 +377,23 @@ class Domain:
                         spec.loader.exec_module(module)
 
                     logger.debug(f"Loaded {filename}")
+
+    def _is_domain_file(self, file_path):
+        """Check if this is the domain file itself, to avoid self-import.
+
+        This replaces the direct path comparison that was used before.
+        """
+        if not Path(file_path).is_file():
+            return False
+
+        # Get the frame where the Domain was instantiated
+        frame = sys._getframe(0)
+        while frame:
+            if frame.f_code.co_filename == file_path:
+                return True
+            frame = frame.f_back
+
+        return False
 
     def _initialize(self):
         """Initialize domain dependencies and adapters."""

--- a/src/protean/domain/config.py
+++ b/src/protean/domain/config.py
@@ -88,7 +88,7 @@ class Config2(dict):
             return None
 
         # Start checking from the provided path up to 2 parent directories
-        current_dir = os.path.abspath(os.path.dirname(path))
+        current_dir = path
         config_file_name = None
 
         for _ in range(3):  # Check the current directory and up to 2 parent directories

--- a/src/protean/template/domain_template/src/{{package_name}}/domain.py.jinja
+++ b/src/protean/template/domain_template/src/{{package_name}}/domain.py.jinja
@@ -1,7 +1,7 @@
 from protean.domain import Domain
 
 # Domain Composition Root
-{{ package_name }} = Domain(__file__, "{{ project_name }}")
+{{ package_name }} = Domain(name="{{ project_name }}")
 
 # Initialize and load all domain elements under the composition root
 {{ package_name }}.init()

--- a/tests/adapters/broker/redis_broker/conftest.py
+++ b/tests/adapters/broker/redis_broker/conftest.py
@@ -5,7 +5,12 @@ from tests.shared import initialize_domain
 
 @pytest.fixture(autouse=True)
 def test_domain():
-    domain = initialize_domain(__file__, "Redis Broker Tests")
+    domain = initialize_domain(name="Redis Broker Tests", root_path=__file__)
+
+    # We initialize and load default configuration into the domain here
+    #   so that test cases that don't need explicit domain setup can
+    #   still function.
+    domain._initialize()
 
     with domain.domain_context():
         yield domain

--- a/tests/adapters/cache/redis_cache/conftest.py
+++ b/tests/adapters/cache/redis_cache/conftest.py
@@ -5,7 +5,7 @@ from tests.shared import initialize_domain
 
 @pytest.fixture(autouse=True)
 def test_domain():
-    domain = initialize_domain(__file__, "Redis Cache Tests")
+    domain = initialize_domain(name="Redis Cache Tests", root_path=__file__)
     domain.init(traverse=False)
 
     with domain.domain_context():

--- a/tests/adapters/database_model/elasticsearch_model/conftest.py
+++ b/tests/adapters/database_model/elasticsearch_model/conftest.py
@@ -5,7 +5,7 @@ from tests.shared import initialize_domain
 
 @pytest.fixture
 def test_domain():
-    domain = initialize_domain(__file__, "Elasticsearch Model Tests")
+    domain = initialize_domain(name="Elasticsearch Model Tests", root_path=__file__)
 
     with domain.domain_context():
         yield domain
@@ -13,7 +13,7 @@ def test_domain():
 
 @pytest.fixture(scope="module", autouse=True)
 def setup_db():
-    domain = initialize_domain(__file__, "Elasticsearch Model DB Setup")
+    domain = initialize_domain(name="Elasticsearch Model DB Setup", root_path=__file__)
     with domain.domain_context():
         # Create all indexes
         from .elements import (

--- a/tests/adapters/database_model/sqlalchemy_model/postgresql/conftest.py
+++ b/tests/adapters/database_model/sqlalchemy_model/postgresql/conftest.py
@@ -5,7 +5,7 @@ from tests.shared import initialize_domain
 
 @pytest.fixture(autouse=True)
 def test_domain():
-    domain = initialize_domain(__file__, "PostgreSQL Model Tests")
+    domain = initialize_domain(name="PostgreSQL Model Tests", root_path=__file__)
 
     with domain.domain_context():
         yield domain
@@ -13,7 +13,7 @@ def test_domain():
 
 @pytest.fixture(scope="module", autouse=True)
 def setup_db():
-    domain = initialize_domain(__file__, "PostgreSQL Model DB Setup")
+    domain = initialize_domain(name="PostgreSQL Model DB Setup", root_path=__file__)
     with domain.domain_context():
         # Create all associated tables
         from .elements import (

--- a/tests/adapters/database_model/sqlalchemy_model/sqlite/conftest.py
+++ b/tests/adapters/database_model/sqlalchemy_model/sqlite/conftest.py
@@ -5,7 +5,7 @@ from tests.shared import initialize_domain
 
 @pytest.fixture(autouse=True)
 def test_domain():
-    domain = initialize_domain(__file__, "SQLAlchemy Model Tests")
+    domain = initialize_domain(name="SQLAlchemy Model Tests", root_path=__file__)
 
     with domain.domain_context():
         yield domain
@@ -13,7 +13,7 @@ def test_domain():
 
 @pytest.fixture(scope="module", autouse=True)
 def setup_db():
-    domain = initialize_domain(__file__, "SQLAlchemy Model DB Setup")
+    domain = initialize_domain(name="SQLAlchemy Model DB Setup", root_path=__file__)
     with domain.domain_context():
         # Create all associated tables
         from .elements import ComplexUser, Person, Provider, ProviderCustomModel, User

--- a/tests/adapters/email/sendgrid_email/conftest.py
+++ b/tests/adapters/email/sendgrid_email/conftest.py
@@ -5,7 +5,7 @@ from tests.shared import initialize_domain
 
 @pytest.fixture(autouse=True)
 def test_domain():
-    domain = initialize_domain(__file__, "Sendgrid Email Tests")
+    domain = initialize_domain(name="Sendgrid Email Tests", root_path=__file__)
 
     with domain.domain_context():
         yield domain

--- a/tests/adapters/event_store/message_db_event_store/conftest.py
+++ b/tests/adapters/event_store/message_db_event_store/conftest.py
@@ -5,7 +5,7 @@ from tests.shared import initialize_domain
 
 @pytest.fixture
 def test_domain():
-    domain = initialize_domain(__file__, "Message DB Event Store Tests")
+    domain = initialize_domain(name="Message DB Event Store Tests", root_path=__file__)
 
     with domain.domain_context():
         yield domain

--- a/tests/adapters/event_store/message_db_event_store/tests.py
+++ b/tests/adapters/event_store/message_db_event_store/tests.py
@@ -17,7 +17,7 @@ class TestMessageDBEventStore:
         assert isinstance(test_domain.event_store.store, MessageDBStore)
 
     def test_error_on_message_db_initialization(self):
-        domain = Domain(__file__)
+        domain = Domain()
         domain.config["event_store"]["provider"] = "message_db"
         domain.config["event_store"]["database_uri"] = (
             "postgresql://message_store@localhost:5433/dummy"

--- a/tests/adapters/repository/elasticsearch_repo/conftest.py
+++ b/tests/adapters/repository/elasticsearch_repo/conftest.py
@@ -5,7 +5,9 @@ from tests.shared import initialize_domain
 
 @pytest.fixture
 def test_domain():
-    domain = initialize_domain(__file__, "Elasticsearch Repository Tests")
+    domain = initialize_domain(
+        name="Elasticsearch Repository Tests", root_path=__file__
+    )
 
     with domain.domain_context():
         yield domain
@@ -13,7 +15,9 @@ def test_domain():
 
 @pytest.fixture(scope="module", autouse=True)
 def setup_db():
-    domain = initialize_domain(__file__, "Elasticsearch Repository DB Setup")
+    domain = initialize_domain(
+        name="Elasticsearch Repository DB Setup", root_path=__file__
+    )
 
     with domain.domain_context():
         # Create all indexes

--- a/tests/adapters/repository/elasticsearch_repo/test_provider.py
+++ b/tests/adapters/repository/elasticsearch_repo/test_provider.py
@@ -46,7 +46,7 @@ class TestProviders:
     @pytest.mark.no_test_domain
     def test_exception_on_invalid_provider(self):
         """Test exception on invalid provider"""
-        domain = Domain(__file__)
+        domain = Domain()
         domain.config["databases"]["default"] = {
             "provider": "elasticsearch",
             "database_uri": '{"hosts": ["imaginary"]}',

--- a/tests/adapters/repository/sqlalchemy_repo/postgresql/conftest.py
+++ b/tests/adapters/repository/sqlalchemy_repo/postgresql/conftest.py
@@ -5,7 +5,9 @@ from tests.shared import initialize_domain
 
 @pytest.fixture
 def test_domain():
-    domain = initialize_domain(__file__, "SQLAlchemy Postgres Repository Tests")
+    domain = initialize_domain(
+        name="SQLAlchemy Postgres Repository Tests", root_path=__file__
+    )
 
     with domain.domain_context():
         yield domain
@@ -13,7 +15,9 @@ def test_domain():
 
 @pytest.fixture(scope="module", autouse=True)
 def setup_db():
-    domain = initialize_domain(__file__, "SQLAlchemy Postgres Repository DB Setup")
+    domain = initialize_domain(
+        name="SQLAlchemy Postgres Repository DB Setup", root_path=__file__
+    )
     with domain.domain_context():
         # Create all associated tables
         from .elements import Alien, ComplexUser, Person, User

--- a/tests/adapters/repository/sqlalchemy_repo/postgresql/test_provider.py
+++ b/tests/adapters/repository/sqlalchemy_repo/postgresql/test_provider.py
@@ -48,7 +48,7 @@ class TestProviders:
     @pytest.mark.no_test_domain
     def test_exception_on_invalid_provider(self):
         """Test exception on invalid provider"""
-        domain = Domain(__file__)
+        domain = Domain()
         domain.config["databases"]["default"] = {
             "provider": "postgresql",
             "database_uri": "postgresql://postgres:postgres@localhost:5444/foobar",

--- a/tests/adapters/repository/sqlalchemy_repo/sqlite/conftest.py
+++ b/tests/adapters/repository/sqlalchemy_repo/sqlite/conftest.py
@@ -5,7 +5,9 @@ from tests.shared import initialize_domain
 
 @pytest.fixture(autouse=True)
 def test_domain():
-    domain = initialize_domain(__file__, "SQLAlchemy SQLite Repository Tests")
+    domain = initialize_domain(
+        name="SQLAlchemy SQLite Repository Tests", root_path=__file__
+    )
 
     with domain.domain_context():
         yield domain
@@ -13,7 +15,9 @@ def test_domain():
 
 @pytest.fixture(scope="module", autouse=True)
 def setup_db():
-    domain = initialize_domain(__file__, "SQLAlchemy SQLite Repository DB Setup")
+    domain = initialize_domain(
+        name="SQLAlchemy SQLite Repository DB Setup", root_path=__file__
+    )
     with domain.domain_context():
         # Create all associated tables
         from .elements import Alien, ComplexUser, Person, User

--- a/tests/adapters/repository/sqlalchemy_repo/sqlite/test_provider.py
+++ b/tests/adapters/repository/sqlalchemy_repo/sqlite/test_provider.py
@@ -49,7 +49,7 @@ class TestProviders:
     @pytest.mark.no_test_domain
     def test_exception_on_invalid_provider(self):
         """Test exception on invalid provider"""
-        domain = Domain(__file__)
+        domain = Domain()
         domain.config["databases"]["default"] = {
             "provider": "sqlite",
             "database_uri": "sqlite:////C:/Users/username/foobar.db",

--- a/tests/cli/test_domain_loading.py
+++ b/tests/cli/test_domain_loading.py
@@ -14,17 +14,17 @@ from tests.shared import change_working_directory_to
 
 def test_find_domain_in_module():
     class Module:
-        domain = Domain(__file__, "name")
+        domain = Domain(name="name")
 
     assert find_domain_in_module(Module) == Module.domain
 
     class Module:
-        subdomain = Domain(__file__, "name")
+        subdomain = Domain(name="name")
 
     assert find_domain_in_module(Module) == Module.subdomain
 
     class Module:
-        my_domain = Domain(__file__, "name")
+        my_domain = Domain(name="name")
 
     assert find_domain_in_module(Module) == Module.my_domain
 
@@ -34,8 +34,8 @@ def test_find_domain_in_module():
     pytest.raises(NoDomainException, find_domain_in_module, Module)
 
     class Module:
-        my_domain1 = Domain(__file__, "name1")
-        my_domain2 = Domain(__file__, "name2")
+        my_domain1 = Domain(name="name1")
+        my_domain2 = Domain(name="name2")
 
     pytest.raises(NoDomainException, find_domain_in_module, Module)
 

--- a/tests/cli/test_find_domain_by_string.py
+++ b/tests/cli/test_find_domain_by_string.py
@@ -16,7 +16,7 @@ def mock_module():
     module = MagicMockWithName()
 
     # Configure the module for different test scenarios
-    module.valid_domain = Domain(__file__)
+    module.valid_domain = Domain()
     module.not_a_domain = "not a domain instance"
     return module
 
@@ -30,7 +30,7 @@ def test_find_domain_by_string_with_empty_domain_name(mock_module):
 
 
 def test_find_domain_by_string_with_whitespace_domain_name(mock_module):
-    mock_module.valid_domain = Domain(__file__)
+    mock_module.valid_domain = Domain()
     domain = find_domain_by_string(mock_module, " valid_domain ")
     assert isinstance(
         domain, Domain
@@ -70,7 +70,7 @@ def test_find_domain_by_string_with_nonexistent_attribute(mock_module):
 
 
 def test_find_domain_by_string_with_function_call(mock_module):
-    mock_module.domain_function = MagicMock(return_value=Domain(__file__))
+    mock_module.domain_function = MagicMock(return_value=Domain())
     domain = find_domain_by_string(mock_module, "domain_function()")
     assert isinstance(domain, Domain), "Should handle function calls correctly"
 
@@ -84,7 +84,7 @@ def test_find_domain_by_string_with_function_call_with_arguments(mock_module):
 
 
 def test_find_domain_by_string_returns_correct_domain_instance(mock_module):
-    expected_domain = Domain(__file__)
+    expected_domain = Domain()
     mock_module.specific_domain = expected_domain
     actual_domain = find_domain_by_string(mock_module, "specific_domain")
     assert (

--- a/tests/config/test_custom_constants.py
+++ b/tests/config/test_custom_constants.py
@@ -30,6 +30,6 @@ class TestConstantsOnDomain:
         domain.FOO == "bar"
 
     def test_when_no_constants_are_defined(self):
-        domain = Domain(__file__)
+        domain = Domain()
         assert domain is not None
         assert hasattr(domain, "FOO") is False

--- a/tests/config/test_load.py
+++ b/tests/config/test_load.py
@@ -27,7 +27,7 @@ class TestLoadingTOML:
         assert test_domain is not None
         assert test_domain.config["databases"]["default"]["provider"] == "memory"
         assert all(
-            key in test_domain.config["databases"] for key in ["memory", "sqlite"]
+            key in test_domain.config["databases"] for key in ["default", "memory"]
         )
         assert all(
             key in test_domain.config

--- a/tests/config/test_load_env_vars.py
+++ b/tests/config/test_load_env_vars.py
@@ -1,4 +1,6 @@
 import os
+import sys
+from pathlib import Path
 
 import pytest
 from mock import patch
@@ -15,6 +17,17 @@ def env_vars():
         os.environ, {"ENV_VAR1": "value1", "ENV_VAR2": "value2", "ENV_VAR3": "value3"}
     ):
         yield
+
+
+@pytest.fixture(autouse=True)
+def reset_path():
+    """Reset sys.path after every test run"""
+    original_path = sys.path[:]
+    cwd = Path.cwd()
+    yield
+
+    sys.path[:] = original_path
+    os.chdir(cwd)
 
 
 def test_load_env_vars_single_string(env_vars):

--- a/tests/config/test_optional_config.py
+++ b/tests/config/test_optional_config.py
@@ -4,7 +4,7 @@ from protean.domain import Domain
 
 
 def test_domain_loads_config_from_toml_file():
-    domain = Domain(__file__, "dummy")
+    domain = Domain(name="dummy")
     config = domain.load_config()
     assert config["debug"] is True
     assert config["testing"] is True
@@ -18,7 +18,7 @@ def test_domain_loads_config_from_dict():
         "testing": False,
         "custom": {"test_key": "test_value"},
     }
-    domain = Domain(__file__, "dummy")
+    domain = Domain(name="dummy")
     config = domain.load_config(test_config)
     assert config["debug"] is False
     assert config["testing"] is False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,8 @@ import sys
 
 import pytest
 
+from protean.domain import Processing
+
 
 def pytest_configure(config):
     # Insert the docs_src path into sys.path so that we can import elements from there
@@ -203,10 +205,14 @@ def test_domain(db_config, store_config, request):
     else:
         from protean.domain import Domain
 
-        domain = Domain(__file__, "Test")
+        domain = Domain(name="Test")
 
         domain.config["databases"]["default"] = db_config
         domain.config["event_store"] = store_config
+
+        domain.config["command_processing"] = Processing.SYNC.value
+        domain.config["event_processing"] = Processing.SYNC.value
+        domain.config["message_processing"] = Processing.SYNC.value
 
         # We initialize and load default configuration into the domain here
         #   so that test cases that don't need explicit domain setup can

--- a/tests/domain/test_config_immutability.py
+++ b/tests/domain/test_config_immutability.py
@@ -3,10 +3,10 @@ from protean.utils import IdentityStrategy
 
 
 def test_that_config_is_unique_to_each_domain():
-    domain1 = Domain(__file__)
+    domain1 = Domain()
     assert domain1.config["identity_strategy"] == IdentityStrategy.UUID.value
 
     domain1.config["identity_strategy"] = "FOO"
 
-    domain2 = Domain(__file__)
+    domain2 = Domain()
     assert domain2.config["identity_strategy"] == IdentityStrategy.UUID.value

--- a/tests/domain/test_domain_config.py
+++ b/tests/domain/test_domain_config.py
@@ -7,7 +7,7 @@ from protean.fields import Auto
 
 
 def test_invalid_identity_strategy():
-    domain = Domain(__file__)
+    domain = Domain()
     domain.config["identity_strategy"] = "invalid"
 
     class AutoTest(BaseAggregate):
@@ -23,7 +23,7 @@ def test_invalid_identity_strategy():
 
 
 def test_error_on_no_identity_function_if_strategy_is_function():
-    domain = Domain(__file__)
+    domain = Domain()
     domain.config["identity_strategy"] = "function"
 
     class AutoTest(BaseAggregate):

--- a/tests/domain/test_domain_identity_function.py
+++ b/tests/domain/test_domain_identity_function.py
@@ -16,7 +16,7 @@ def gen_ids(prefix="id"):
 
 
 def test_domain_accepts_custom_identity_function():
-    domain = Domain(__file__, identity_function=gen_ids)
+    domain = Domain(identity_function=gen_ids)
 
     assert domain._identity_function == gen_ids
 
@@ -26,7 +26,7 @@ def test_domain_accepts_custom_identity_function():
 
 
 def test_domain_identity_function_can_be_specified_with_lambda():
-    domain = Domain(__file__, identity_function=lambda: gen_ids("foo"))
+    domain = Domain(identity_function=lambda: gen_ids("foo"))
 
     pattern = r"^foo-\d{13}-\d+$"
     id_value = domain._identity_function()
@@ -34,7 +34,7 @@ def test_domain_identity_function_can_be_specified_with_lambda():
 
 
 def test_domain_identity_function_is_used_to_generate_identity():
-    domain = Domain(__file__, identity_function=gen_ids)
+    domain = Domain(identity_function=gen_ids)
     domain.config["identity_strategy"] = "function"
 
     class TestAggregate(BaseAggregate):
@@ -50,7 +50,7 @@ def test_domain_identity_function_is_used_to_generate_identity():
 
 
 def test_domain_identity_function_with_params_is_used_to_generate_identity():
-    domain = Domain(__file__, identity_function=lambda: gen_ids("foo"))
+    domain = Domain(identity_function=lambda: gen_ids("foo"))
     domain.config["identity_strategy"] = "function"
 
     class TestAggregate(BaseAggregate):
@@ -66,7 +66,7 @@ def test_domain_identity_function_with_params_is_used_to_generate_identity():
 
 
 def test_domain_identity_function_is_used_with_explicit_auto_field():
-    domain = Domain(__file__, identity_function=gen_ids)
+    domain = Domain(identity_function=gen_ids)
     domain.config["identity_strategy"] = "function"
 
     class TestAggregate(BaseAggregate):
@@ -86,7 +86,7 @@ def test_domain_identity_function_is_used_with_explicit_auto_field():
 
 
 def test_invalid_identity_function_raises_exception():
-    domain = Domain(__file__, identity_function="foo")
+    domain = Domain(identity_function="foo")
     domain.config["identity_strategy"] = "function"
 
     class TestAggregate(BaseAggregate):
@@ -106,7 +106,7 @@ def test_identity_function_returns_no_value():
     def return_no_value():
         return None
 
-    domain = Domain(__file__, identity_function=return_no_value)
+    domain = Domain(identity_function=return_no_value)
     domain.config["identity_strategy"] = "function"
 
     class TestAggregate(BaseAggregate):

--- a/tests/domain/test_domain_init.py
+++ b/tests/domain/test_domain_init.py
@@ -86,3 +86,121 @@ def test_domain_frozen_application(monkeypatch):
 
     domain = Domain()
     assert domain.root_path == frozen_path
+
+
+def test_is_interactive_context():
+    """Test that _is_interactive_context correctly identifies interactive shells and notebooks."""
+    domain = Domain()
+
+    # Test all interactive filenames from the actual implementation
+    interactive_filenames = ["<stdin>", "<ipython-input>", "<string>", "<console>"]
+    for filename in interactive_filenames:
+        assert (
+            domain._is_interactive_context(filename) is True
+        ), f"Should identify {filename} as interactive"
+
+    # Test typical non-interactive filenames
+    non_interactive_filenames = [
+        "/path/to/script.py",
+        "script.py",
+        "__main__.py",
+        "",
+        None,
+    ]
+    for filename in non_interactive_filenames:
+        assert (
+            domain._is_interactive_context(filename) is False
+        ), f"Should identify {filename} as non-interactive"
+
+
+def test_interactive_path_resolution():
+    """Test the code path in _guess_caller_path that handles interactive shells."""
+    domain = Domain()
+
+    # Create a simplified version of the method that uses the actual implementation
+    # of _is_interactive_context to determine behavior
+    def simplified_guess_caller_path(filename):
+        """Simplified version of _guess_caller_path that only tests the interactive branch."""
+        if domain._is_interactive_context(filename):
+            return str(Path.cwd())
+        return "non-interactive-path"
+
+    # Test all the special filenames that should trigger the interactive path
+    for filename in ["<stdin>", "<ipython-input>", "<string>", "<console>"]:
+        path = simplified_guess_caller_path(filename)
+        assert path == str(
+            Path.cwd()
+        ), f"For {filename}, should return current working directory"
+
+    # Make sure a regular filename doesn't trigger the interactive path
+    assert simplified_guess_caller_path("regular_file.py") == "non-interactive-path"
+
+
+def test_guess_caller_path_inner_exception_handling(monkeypatch):
+    """Test the inner exception handling in _guess_caller_path for TypeError/ValueError."""
+    domain = Domain()
+
+    # Mock the frame that would be returned by sys._getframe(2)
+    mock_frame = type(
+        "MockFrame",
+        (),
+        {"f_code": type("MockCode", (), {"co_filename": "/path/to/file.py"})},
+    )
+
+    # Patch sys._getframe to return our mock frame
+    monkeypatch.setattr(sys, "_getframe", lambda depth: mock_frame)
+
+    # Save original Path.resolve
+    original_path_resolve = Path.resolve
+
+    # Define a mock that will raise TypeError
+    def mock_resolve(self, *args, **kwargs):
+        raise TypeError("Mock error for testing")
+
+    # Apply the patch to Path.resolve
+    monkeypatch.setattr(Path, "resolve", mock_resolve)
+
+    # Now when _guess_caller_path tries to resolve the path, it will raise TypeError
+    # and should fall back to returning cwd
+    result = domain._guess_caller_path()
+
+    # Verify the fallback path is used (cwd)
+    assert result == str(Path.cwd())
+
+
+def test_guess_caller_path_outer_exception_handling(monkeypatch):
+    """Test the outer exception handling in _guess_caller_path."""
+    domain = Domain()
+
+    # Mock sys._getframe to raise an exception
+    def mock_getframe(depth):
+        raise Exception("Mock error for testing the outer exception handler")
+
+    # Patch sys._getframe
+    monkeypatch.setattr(sys, "_getframe", mock_getframe)
+
+    # Now calling _guess_caller_path should trigger the outer exception handler
+    # and return cwd as the fallback
+    result = domain._guess_caller_path()
+
+    # Verify the fallback path is used (cwd)
+    assert result == str(Path.cwd())
+
+
+def test_guess_caller_path_interactive_return(monkeypatch):
+    """Test the return value in the interactive shell branch of _guess_caller_path."""
+    domain = Domain()
+
+    # Create a mock frame with a filename that will be identified as interactive
+    mock_frame = type(
+        "MockFrame", (), {"f_code": type("MockCode", (), {"co_filename": "<stdin>"})}
+    )
+
+    # Patch sys._getframe to return our mock frame
+    monkeypatch.setattr(sys, "_getframe", lambda depth: mock_frame)
+
+    # Call _guess_caller_path, which should detect interactive mode and return cwd
+    result = domain._guess_caller_path()
+
+    # Verify it returns the current working directory
+    assert result == str(Path.cwd())

--- a/tests/domain/test_domain_init.py
+++ b/tests/domain/test_domain_init.py
@@ -1,0 +1,88 @@
+"""Tests for the domain initialization behavior."""
+
+import sys
+from pathlib import Path
+
+from protean import Domain
+
+
+def test_domain_init_without_root_path():
+    """Test that a Domain can be initialized without root_path."""
+    domain = Domain()
+    # It should detect the current file's directory
+    assert domain.root_path == str(Path(__file__).parent)
+
+
+def test_domain_init_with_explicit_root_path():
+    """Test that a Domain can be initialized with an explicit root_path."""
+    test_path = "/test/path"
+    domain = Domain(root_path=test_path)
+    assert domain.root_path == test_path
+
+
+def test_domain_init_with_environment_variable(monkeypatch):
+    """Test that a Domain uses DOMAIN_ROOT_PATH if set."""
+    env_path = "/env/path"
+    monkeypatch.setenv("DOMAIN_ROOT_PATH", env_path)
+    domain = Domain()
+    assert domain.root_path == env_path
+
+
+def test_domain_fallback_to_cwd_in_interactive(monkeypatch):
+    """Test that Domain uses cwd in interactive environments."""
+    # Create a Domain with a patched function that intercepts the _guess_caller_path call
+    original_init = Domain.__init__
+
+    def patched_init(
+        self, root_path=None, name="", config=None, identity_function=None
+    ):
+        # Mock as if we're in an interactive shell - call original but override root_path handling
+        if root_path is None:
+            # Simulate the logic in _guess_caller_path for interactive shells
+            root_path = str(Path.cwd())
+
+        original_init(
+            self,
+            root_path=root_path,
+            name=name,
+            config=config,
+            identity_function=identity_function,
+        )
+
+    # Apply the patch
+    monkeypatch.setattr(Domain, "__init__", patched_init)
+
+    domain = Domain()
+    assert domain.root_path == str(Path.cwd())
+
+
+def test_domain_resolution_priority(monkeypatch):
+    """Test that Domain respects the resolution priority."""
+    # 1. Explicit root_path should take precedence
+    env_path = "/env/path"
+    explicit_path = "/explicit/path"
+    monkeypatch.setenv("DOMAIN_ROOT_PATH", env_path)
+
+    domain = Domain(root_path=explicit_path)
+    assert domain.root_path == explicit_path
+
+    # 2. Environment variable should be next
+    domain = Domain()
+    assert domain.root_path == env_path
+
+    # 3. Auto-detection should be last
+    monkeypatch.delenv("DOMAIN_ROOT_PATH")
+    domain = Domain()
+    assert domain.root_path != env_path
+    assert Path(domain.root_path).exists()
+
+
+def test_domain_frozen_application(monkeypatch):
+    """Test that Domain handles frozen applications correctly."""
+    # Mock sys to simulate a frozen app (like PyInstaller)
+    frozen_path = "/frozen/app/path"
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "_MEIPASS", frozen_path, raising=False)
+
+    domain = Domain()
+    assert domain.root_path == frozen_path

--- a/tests/domain/tests.py
+++ b/tests/domain/tests.py
@@ -16,13 +16,13 @@ from .elements import UserAggregate, UserEntity, UserFoo, UserVO
 
 
 def test_domain_name():
-    domain = Domain(__file__, "Foo")
+    domain = Domain(name="Foo")
 
     assert domain.name == "Foo"
 
 
 def test_domain_name_string():
-    domain = Domain(__file__, "Foo")
+    domain = Domain(name="Foo")
 
     assert str(domain) == "Domain: Foo"
 
@@ -48,7 +48,7 @@ def test_normalized_domain_name():
         ("My Domain 1.0", "my_domain_1_0"),
     ]
     for name, result in data:
-        domain = Domain(__file__, name)
+        domain = Domain(name=name)
         assert domain.normalized_name == result, f"Failed for {name}"
 
 
@@ -73,7 +73,7 @@ def test_camel_case_domain_name():
         ("My Domain 1.0", "MyDomain10"),
     ]
     for name, result in data:
-        domain = Domain(__file__, name)
+        domain = Domain(name=name)
         assert domain.camel_case_name == result, f"Failed for {name}"
 
 
@@ -206,12 +206,12 @@ class TestDomainLevelClassResolution:
         def test_domain(self):
             from protean.domain import Domain
 
-            domain = Domain(__file__, "Test")
+            domain = Domain(name="Test")
             domain.config["databases"]["memory"] = {"provider": "memory"}
             yield domain
 
         def test_that_class_reference_is_tracked_at_the_domain_level(self):
-            domain = Domain(__file__)
+            domain = Domain()
 
             class Post(BaseAggregate):
                 content = Text(required=True)
@@ -237,7 +237,7 @@ class TestDomainLevelClassResolution:
             )
 
         def test_that_class_reference_is_resolved_on_domain_initialization(self):
-            domain = Domain(__file__, "Inline Domain")
+            domain = Domain(name="Inline Domain")
 
             class Post(BaseAggregate):
                 content = Text(required=True)
@@ -268,7 +268,7 @@ class TestDomainLevelClassResolution:
         def test_that_domain_throws_exception_on_unknown_class_references_during_activation(
             self,
         ):
-            domain = Domain(__file__, "Inline Domain")
+            domain = Domain(name="Inline Domain")
 
             class Post(BaseAggregate):
                 content = Text(required=True)

--- a/tests/field/test_identifier.py
+++ b/tests/field/test_identifier.py
@@ -109,7 +109,7 @@ class TestIdentityType:
         identifier._load(42) == "42"
 
     def test_invalid_identity_type_in_domain_config(self):
-        domain = Domain(__file__)
+        domain = Domain()
         domain.config["identity_type"] = "invalid"
 
         with domain.domain_context():
@@ -122,7 +122,7 @@ class TestIdentityType:
             }
 
     def test_that_default_is_picked_from_domain_config(self):
-        domain = Domain(__file__)
+        domain = Domain()
 
         # By default, IdentityType is UUID
         with domain.domain_context():

--- a/tests/identity/conftest.py
+++ b/tests/identity/conftest.py
@@ -6,7 +6,7 @@ from protean.utils import IdentityType
 
 @pytest.fixture
 def domain():
-    return Domain(__file__, "Test")
+    return Domain(name="Test")
 
 
 @pytest.fixture

--- a/tests/server/test_engine_exits.py
+++ b/tests/server/test_engine_exits.py
@@ -12,7 +12,7 @@ def test_engine_exits_if_no_subscriptions(caplog):
     logger = logging.getLogger("protean.server.engine")
     logger.setLevel(logging.INFO)
 
-    domain = Domain(__file__, "dummy")
+    domain = Domain(name="dummy")
     engine = Engine(domain, test_mode=True)
     engine.run()
 

--- a/tests/server/test_engine_handle_exception.py
+++ b/tests/server/test_engine_handle_exception.py
@@ -9,7 +9,7 @@ from protean.utils import Processing
 
 @pytest.fixture
 def engine():
-    domain = Domain(__file__)
+    domain = Domain()
     domain.config["event_processing"] = Processing.ASYNC.value
     return Engine(domain, test_mode=True, debug=True)
 

--- a/tests/server/test_message_handling.py
+++ b/tests/server/test_message_handling.py
@@ -1,6 +1,7 @@
 import pytest
 
 from protean.core.subscriber import BaseSubscriber
+from protean.domain import Processing
 from protean.server import Engine
 
 counter = 0
@@ -19,6 +20,11 @@ class DummySubscriber(BaseSubscriber):
 class ExceptionSubscriber(BaseSubscriber):
     def __call__(self, data: dict):
         raise Exception("This is a dummy exception")
+
+
+@pytest.fixture(autouse=True)
+def set_message_processing_async(test_domain):
+    test_domain.config["message_processing"] = Processing.ASYNC.value
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_processing_broker_messages.py
+++ b/tests/server/test_processing_broker_messages.py
@@ -3,6 +3,7 @@ import asyncio
 import pytest
 
 from protean.core.subscriber import BaseSubscriber
+from protean.domain import Processing
 from protean.server import Engine
 
 terms = []
@@ -24,6 +25,11 @@ def clear_terms():
 
     global terms
     terms = []
+
+
+@pytest.fixture(autouse=True)
+def set_message_processing_async(test_domain):
+    test_domain.config["message_processing"] = Processing.ASYNC.value
 
 
 @pytest.mark.broker_common

--- a/tests/server2/test_domain_context.py
+++ b/tests/server2/test_domain_context.py
@@ -12,7 +12,7 @@ class TestDomainContext:
 
     @pytest.fixture
     def custom_domain(self):
-        domain = Domain(__file__, "Custom Domain Context Test")
+        domain = Domain(name="Custom Domain Context Test")
         domain._initialize()
 
         yield domain

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -10,9 +10,9 @@ import pytest
 from protean.domain import Domain
 
 
-def initialize_domain(file_path, name="Tests"):
+def initialize_domain(name="Tests", root_path=None):
     """Initialize a Protean Domain with configuration from a file"""
-    domain = Domain(file_path, name=name)
+    domain = Domain(name=name, root_path=root_path)
 
     # We initialize and load default configuration into the domain here
     #   so that test cases that don't need explicit domain setup can

--- a/tests/support/domains/test1/basic.py
+++ b/tests/support/domains/test1/basic.py
@@ -1,3 +1,3 @@
 from protean import Domain
 
-domain = Domain(__file__, "BASIC")
+domain = Domain(name="BASIC")

--- a/tests/support/domains/test10/domain.py
+++ b/tests/support/domains/test10/domain.py
@@ -4,4 +4,4 @@ when no file/package and attribute name were provided
 
 from protean.domain import Domain
 
-domain = Domain(__file__, "TEST10")
+domain = Domain(name="TEST10")

--- a/tests/support/domains/test11/subdomain.py
+++ b/tests/support/domains/test11/subdomain.py
@@ -4,4 +4,4 @@ when no file/package and attribute name were provided
 
 from protean.domain import Domain
 
-domain = Domain(__file__, "TEST11")
+domain = Domain(name="TEST11")

--- a/tests/support/domains/test12/foo12.py
+++ b/tests/support/domains/test12/foo12.py
@@ -2,5 +2,5 @@
 
 from protean.domain import Domain
 
-subdomain = Domain(__file__, "TEST12")
-specific = Domain(__file__, "TEST12_SPECIFIC")
+subdomain = Domain(name="TEST12")
+specific = Domain(name="TEST12_SPECIFIC")

--- a/tests/support/domains/test13/publishing13.py
+++ b/tests/support/domains/test13/publishing13.py
@@ -5,4 +5,4 @@ The test is to check if the name is initialized to the module containing the dom
 
 from protean.domain import Domain
 
-domain = Domain(__file__)
+domain = Domain()

--- a/tests/support/domains/test14/domain14.py
+++ b/tests/support/domains/test14/domain14.py
@@ -1,3 +1,3 @@
 from protean import Domain
 
-domain = Domain(__file__, "TEST14")
+domain = Domain(name="TEST14")

--- a/tests/support/domains/test15/domain15.py
+++ b/tests/support/domains/test15/domain15.py
@@ -1,3 +1,3 @@
 from protean import Domain
 
-domain = Domain(__file__, "TEST15")
+domain = Domain(name="TEST15")

--- a/tests/support/domains/test16/domain16.py
+++ b/tests/support/domains/test16/domain16.py
@@ -1,3 +1,3 @@
 from protean import Domain
 
-domain = Domain(__file__, "TEST15")
+domain = Domain(name="TEST15")

--- a/tests/support/domains/test17/domain17.py
+++ b/tests/support/domains/test17/domain17.py
@@ -1,3 +1,3 @@
 from protean import Domain
 
-domain = Domain(__file__, "TEST15")
+domain = Domain(name="TEST15")

--- a/tests/support/domains/test18/domain18.py
+++ b/tests/support/domains/test18/domain18.py
@@ -1,3 +1,3 @@
 from protean import Domain
 
-domain = Domain(__file__, "TEST18")
+domain = Domain(name="TEST18")

--- a/tests/support/domains/test19/domain19.py
+++ b/tests/support/domains/test19/domain19.py
@@ -1,3 +1,3 @@
 from protean import Domain
 
-domain = Domain(__file__, "TEST19")
+domain = Domain(name="TEST19")

--- a/tests/support/domains/test2/src/folder.py
+++ b/tests/support/domains/test2/src/folder.py
@@ -1,3 +1,3 @@
 from protean import Domain
 
-domain = Domain(__file__, "FOLDER")
+domain = Domain(name="FOLDER")

--- a/tests/support/domains/test20/publishing20.py
+++ b/tests/support/domains/test20/publishing20.py
@@ -1,4 +1,4 @@
 from protean import Domain
 
-publishing = Domain(__file__, "Publishing20")
+publishing = Domain(name="Publishing20")
 print(id(publishing))

--- a/tests/support/domains/test21/publishing21.py
+++ b/tests/support/domains/test21/publishing21.py
@@ -1,3 +1,3 @@
 from protean import Domain
 
-publishing = Domain(__file__, "Publishing21")
+publishing = Domain(name="Publishing21")

--- a/tests/support/domains/test22/src/publishing/domain22.py
+++ b/tests/support/domains/test22/src/publishing/domain22.py
@@ -1,3 +1,3 @@
 from protean import Domain
 
-domain = Domain(__file__, "TEST22")
+domain = Domain(name="TEST22")

--- a/tests/support/domains/test23/src/publishing/domain23.py
+++ b/tests/support/domains/test23/src/publishing/domain23.py
@@ -1,3 +1,3 @@
 from protean import Domain
 
-domain = Domain(__file__, "TEST23")
+domain = Domain(name="TEST23")

--- a/tests/support/domains/test24/domain24.py
+++ b/tests/support/domains/test24/domain24.py
@@ -1,3 +1,3 @@
 from protean import Domain
 
-domain = Domain(__file__, "TEST24")
+domain = Domain(name="TEST24")

--- a/tests/support/domains/test3/nested/web.py
+++ b/tests/support/domains/test3/nested/web.py
@@ -1,3 +1,3 @@
 from protean import Domain
 
-domain = Domain(__file__, "WEB")
+domain = Domain(name="WEB")

--- a/tests/support/domains/test4/instance.py
+++ b/tests/support/domains/test4/instance.py
@@ -1,3 +1,3 @@
 from protean import Domain
 
-dom2 = Domain(__file__, "INSTANCE")
+dom2 = Domain(name="INSTANCE")

--- a/tests/support/domains/test6/publishing6.py
+++ b/tests/support/domains/test6/publishing6.py
@@ -1,3 +1,3 @@
 from protean.domain import Domain
 
-domain = Domain(__file__, "TEST6")
+domain = Domain(name="TEST6")

--- a/tests/support/domains/test7/publishing7.py
+++ b/tests/support/domains/test7/publishing7.py
@@ -1,3 +1,3 @@
 from protean.domain import Domain
 
-domain = Domain(__file__, "TEST7")
+domain = Domain(name="TEST7")

--- a/tests/support/domains/test8/sqlite_domain.py
+++ b/tests/support/domains/test8/sqlite_domain.py
@@ -4,7 +4,7 @@ for further testing, like docker file generation
 
 from protean.domain import Domain
 
-domain = Domain(__file__, "SQLite-Domain")
+domain = Domain(name="SQLite-Domain")
 
 
 domain.config["databases"] = {

--- a/tests/support/domains/test9/publishing9.py
+++ b/tests/support/domains/test9/publishing9.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from protean.domain import Domain
 from protean.fields import DateTime, HasMany, Reference, String
 
-domain = Domain(__file__, "TEST9")
+domain = Domain(name="TEST9")
 
 
 @domain.aggregate

--- a/tests/workflows/test_event_flows.py
+++ b/tests/workflows/test_event_flows.py
@@ -163,7 +163,7 @@ class ShipmentEventHandler(BaseEventHandler):
 
 @pytest.fixture
 def test_domain():
-    test_domain = Domain(__file__, "Test")
+    test_domain = Domain(name="Test")
 
     test_domain.config["event_store"] = {
         "provider": "message_db",
@@ -192,7 +192,7 @@ def test_domain():
 
 @pytest.fixture
 def shipment_domain():
-    shipment_domain = Domain(__file__, "Shipment")
+    shipment_domain = Domain(name="Shipment")
 
     shipment_domain.config["event_store"] = {
         "provider": "message_db",


### PR DESCRIPTION
Removes the need for users to pass `__file__` when instantiating a Domain, while still allowing an explicit override.

Environments supported:

- Standard Python execution (scripts, console entry-points)
- Jupyter / IPython notebooks
- REPL / interactive shell
- Frozen / zipapp / PyInstaller builds

Also:
- Updated the Domain initialization across various documentation files and test cases to use the new parameter format.
- Changed instances of `Domain(__file__, "name")` to `Domain(name="name")` for consistency and clarity.

Fixes #514