### PR TITLE
Enhance-postgres deps docs sqlalchemy warnings

### DIFF
--- a/docs/adapters/database/postgresql.md
+++ b/docs/adapters/database/postgresql.md
@@ -3,6 +3,48 @@
 The PostgreSQL adapter uses (`SQLAlchemy`)[https://www.sqlalchemy.org/] under
 the covers as the ORM to communicate with the database.
 
+## Prerequisites
+
+To use the PostgreSQL adapter, you need to install additional dependencies:
+
+1. **SQLAlchemy**: Required for all database operations (included when installing with `postgresql` extra)
+2. **PostgreSQL Driver**: You need either `psycopg2` or `psycopg2-binary`
+
+### Installing Dependencies
+
+You can install Protean with PostgreSQL support using pip:
+
+```bash
+# Option 1: Use psycopg2-binary (easier installation, recommended for development)
+pip install "protean[postgresql]"
+
+# Option 2: Use psycopg2 (recommended for production)
+pip install "protean[postgresql-dev]"
+```
+
+### psycopg2 vs psycopg2-binary
+
+- `psycopg2-binary`: Pre-compiled binary package, easier to install but may have compatibility issues in some environments.
+- `psycopg2`: Source distribution that requires compilation but generally more stable for production use.
+
+### System Prerequisites for psycopg2
+
+If you choose to use `psycopg2` (not the binary version), you'll need these system dependencies:
+
+#### Ubuntu/Debian:
+```bash
+sudo apt-get install python3-dev libpq-dev
+```
+
+#### macOS with Homebrew:
+```bash
+brew install postgresql
+```
+After installation, you may need to set environment variables as instructed in the Homebrew output.
+
+#### Windows:
+Install PostgreSQL from the [official website](https://www.postgresql.org/download/windows/) which includes the required libraries.
+
 ## Configuration
 
 ```toml
@@ -37,4 +79,19 @@ generates internally, allowing you full customization.
 !!!note
     The column names specified in the model should exactly match the attribute
     names of the Aggregate or Entity it represents.
+
+## Troubleshooting
+
+### Missing Dependencies
+
+If you encounter errors about missing dependencies, you'll see helpful warning messages that guide you to install the necessary packages. Common errors include:
+
+- `ImportError: No module named 'psycopg2'`: Install either `psycopg2` or `psycopg2-binary`
+- Compilation errors with `psycopg2`: Install the system dependencies mentioned above
+
+### Connection Issues
+
+- Ensure PostgreSQL is running on the specified host and port
+- Verify the database user has appropriate permissions
+- Check if the database specified in the URI exists
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ elasticsearch = {version = "~7.17.9", optional = true}
 elasticsearch-dsl = {version = "~7.4.1", optional = true}
 redis = {version = ">=5.0.7,<5.3.0", optional = true}
 sqlalchemy = {version = "~2.0.30", optional = true}
+psycopg2-binary = {version = ">=2.9.9", optional = true}
 psycopg2 = {version = ">=2.9.9", optional = true}
 flask = {version = ">=1.1.1", optional = true}
 sendgrid = {version = ">=6.1.3", optional = true}
@@ -76,7 +77,8 @@ uvicorn = {version = ">=0.27.1", optional = true}
 [tool.poetry.extras]
 elasticsearch = ["elasticsearch", "elasticsearch-dsl"]
 redis = ["redis"]
-postgresql = ["sqlalchemy", "psycopg2"]
+postgresql = ["sqlalchemy", "psycopg2-binary"]
+postgresql-dev = ["sqlalchemy", "psycopg2"]
 sqlite = ["sqlalchemy"]
 message-db = ["message-db-py"]
 flask = ["flask"]

--- a/src/protean/adapters/repository/sqlalchemy.py
+++ b/src/protean/adapters/repository/sqlalchemy.py
@@ -1,6 +1,7 @@
 """Module with repository implementation for SQLAlchemy"""
 
 import copy
+import importlib.util
 import json
 import logging
 import uuid
@@ -49,6 +50,19 @@ from protean.utils.reflection import attributes, id_field
 
 logging.getLogger("sqlalchemy").setLevel(logging.ERROR)
 logger = logging.getLogger(__name__)
+
+
+def check_psycopg2_availability():
+    """Check if psycopg2 or psycopg2-binary is available"""
+    psycopg2_spec = importlib.util.find_spec("psycopg2")
+    psycopg2_binary_spec = importlib.util.find_spec("psycopg2_binary")
+
+    if psycopg2_spec is not None:
+        return "psycopg2"
+    elif psycopg2_binary_spec is not None:
+        return "psycopg2-binary"
+    else:
+        return None
 
 
 class GUID(TypeDecorator):
@@ -766,6 +780,16 @@ class SAProvider(BaseProvider):
 
 class PostgresqlProvider(SAProvider):
     __database__ = SAProvider.databases.postgresql.value
+
+    def __init__(self, name, domain, conn_info: dict):
+        psycopg2_package = check_psycopg2_availability()
+        if not psycopg2_package:
+            logger.warning(
+                "PostgreSQL provider requires psycopg2 or psycopg2-binary. Please install one of them."
+            )
+        else:
+            logger.info(f"Using {psycopg2_package} for PostgreSQL connection.")
+        super().__init__(name, domain, conn_info)
 
     def _get_database_specific_engine_args(self) -> dict:
         """Supplies additional database-specific arguments to SQLAlchemy Engine.


### PR DESCRIPTION
Fixes #511 
This pull request introduces support for differentiating between `psycopg2` and `psycopg2-binary` for PostgreSQL connections, enhances documentation, and adds runtime checks for dependency availability. Below are the most important changes grouped by theme: