### PR TITLE
Fix coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       message-db:
         image: ethangarofolo/message-db:1.2.6
         ports:
-          - 5433:5432z
+          - 5433:5432
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, fix-coverage-reporting]  # Add your branch name here
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,11 +102,13 @@ jobs:
 
       - name: Generate Coverage XML
         run: |
+          coverage combine
           coverage xml
 
       - name: CodeCOV
         uses: codecov/codecov-action@v5.4.2
         with:
+          files: coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
 
   docs-deploy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, fix-coverage-reporting]
   pull_request:
     branches: [main]
 
@@ -100,10 +100,16 @@ jobs:
           # The default Redis port
           REDIS_PORT: ${{ job.services.redis.ports[6379] }}
 
+      - name: Generate Coverage XML
+        run: |
+          coverage xml
+
       - name: CodeCOV
         uses: codecov/codecov-action@v5.4.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+          fail_ci_if_error: true
 
   docs-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, fix-coverage-reporting]  # Add your branch name here
   pull_request:
     branches: [main]
 
@@ -50,7 +50,7 @@ jobs:
       message-db:
         image: ethangarofolo/message-db:1.2.6
         ports:
-          - 5433:5432
+          - 5433:5432z
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, fix-coverage-reporting]
+    branches: [main]
   pull_request:
     branches: [main]
 
@@ -108,8 +108,6 @@ jobs:
         uses: codecov/codecov-action@v5.4.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          verbose: true
-          fail_ci_if_error: true
 
   docs-deploy:
     runs-on: ubuntu-latest

--- a/src/protean/cli/__init__.py
+++ b/src/protean/cli/__init__.py
@@ -101,7 +101,6 @@ def test(
 
             # Run full suite of tests with coverage
             # Run main tests with all markers
-            print("Running main test suite with coverage...")
             subprocess.call(
                 ["coverage", "run", "--parallel-mode", "-m"]
                 + commands

--- a/src/protean/cli/__init__.py
+++ b/src/protean/cli/__init__.py
@@ -96,10 +96,14 @@ def test(
                 print(f"Running tests for DATABASE: {db}...")
                 subprocess.call(commands + ["-m", "database", f"--db={db}"])
         case "FULL":
+            # First, ensure any existing coverage data is removed to avoid mixing previous runs
+            subprocess.call(["coverage", "erase"])
+
             # Run full suite of tests with coverage
-            # FIXME: Add support for auto-fetching supported adapters
+            # Run main tests with all markers
+            print("Running main test suite with coverage...")
             subprocess.call(
-                ["coverage", "run", "-m"]
+                ["coverage", "run", "--parallel-mode", "-m"]
                 + commands
                 + [
                     "--slow",
@@ -116,7 +120,7 @@ def test(
             for db in ["MEMORY", "POSTGRESQL", "SQLITE"]:
                 print(f"Running tests for DB: {db}...")
                 subprocess.call(
-                    ["coverage", "run", "-m"]
+                    ["coverage", "run", "--parallel-mode", "-m"]
                     + commands
                     + ["-m", "database", f"--db={db}"]
                 )
@@ -124,12 +128,13 @@ def test(
             for store in ["MESSAGE_DB"]:
                 print(f"Running tests for EVENTSTORE: {store}...")
                 subprocess.call(
-                    ["coverage", "run", "-m"]
+                    ["coverage", "run", "--parallel-mode", "-m"]
                     + commands
                     + ["-m", "eventstore", f"--store={store}"]
                 )
 
-            # Run coverage report
+            # Combine all coverage data files and generate report
+            print("\nCombining coverage data and generating report...")
             subprocess.call(["coverage", "combine"])
             subprocess.call(["coverage", "report"])
         case _:

--- a/tests/cli/test_test.py
+++ b/tests/cli/test_test.py
@@ -81,10 +81,12 @@ def mock_subprocess_call(mocker):
         (
             Category.FULL,
             [
+                call(["coverage", "erase"]),
                 call(
                     [
                         "coverage",
                         "run",
+                        "--parallel-mode",
                         "-m",
                         "pytest",
                         "--cache-clear",
@@ -102,6 +104,7 @@ def mock_subprocess_call(mocker):
                     [
                         "coverage",
                         "run",
+                        "--parallel-mode",
                         "-m",
                         "pytest",
                         "--cache-clear",
@@ -115,6 +118,7 @@ def mock_subprocess_call(mocker):
                     [
                         "coverage",
                         "run",
+                        "--parallel-mode",
                         "-m",
                         "pytest",
                         "--cache-clear",
@@ -128,6 +132,7 @@ def mock_subprocess_call(mocker):
                     [
                         "coverage",
                         "run",
+                        "--parallel-mode",
                         "-m",
                         "pytest",
                         "--cache-clear",
@@ -141,6 +146,7 @@ def mock_subprocess_call(mocker):
                     [
                         "coverage",
                         "run",
+                        "--parallel-mode",
                         "-m",
                         "pytest",
                         "--cache-clear",
@@ -150,8 +156,10 @@ def mock_subprocess_call(mocker):
                         "--store=MESSAGE_DB",
                     ]
                 ),
+                call(["coverage", "combine"]),
+                call(["coverage", "report"]),
             ],
-            7,  # 5 calls + 2 for coverage
+            8,  # 5 calls + 3 for coverage operations (erase, combine, report)
         ),
         (
             Category.CORE,


### PR DESCRIPTION
fixes #512 
This pull request introduces improvements to the test execution process in the CLI by enhancing coverage handling and ensuring better test isolation. It also updates the corresponding test cases to reflect these changes.

### Enhancements to test execution in `src/protean/cli/__init__.py`:
* Added a step to erase existing coverage data (`coverage erase`) before running tests to ensure no mixing of previous runs.
* Updated the `coverage` command to use `--parallel-mode` for all test runs, enabling better handling of parallelized test execution. 

### Improved in `tests/cli/test_test.py` to incorporate above `--parallel-mode` command

This is the image from github workflow

![image](https://github.com/user-attachments/assets/b2c201f4-04f0-4e4d-be42-3ec1715b2df5)

This image is from local testing

![image](https://github.com/user-attachments/assets/c6474792-1fcf-4d07-825d-a11be30abf0b)