### PR TITLE
Add new test category for coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,11 +94,6 @@ jobs:
           REDIS_HOST: localhost
           REDIS_PORT: ${{ job.services.redis.ports[6379] }}
 
-      - name: Generate Coverage XML
-        run: |
-          coverage combine
-          coverage xml
-
       - name: CodeCOV
         uses: codecov/codecov-action@v5.4.2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,9 +94,15 @@ jobs:
           REDIS_HOST: localhost
           REDIS_PORT: ${{ job.services.redis.ports[6379] }}
 
+      - name: Generate Coverage XML
+        run: |
+          coverage combine
+          coverage xml
+
       - name: CodeCOV
         uses: codecov/codecov-action@v5.4.2
         with:
+          files: coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
 
   docs-deploy:

--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,7 @@ output/*/index.html
 *.bak
 .testmondata
 *.rdb
+diff_coverage_report.html
 
 # TODOs
 TODO

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,10 @@ html:
 	@cd docs-sphinx; $(MAKE) html
 
 test-full: up
-	protean test
+	protean test -c FULL
+
+test-coverage: up
+	protean test -c COVERAGE
 
 cov: up
 	pytest --slow --sqlite --postgresql --elasticsearch --redis --message_db --cov=protean --cov-config .coveragerc tests

--- a/poetry.lock
+++ b/poetry.lock
@@ -261,6 +261,18 @@ files = [
 ]
 
 [[package]]
+name = "chardet"
+version = "5.2.0"
+description = "Universal encoding detector for Python 3"
+optional = false
+python-versions = ">=3.7"
+groups = ["test"]
+files = [
+    {file = "chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970"},
+    {file = "chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7"},
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.3.2"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
@@ -590,6 +602,27 @@ files = [
 ]
 
 [[package]]
+name = "diff-cover"
+version = "9.2.4"
+description = "Run coverage and linting reports on diffs"
+optional = false
+python-versions = "<4.0.0,>=3.9.17"
+groups = ["test"]
+files = [
+    {file = "diff_cover-9.2.4-py3-none-any.whl", hash = "sha256:c68b34e368b13888cb04a14aeb509821aab594c171a621e8bd3248435c9dd0c9"},
+    {file = "diff_cover-9.2.4.tar.gz", hash = "sha256:6ea44711f09199a1b8bcaa2eae002e1f337dd22f2d798fcfd62a6a1554bb2a86"},
+]
+
+[package.dependencies]
+chardet = ">=3.0.0"
+Jinja2 = ">=2.7.1"
+pluggy = ">=0.13.1,<2"
+Pygments = ">=2.19.1,<3.0.0"
+
+[package.extras]
+toml = ["tomli (>=1.2.1)"]
+
+[[package]]
 name = "distlib"
 version = "0.3.8"
 description = "Distribution utilities"
@@ -860,6 +893,7 @@ files = [
     {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
     {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
 ]
+markers = {main = "extra == \"fastapi\""}
 
 [[package]]
 name = "httpcore"
@@ -1125,7 +1159,7 @@ version = "3.1.6"
 description = "A very fast and expressive template engine."
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "docs"]
+groups = ["main", "docs", "test"]
 files = [
     {file = "jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"},
     {file = "jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d"},
@@ -1228,7 +1262,7 @@ version = "2.1.5"
 description = "Safely add untrusted strings to HTML/XML markup."
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "docs"]
+groups = ["main", "docs", "test"]
 files = [
     {file = "MarkupSafe-2.1.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a17a92de5231666cfbe003f0e4b9b3a7ae3afb1ec2845aadc2bacc93ff85febc"},
     {file = "MarkupSafe-2.1.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:72b6be590cc35924b02c78ef34b467da4ba07e4e0f0454a2c5907f473fc50ce5"},
@@ -1958,18 +1992,17 @@ typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
 name = "pygments"
-version = "2.17.2"
+version = "2.19.1"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
-python-versions = ">=3.7"
-groups = ["main", "dev", "docs"]
+python-versions = ">=3.8"
+groups = ["main", "dev", "docs", "test"]
 files = [
-    {file = "pygments-2.17.2-py3-none-any.whl", hash = "sha256:b27c2826c47d0f3219f29554824c30c5e8945175d888647acd804ddd04af846c"},
-    {file = "pygments-2.17.2.tar.gz", hash = "sha256:da46cec9fd2de5be3a8a784f434e4c4ab670b4ff54d605c4c2717e9d49c4c367"},
+    {file = "pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c"},
+    {file = "pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f"},
 ]
 
 [package.extras]
-plugins = ["importlib-metadata ; python_version < \"3.8\""]
 windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
@@ -2934,4 +2967,4 @@ sqlite = ["sqlalchemy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "31e4f57cd76c29286adef39252e6b152e73de4e968fef787259347b06eb5c08c"
+content-hash = "59106042aaca0ee0ef93052fe6f281163db924bea52e281526d342100eb81293"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ twine = ">=4.0.2"
 optional = true
 
 [tool.poetry.group.test.dependencies]
+diff-cover = ">=9.2.4"
 mock = "5.2.0"
 pytest-asyncio = ">=0.21.1"
 pytest-mock = "3.14.0"
@@ -183,7 +184,7 @@ source = [
 [tool.coverage.run]
 branch = true
 parallel = true
-source = ["protean", "src/protean"]
+source = ["src/protean"]
 omit = [
     "*/__main__.py",
     "src/protean/utils/inflection.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,7 @@ known-first-party = ["protean"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 testpaths = ["tests"]
 filterwarnings = [
     "ignore::sqlalchemy.exc.SAWarning",

--- a/src/protean/cli/test.py
+++ b/src/protean/cli/test.py
@@ -67,7 +67,7 @@ def _run(cmd: list[str]) -> int:
 
 
 def _inject_style(path: Path, style_block: str = STYLE_BLOCK) -> None:
-    """Insert the Source Sans Pro font + style block before </head>."""
+    """Insert the style block before </head>."""
     with suppress(FileNotFoundError):
         html = path.read_text(encoding="utf-8")
         if "</head>" in html and style_block not in html:
@@ -165,7 +165,7 @@ def test(
             rc = run_full(subprocess, coverage_command, pytest_command)
 
             # ------------------------------------------------------------------
-            # ✅ Only generate & style diff-cover report if *everything* passed
+            # Only generate & style diff-cover report if *everything* passed
             # ------------------------------------------------------------------
             if rc == 0:
                 rc |= _run(
@@ -177,7 +177,7 @@ def test(
                         REPORT_PATH.name,
                     ]
                 )
-                _inject_style(REPORT_PATH)  # 👈 inject Source Sans Pro
+                _inject_style(REPORT_PATH)
                 _run(["open", REPORT_PATH.name])
             else:
                 print("\n❌ Tests failed – skipping diff-cover report.")

--- a/src/protean/cli/test.py
+++ b/src/protean/cli/test.py
@@ -1,4 +1,5 @@
 import subprocess
+import webbrowser
 from contextlib import suppress
 from enum import Enum
 from pathlib import Path
@@ -178,7 +179,7 @@ def test(
                     ]
                 )
                 _inject_style(REPORT_PATH)
-                _run(["open", REPORT_PATH.name])
+                webbrowser.open(REPORT_PATH.name)
             else:
                 print("\n❌ Tests failed – skipping diff-cover report.")
         case _:

--- a/src/protean/cli/test.py
+++ b/src/protean/cli/test.py
@@ -1,0 +1,190 @@
+import subprocess
+from contextlib import suppress
+from enum import Enum
+from pathlib import Path
+
+import typer
+from typing_extensions import Annotated
+
+REPORT_PATH = Path("diff_coverage_report.html")
+GOOGLE_FONT = "https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@300;400;600&display=swap"
+STYLE_BLOCK = f"""
+<!-- Injected by protean CLI -->
+<link href="{GOOGLE_FONT}" rel="stylesheet">
+<style>
+    body {{
+        font-family: "Source Sans Pro", sans-serif;
+        margin: 20px;
+        background-color: #f8f9fa;
+    }}
+    table {{
+        border-collapse: collapse;
+        width: 100%;
+        background: #fff;
+        box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    }}
+    th, td {{
+        padding: 12px 15px;
+        border: 1px solid #dee2e6;
+        text-align: left;
+    }}
+    th {{
+        background-color: #343a40;
+        color: white;
+    }}
+    tr:nth-child(even) {{
+        background-color: #f2f2f2;
+    }}
+    .low-coverage {{
+        color: red;
+        font-weight: bold;
+    }}
+    .high-coverage {{
+        color: green;
+        font-weight: bold;
+    }}
+</style>
+"""
+
+
+class TestCategory(str, Enum):
+    CORE = "CORE"
+    EVENTSTORE = "EVENTSTORE"
+    DATABASE = "DATABASE"
+    COVERAGE = "COVERAGE"
+    FULL = "FULL"
+
+
+app = typer.Typer()
+
+
+# ------------------------------------------------------------------------ #
+# Helpers
+# ------------------------------------------------------------------------ #
+def _run(cmd: list[str]) -> int:
+    """Run a command, streaming output, and return its exit code."""
+    return subprocess.call(cmd)
+
+
+def _inject_style(path: Path, style_block: str = STYLE_BLOCK) -> None:
+    """Insert the Source Sans Pro font + style block before </head>."""
+    with suppress(FileNotFoundError):
+        html = path.read_text(encoding="utf-8")
+        if "</head>" in html and style_block not in html:
+            html = html.replace("</head>", f"{style_block}\n</head>")
+            path.write_text(html, encoding="utf-8")
+
+
+# ------------------------------------------------------------------------ #
+# Existing helpers (only small change: return accumulated status)
+# ------------------------------------------------------------------------ #
+def run_full(subprocess, coverage_command, pytest_command) -> int:
+    """Run all test combos under coverage.
+    Returns the _highest_ exit code seen (0 == success)."""
+    exit_status = 0  # 0 means success so far
+
+    def track(rc: int) -> None:
+        nonlocal exit_status
+        exit_status |= rc  # keep the highest non-zero code
+
+    # fresh slate
+    track(_run(["coverage", "erase"]))
+
+    # full matrix
+    track(
+        _run(
+            coverage_command
+            + pytest_command
+            + [
+                "--slow",
+                "--sqlite",
+                "--postgresql",
+                "--elasticsearch",
+                "--redis",
+                "--message_db",
+                "tests",
+            ]
+        )
+    )
+
+    # database permutations
+    for db in ["MEMORY", "POSTGRESQL", "SQLITE"]:
+        print(f"Running tests for DB: {db}…")
+        track(
+            _run(coverage_command + pytest_command + ["-m", "database", f"--db={db}"])
+        )
+
+    # event-store permutations
+    for store in ["MESSAGE_DB"]:
+        print(f"Running tests for EVENTSTORE: {store}…")
+        track(
+            _run(
+                coverage_command
+                + pytest_command
+                + ["-m", "eventstore", f"--store={store}"]
+            )
+        )
+
+    # gather coverage
+    if exit_status == 0:  # only combine if all tests passed
+        print("\nCombining coverage data and generating report…")
+        track(_run(["coverage", "combine"]))
+        track(_run(["coverage", "xml"]))
+        track(_run(["coverage", "report"]))
+    else:
+        print("\n❌ Skipping coverage combine – some tests failed.")
+
+    return exit_status
+
+
+@app.callback(invoke_without_command=True)
+def test(
+    category: Annotated[
+        TestCategory, typer.Option("-c", "--category", case_sensitive=False)
+    ] = TestCategory.CORE,
+):
+    coverage_command = ["coverage", "run", "--parallel-mode", "-m"]
+    pytest_command = ["pytest", "--cache-clear", "--ignore=tests/support/"]
+
+    # Each branch now captures exit code and, in COVERAGE mode,
+    # decides whether to post-process coverage.
+    match category.value:
+        case "EVENTSTORE":
+            rc = 0
+            for store in ["MEMORY", "MESSAGE_DB"]:
+                print(f"Running tests for EVENTSTORE: {store}…")
+                rc |= _run(pytest_command + ["-m", "eventstore", f"--store={store}"])
+        case "DATABASE":
+            rc = 0
+            for db in ["MEMORY", "POSTGRESQL", "SQLITE"]:
+                print(f"Running tests for DATABASE: {db}…")
+                rc |= _run(pytest_command + ["-m", "database", f"--db={db}"])
+        case "FULL":
+            rc = run_full(subprocess, coverage_command, pytest_command)
+        case "COVERAGE":
+            rc = run_full(subprocess, coverage_command, pytest_command)
+
+            # ------------------------------------------------------------------
+            # ✅ Only generate & style diff-cover report if *everything* passed
+            # ------------------------------------------------------------------
+            if rc == 0:
+                rc |= _run(
+                    [
+                        "diff-cover",
+                        "coverage.xml",
+                        "--compare-branch=main",
+                        "--html-report",
+                        REPORT_PATH.name,
+                    ]
+                )
+                _inject_style(REPORT_PATH)  # 👈 inject Source Sans Pro
+                _run(["open", REPORT_PATH.name])
+            else:
+                print("\n❌ Tests failed – skipping diff-cover report.")
+        case _:
+            print("Running core tests…")
+            rc = _run(pytest_command)
+
+    # Exit Typer CLI with the highest non-zero status we saw
+    if rc != 0:
+        raise typer.Exit(code=rc)

--- a/tests/adapters/repository/sqlalchemy_repo/test_provider_create_drop_tables.py
+++ b/tests/adapters/repository/sqlalchemy_repo/test_provider_create_drop_tables.py
@@ -26,6 +26,8 @@ def test_create_database_artifacts_creates_tables(
     # Setup
     provider.domain = test_domain
     mock_engine = Mock()
+    mock_connection = Mock()
+    mock_engine.connect.return_value = mock_connection
     mock_create_engine.return_value = mock_engine
     provider._engine = mock_engine
 
@@ -36,8 +38,12 @@ def test_create_database_artifacts_creates_tables(
     provider._create_database_artifacts()
 
     # Assert
-    # Verify metadata.create_all was called with engine
-    provider._metadata.create_all.assert_called_with(mock_engine)
+    # Verify engine.connect was called
+    mock_engine.connect.assert_called()
+    # Verify metadata.create_all was called with connection
+    provider._metadata.create_all.assert_called_with(mock_connection)
+    # Verify connection.close was called
+    mock_connection.close.assert_called()
 
 
 @patch("protean.adapters.repository.sqlalchemy.create_engine")
@@ -47,6 +53,8 @@ def test_drop_database_artifacts_drops_tables(
     # Setup
     provider.domain = test_domain
     mock_engine = Mock()
+    mock_connection = Mock()
+    mock_engine.connect.return_value = mock_connection
     mock_create_engine.return_value = mock_engine
     provider._engine = mock_engine
 
@@ -57,7 +65,11 @@ def test_drop_database_artifacts_drops_tables(
     provider._drop_database_artifacts()
 
     # Assert
-    # Verify metadata.drop_all was called with engine
-    provider._metadata.drop_all.assert_called_with(mock_engine)
+    # Verify engine.connect was called
+    mock_engine.connect.assert_called()
+    # Verify metadata.drop_all was called with connection
+    provider._metadata.drop_all.assert_called_with(mock_connection)
+    # Verify connection.close was called
+    mock_connection.close.assert_called()
     # Verify metadata was cleared
     provider._metadata.clear.assert_called()

--- a/tests/cli/test_test.py
+++ b/tests/cli/test_test.py
@@ -1,6 +1,8 @@
+import subprocess
 from unittest.mock import call
 
 import pytest
+import typer
 from typer.testing import CliRunner
 
 from protean.cli import app
@@ -299,3 +301,221 @@ def test_invalid_category(mock_subprocess_call):
         str(result.exception)
         == "'INVALID' is not one of 'CORE', 'EVENTSTORE', 'DATABASE', 'COVERAGE', 'FULL'."
     )
+
+
+class TestInjectStyle:
+    def test_inject_style_success(self, tmp_path):
+        """Test successful style injection into HTML file."""
+        from protean.cli.test import STYLE_BLOCK, _inject_style
+
+        # Create a test HTML file with a head section
+        test_html = tmp_path / "test.html"
+        test_html.write_text("<html><head></head><body>content</body></html>")
+
+        # Call the function
+        _inject_style(test_html)
+
+        # Verify the style was injected
+        content = test_html.read_text()
+        assert STYLE_BLOCK in content
+        assert content.find(STYLE_BLOCK) < content.find("</head>")
+        assert content.endswith("<body>content</body></html>")
+
+    def test_inject_style_already_injected(self, tmp_path):
+        """Test injection when style is already present."""
+        from protean.cli.test import STYLE_BLOCK, _inject_style
+
+        # Create a test HTML file that already has the style block
+        test_html = tmp_path / "test.html"
+        test_html.write_text(
+            f"<html><head>{STYLE_BLOCK}</head><body>content</body></html>"
+        )
+
+        # Get the original content for comparison
+        original_content = test_html.read_text()
+
+        # Call the function
+        _inject_style(test_html)
+
+        # Verify the file wasn't modified
+        assert test_html.read_text() == original_content
+
+    def test_inject_style_no_head(self, tmp_path):
+        """Test injection with no </head> tag."""
+        from protean.cli.test import _inject_style
+
+        # Create a test HTML file without a head closing tag
+        test_html = tmp_path / "test.html"
+        test_html.write_text("<html><body>content</body></html>")
+
+        # Get the original content for comparison
+        original_content = test_html.read_text()
+
+        # Call the function
+        _inject_style(test_html)
+
+        # Verify the file wasn't modified
+        assert test_html.read_text() == original_content
+
+    def test_inject_style_file_not_found(self):
+        """Test injection when file doesn't exist."""
+        from pathlib import Path
+
+        from protean.cli.test import _inject_style
+
+        # Try to inject into a non-existent file
+        nonexistent_file = Path("nonexistent_file.html")
+
+        # This should not raise an exception due to suppress(FileNotFoundError)
+        _inject_style(nonexistent_file)
+
+    def test_inject_style_custom_block(self, tmp_path):
+        """Test injection with a custom style block."""
+        from protean.cli.test import _inject_style
+
+        # Create a test HTML file
+        test_html = tmp_path / "test.html"
+        test_html.write_text("<html><head></head><body>content</body></html>")
+
+        # Custom style block
+        custom_style = "<style>body { color: blue; }</style>"
+
+        # Call the function with custom style
+        _inject_style(test_html, custom_style)
+
+        # Verify the custom style was injected
+        content = test_html.read_text()
+        assert custom_style in content
+        assert content.find(custom_style) < content.find("</head>")
+
+
+class TestRunFull:
+    def test_run_full_success(self, mock_subprocess_call):
+        """Test run_full with all tests passing (line 135 where exit_status == 0)."""
+        from protean.cli.test import run_full
+
+        # Configure the mock to indicate all commands succeeded
+        mock_subprocess_call.return_value = 0
+
+        # Run the function
+        exit_status = run_full(
+            subprocess,
+            ["coverage", "run", "--parallel-mode", "-m"],
+            ["pytest", "--cache-clear", "--ignore=tests/support/"],
+        )
+
+        # Verify all expected commands were called
+        assert mock_subprocess_call.call_count == 9
+        assert exit_status == 0
+
+        # Verify coverage combine commands were called (happens when exit_status == 0)
+        mock_subprocess_call.assert_any_call(["coverage", "combine"])
+        mock_subprocess_call.assert_any_call(["coverage", "xml"])
+        mock_subprocess_call.assert_any_call(["coverage", "report"])
+
+    def test_run_full_with_failures(self, mock_subprocess_call):
+        """Test run_full with some tests failing (line 135 where exit_status != 0)."""
+        from protean.cli.test import run_full
+
+        # Configure the mock to indicate some commands failed
+        # First call (erase) succeeds, second call (full test run) fails
+        mock_subprocess_call.side_effect = [0, 1] + [0] * 10
+
+        # Run the function
+        exit_status = run_full(
+            subprocess,
+            ["coverage", "run", "--parallel-mode", "-m"],
+            ["pytest", "--cache-clear", "--ignore=tests/support/"],
+        )
+
+        # Verify the function returned non-zero exit status
+        assert exit_status != 0
+
+        # Verify coverage combine commands were NOT called
+        # (this is the branch we want to test, when failures occur)
+        for cmd in [
+            ["coverage", "combine"],
+            ["coverage", "xml"],
+            ["coverage", "report"],
+        ]:
+            assert call(cmd) not in mock_subprocess_call.call_args_list
+
+
+class TestExitHandling:
+    def test_category_coverage_success(self, mock_subprocess_call, monkeypatch):
+        """Test COVERAGE category with success (line 183 where rc == 0)."""
+        from protean.cli.test import REPORT_PATH
+
+        # Setup mocks
+        mock_subprocess_call.return_value = 0
+
+        # Mock _inject_style to avoid file operations
+        monkeypatch.setattr("protean.cli.test._inject_style", lambda *args: None)
+
+        # Run the test command with COVERAGE category
+        result = runner.invoke(
+            app, ["test", "--category", "COVERAGE"], standalone_mode=False
+        )
+
+        # Verify exit code is 0
+        assert result.exit_code == 0
+
+        # Verify diff-cover was called and report was opened
+        mock_subprocess_call.assert_any_call(
+            [
+                "diff-cover",
+                "coverage.xml",
+                "--compare-branch=main",
+                "--html-report",
+                REPORT_PATH.name,
+            ]
+        )
+        mock_subprocess_call.assert_any_call(["open", REPORT_PATH.name])
+
+    def test_category_coverage_with_failure(self, mock_subprocess_call, monkeypatch):
+        """Test COVERAGE category with failure (line 183 where rc != 0)."""
+        from protean.cli.test import test
+
+        # Setup mocks to simulate a test failure in run_full
+        # We need to control what run_full returns
+        def mock_run_full(*args, **kwargs):
+            return 1  # Return non-zero to simulate failure
+
+        monkeypatch.setattr("protean.cli.test.run_full", mock_run_full)
+
+        # Mock the print function to capture output
+        printed_messages = []
+        monkeypatch.setattr(
+            "builtins.print",
+            lambda *args: printed_messages.append(" ".join(str(a) for a in args)),
+        )
+
+        # Running with failures should raise typer.Exit
+        with pytest.raises(typer.Exit) as excinfo:
+            test(category=TestCategory.COVERAGE)
+
+        # Verify exit code is non-zero (line 190)
+        assert excinfo.value.exit_code != 0
+
+        # Check if the error message was printed
+        assert "❌ Tests failed – skipping diff-cover report." in " ".join(
+            printed_messages
+        )
+
+    def test_exit_with_error_code(self, mock_subprocess_call, monkeypatch):
+        """Test exiting with non-zero status (line 190)."""
+
+        # Configure subprocess.call to return non-zero to trigger the exception
+        def mock_run(*args):
+            return 1  # Return error code
+
+        monkeypatch.setattr("protean.cli.test._run", mock_run)
+
+        # This should raise typer.Exit with code=1
+        with pytest.raises(typer.Exit) as excinfo:
+            from protean.cli.test import test
+
+            test(category=TestCategory.CORE)
+
+        # Verify the exit code matches what the subprocess returned
+        assert excinfo.value.exit_code == 1

--- a/tests/server2/test_cli_command.py
+++ b/tests/server2/test_cli_command.py
@@ -36,7 +36,6 @@ class TestServerCliCommand:
         result = runner.invoke(cli_app, ["server2", "--help"])
         assert result.exit_code == 0
         assert "Run the FastAPI server for Protean applications" in result.stdout
-        assert "--cors-origins" in result.stdout
 
     @pytest.mark.fastapi
     @patch("protean.cli.server2.ProteanFastAPIServer")
@@ -187,6 +186,6 @@ class TestServerCliCommand:
         # Verify error handling
         assert result.exit_code != 0
         assert (
-            "Error loading Protean domain: Could not import 'nonexistent'.\nAborted.\n"
+            "Error loading Protean domain: Could not import 'nonexistent'"
             in result.stdout
         )


### PR DESCRIPTION
- Introduced a new COVERAGE category in the CLI to run tests with coverage.
- Added functionality to generate a diff coverage report using `diff-cover` after running tests.
- Updated the Makefile to include a new `test-coverage` target.
- Modified the CI workflow to generate coverage XML and include it in the Codecov upload.
- Updated dependencies in `pyproject.toml` and `poetry.lock` to include `diff-cover`
- Enhanced the `.gitignore` to exclude the generated coverage report file.
- Show HTML coverage report under COVERAGE command

Fixes #512 