### PR TITLE
Command handlers can optionally return value

### DIFF
--- a/docs/community/contributing/testing.md
+++ b/docs/community/contributing/testing.md
@@ -8,7 +8,7 @@ Protean uses `pytest` as the testing tool, because it allows for simple unit tes
 
 Protean provides a built-in command for running tests:
 
-```
+```shell
 protean test [OPTIONS]
 ```
 
@@ -21,15 +21,16 @@ Categories:
 - `CORE`: Runs core tests without external dependencies (default)
 - `EVENTSTORE`: Runs tests for all configured event store adapters
 - `DATABASE`: Runs tests for all configured database adapters
-- `FULL`: Runs the complete test suite with coverage
+- `FULL`: Runs the complete test suite for all adapters
+- `COVERAGE`: Runs the complete test suite with all adapters and generates coverage report
 
 Example:
-```
+
+```shell
 protean test -c DATABASE
 ```
 
 > **Note**: Ensure that the underlying database services are running within Docker before executing tests in the `DATABASE`, `EVENTSTORE`, or `FULL` categories. Use the `make up` command to start the necessary services.
-
 
 This will run database tests against multiple adapters (MEMORY, POSTGRESQL, SQLITE).
 
@@ -59,6 +60,7 @@ services:
 ```
 
 The development environment includes:
+
 - PostgreSQL for relational database testing
 - Elasticsearch for document store testing
 - Redis for caching and simple key-value storage
@@ -66,7 +68,7 @@ The development environment includes:
 
 To start the development environment, Protean provides easy `make` commands:
 
-```
+```shell
 make up
 ```
 
@@ -114,6 +116,7 @@ provider = "memory"
 ```
 
 This configuration establishes a consistent testing environment, setting key parameters like:
+
 - Enabling debug and test modes
 - Setting up default database providers (memory and SQLite)
 - Configuring default brokers and caches
@@ -137,11 +140,13 @@ The Protean test suite is organized into specialized directories matching the fr
 - Integration tests that span multiple components are organized by functionality
 
 Within each core element's test directory, the tests are further divided:
+
 - Each aspect of functionality is tested separately
 - Complex components are tested in dedicated files for better organization
 - Tests progressively build complexity, starting with simple unit tests and progressing to more complex integration scenarios
 
 For example, in the `tests/domain/` directory, different aspects of domain functionality are split into individual files:
+
 - `test_domain_config.py`
 - `test_domain_traversal.py`
 - `test_domain_shell_context.py`
@@ -187,6 +192,7 @@ The `test_domain` fixture creates a fresh Protean domain for each test. It:
 - Is automatically used in all tests unless the `no_test_domain` marker is applied
 
 Example usage:
+
 ```python
 def test_domain_initialization(test_domain):
     assert test_domain.name == "Test"
@@ -248,15 +254,17 @@ The `store_config` fixture does the same for event stores:
 
 ## Code Coverage
 
-<!-- Talk about coveragepy and its options in use (like coverage combine) -->
-
 Protean uses Coverage.py to track test coverage. `coverage` configuration is maintained in `pyproject.toml`.
 
-When running the full test suite with `protean test -c FULL`, coverage data is automatically collected and combined:
+When running the full test suite with `protean test -c FULL`, coverage data is automatically collected and combined from tests across multiple adapters:
 
 1. Each test run generates a `.coverage` file
 2. The `coverage combine` command merges these files
 3. The `coverage report` command generates a summary
+
+You can also view coverage diffs and look for lines missing coverage with the `protean test -c COVERAGE`. The command generates an HTML report that visually represents the coverage data, making it easy to identify untested code paths.
+
+It compares the current branch's coverage against the main branch to highlight changes in coverage, which is especially useful for pull request reviews. Unless tests completely cover all changes, CodeCov will fail the PR.
 
 ### Constraints
 
@@ -267,11 +275,13 @@ Protean enforces coverage constraints to ensure code quality:
 - Coverage is checked as part of the CI pipeline
 
 If a PR introduces code that lacks sufficient test coverage:
+
 1. The CI pipeline will fail
 2. A coverage report will show which lines need tests
 3. The PR author should add tests to cover the new code
 
 To avoid coverage failures:
+
 - Write tests alongside new code
 - Test all code paths, including error cases
 - Use pytest parametrization to test multiple scenarios efficiently
@@ -303,6 +313,7 @@ jobs:
 ```
 
 The CI pipeline:
+
 - Runs on each pull request and push to main
 - Tests against multiple Python versions (3.11, 3.12, ...)
 - Sets up all required services (PostgreSQL, Redis, Elasticsearch, Message-DB, ...)
@@ -310,6 +321,7 @@ The CI pipeline:
 - Reports coverage to Codecov
 
 Pull requests cannot be merged until tests pass. This ensures:
+
 - All features work as expected
 - No regressions are introduced
 - Code coverage remains high

--- a/docs/core-concepts/domain-elements/command-handlers.md
+++ b/docs/core-concepts/domain-elements/command-handlers.md
@@ -10,39 +10,60 @@ bridge between the application's API and the domain model.
 ## Facts
 
 ### Command handlers are connected to an aggregate. { data-toc-label="Connected to Aggregate" }
+
 Command handlers are always connected to a single aggregate. One command handler
 per aggregate is the norm, with all aggregate commands handled within it.
 
 ### A Command handler contains multiple handlers. { data-toc-label="Handlers" }
+
 Each method in a command handler is connected to a specific command to handle
 and process.
 
 ### Handlers are single-purpose. { data-toc-label="Single-Purpose" }
+
 Each handler method is responsible for handling a single type of command. This
 ensures that the command handling logic is focused and manageable.
 
 ### Handlers should deal only with the associated aggregate. { data-toc-label="Single Aggregate" }
+
 Methods in a command handler should only deal with managing the lifecycle of
 the aggregate associated with it. Any state change beyong an aggregate's
 boundary should be performed by eventual consistency mechanisms, like raising
 an event and consuming it in the event handler of the other aggregate.
 
 ### Command handlers invoke domain logic. { data-toc-label="Invoke Domain Logic" }
+
 Command handlers do not contain business logic themselves. Instead, they invoke
 methods on aggregates or domain services to perform the necessary actions.
 
 ### Command handlers coordinate actions. { data-toc-label="Coordinate Actions" }
+
 Command handlers coordinate multiple actions related to each command. Primarily,
 this involves hydrating (fetching) the aggregate, invoking methods to perform
 state changes and persisting changes through a repository.
 
+### Command handlers can return values. { data-toc-label="Return Values" }
+
+When processed synchronously, command handlers can return values to the caller. This
+is useful for scenarios like authentication where you need to return a token, or when
+you need to return the ID of a newly created resource.
+
+Unlike event handlers (which can have multiple handlers for a single event and don't return values), 
+a command can only be handled by a single handler, allowing the return value to be passed back to the caller.
+This is consistent with the command pattern, where a command represents an intent to perform an action
+and may need to provide immediate feedback.
+
+By default, command handlers return the position of the command in the command stream back to the caller.
+
 ### Handler methdos are enclosed in Unit of Work context. { data-toc-label="Unit of Work"}
+
 Each handler method is automatically enclosed within a Unit of Work context.
 This means that all interactions with the infrastructure is packaged into a
 single transaction. This makes it all the more important to not mix multiple
 responsibilities or aggregates when handling a command.
 
 ### Commands can be handled asynchronously. { data-toc-label="Asynchronous" }
+
 While handling commands synchronously is the norm to preserve data integrity,
 it is possible to configure the domain to handle commands asynchronously for
 performance reasons.
@@ -50,15 +71,25 @@ performance reasons.
 ## Best Practices
 
 ### Ensure idempotency. { data-toc-label="Idempotency" }
+
 Command handling should be idempotent, meaning that handling the same command
 multiple times should not produce unintended side effects. This can be achieved
 by checking the current state before applying changes.
 
 ### Handle exceptions gracefully. { data-toc-label="Exception Handling" }
+
 Command handlers should handle exceptions gracefully, ensuring that any
 necessary rollback actions are performed and that meaningful error messages are
 returned to the caller.
 
 ### Validate commands. { data-toc-label="Validation" }
+
 Ensure that commands are validated before processing. This can be done in a
 separate validation layer or within the command handler itself.
+
+### Return values only when necessary. { data-toc-label="Return Values" }
+
+Only return values from command handlers when they are genuinely needed by the caller. 
+For example, return authentication tokens or newly created resource IDs, but not entire 
+entity representations. Return values should be small and relevant to the immediate needs 
+of the caller.

--- a/src/protean/domain/__init__.py
+++ b/src/protean/domain/__init__.py
@@ -1171,7 +1171,8 @@ class Domain:
         ):
             handler_class = self.command_handler_for(command)
             if handler_class:
-                handler_class._handle(command_with_metadata)
+                result = handler_class._handle(command_with_metadata)
+                return result
 
         return position
 

--- a/src/protean/utils/mixins.py
+++ b/src/protean/utils/mixins.py
@@ -4,13 +4,14 @@ import functools
 import logging
 from collections import defaultdict
 from enum import Enum
-from typing import Callable, Dict, Type, Union
+from typing import Any, Callable, Dict, Type, Union
 
 from protean import fields
 from protean.core.command import BaseCommand
 from protean.core.event import BaseEvent
 from protean.core.unit_of_work import UnitOfWork
 from protean.exceptions import ConfigurationError, InvalidDataError
+from protean.utils import DomainObjects
 from protean.utils.container import BaseContainer, OptionsMixin
 from protean.utils.eventing import Metadata
 from protean.utils.globals import current_domain
@@ -146,7 +147,7 @@ class handle:
         def wrapper(instance, target_obj):
             # Wrap function call within a UoW
             with UnitOfWork():
-                fn(instance, target_obj)
+                return fn(instance, target_obj)
 
         setattr(wrapper, "_target_cls", self._target_cls)
         return wrapper
@@ -168,8 +169,12 @@ class HandlerMixin:
         setattr(subclass, "_handlers", defaultdict(set))
 
     @classmethod
-    def _handle(cls, item: Union[Message, BaseCommand, BaseEvent]) -> None:
-        """Handle a message or command/event."""
+    def _handle(cls, item: Union[Message, BaseCommand, BaseEvent]) -> Any:
+        """Handle a message or command/event.
+
+        Returns:
+            Any: Return value from the handler method (only applicable for command handlers)
+        """
 
         # Convert Message to object if necessary
         item = item.to_object() if isinstance(item, Message) else item
@@ -177,8 +182,18 @@ class HandlerMixin:
         # Use specific handlers if available, or fallback on `$any` if defined
         handlers = cls._handlers[item.__class__.__type__] or cls._handlers["$any"]
 
-        for handler_method in handlers:
-            handler_method(cls(), item)
+        if cls.element_type == DomainObjects.COMMAND_HANDLER:
+            # Command handlers only have one handler method per command
+            if handlers:
+                handler_method = next(iter(handlers))
+                return handler_method(cls(), item)
+        else:
+            # Event handlers can have multiple handlers per event
+            # Execute all handlers but don't return anything
+            for handler_method in handlers:
+                handler_method(cls(), item)
+
+            return None
 
     @classmethod
     def handle_error(cls, exc: Exception, message: Message) -> None:

--- a/tests/command_handler/test_handler_return_behavior.py
+++ b/tests/command_handler/test_handler_return_behavior.py
@@ -1,0 +1,151 @@
+from uuid import uuid4
+
+import pytest
+
+from protean.core.aggregate import BaseAggregate
+from protean.core.command import BaseCommand
+from protean.core.command_handler import BaseCommandHandler
+from protean.core.event import BaseEvent
+from protean.core.event_handler import BaseEventHandler
+from protean.fields import Identifier, String
+from protean.utils import Processing
+from protean.utils.globals import current_domain
+from protean.utils.mixins import handle
+
+# Track invocations for testing
+event_counter1 = 0
+event_counter2 = 0
+
+
+class User(BaseAggregate):
+    user_id = Identifier(identifier=True)
+    name = String()
+
+
+class LoginCommand(BaseCommand):
+    user_id = Identifier()
+    name = String()
+    password = String()
+
+
+class UserRegisteredEvent(BaseEvent):
+    user_id = Identifier()
+    name = String()
+
+
+class UserCommandHandler(BaseCommandHandler):
+    @handle(LoginCommand)
+    def login(self, command):
+        user = User(user_id=command.user_id, name="Test User")
+        user.raise_(UserRegisteredEvent(user_id=command.user_id, name=command.name))
+
+        current_domain.repository_for(User).add(user)
+
+        # Return a value (like a token) that should be passed back when sync processing
+        return {"token": f"token-{command.user_id}"}
+
+
+class UserEventHandler1(BaseEventHandler):
+    @handle(UserRegisteredEvent)
+    def on_user_registered(self, event):
+        global event_counter1
+        event_counter1 += 1
+        # Return a value that should NOT be passed back
+        return "This should be ignored"
+
+
+class UserEventHandler2(BaseEventHandler):
+    @handle(UserRegisteredEvent)
+    def on_user_registered_again(self, event):
+        global event_counter2
+        event_counter2 += 1
+        # Return a value that should NOT be passed back
+        return "This too should be ignored"
+
+
+@pytest.fixture(autouse=True)
+def reset_counters():
+    """Reset all counters before each test."""
+    global event_counter1, event_counter2
+    event_counter1 = 0
+    event_counter2 = 0
+    yield
+
+
+@pytest.fixture(autouse=True)
+def register_elements(test_domain):
+    test_domain.register(User)
+    test_domain.register(LoginCommand, part_of=User)
+    test_domain.register(UserRegisteredEvent, part_of=User)
+    test_domain.register(UserCommandHandler, part_of=User)
+    test_domain.register(UserEventHandler1, part_of=User)
+    test_domain.register(UserEventHandler2, part_of=User)
+    test_domain.init(traverse=False)
+
+
+def test_command_handler_returns_value_when_processed_synchronously(test_domain):
+    """Test that command handlers can return values when processed synchronously."""
+    user_id = str(uuid4())
+
+    # Process command synchronously
+    result = test_domain.process(
+        LoginCommand(user_id=user_id, password="secret"), asynchronous=False
+    )
+
+    # Verify the handler was called
+    retrieved_user = test_domain.repository_for(User).get(user_id)
+    assert retrieved_user is not None
+    assert retrieved_user.user_id == user_id
+
+    # Verify the handler's return value was returned by process
+    assert result == {"token": f"token-{user_id}"}
+
+
+def test_command_handler_returns_position_when_processed_asynchronously(test_domain):
+    """Test that command handlers return None when processed asynchronously."""
+    user_id = str(uuid4())
+
+    test_domain.config["command_processing"] = Processing.ASYNC.value
+
+    result = test_domain.process(
+        LoginCommand(user_id=user_id, password="secret"), asynchronous=True
+    )
+
+    assert result == 0
+
+
+def test_event_handlers_are_all_executed_and_return_nothing(test_domain):
+    """Test that all event handlers for an event are executed and nothing is returned."""
+    user_id = str(uuid4())
+
+    test_domain.config["command_processing"] = Processing.SYNC.value
+    test_domain.config["event_processing"] = Processing.SYNC.value
+
+    # Process command synchronously
+    result = test_domain.process(LoginCommand(user_id=user_id, password="secret"))
+
+    assert result == {"token": f"token-{user_id}"}
+
+    # Verify both handlers were executed synchronously
+    assert event_counter1 == 1
+    assert event_counter2 == 1
+
+
+def test_command_and_event_handling_integration(test_domain):
+    """Test that command handlers return values but event handlers don't in an integration flow."""
+    user_id = str(uuid4())
+
+    test_domain.config["command_processing"] = Processing.SYNC.value
+    test_domain.config["event_processing"] = Processing.ASYNC.value
+
+    # 1. Process command synchronously and get token
+    result = test_domain.process(
+        LoginCommand(user_id=user_id, password="secret"), asynchronous=False
+    )
+
+    # Verify command handler was called and returned the token
+    assert result == {"token": f"token-{user_id}"}
+
+    # Verify both event handlers were not executed
+    assert event_counter1 == 0
+    assert event_counter2 == 0


### PR DESCRIPTION
# Allow Command Handlers to Return Values when Processed Synchronously

## Summary

This PR enables command handlers to return values when processed synchronously, while keeping event handlers functioning as before (executing multiple handlers with no return value). This feature is useful for scenarios like authentication where we need to return tokens, or when creating resources, and we want to return identifiers.

## Changes

1. Modified the `handle` decorator in `mixins.py` to return the result of the wrapped function
2. Updated the `_handle` method in `HandlerMixin` to:
   - Return values from command handlers when processed synchronously
   - Execute all event handlers and return nothing for events
3. Updated the `process` method in `Domain` class to return the handler's result instead of the position when processing synchronously
4. Added tests to verify the expected behavior:
   - Verifying that command handlers return values when processed synchronously
   - Verifying that event handlers execute all handlers and return nothing
   - Testing an integration scenario with both command and event handlers
5. Updated documentation to describe the new behavior and the differences between command and event handlers

## Example Use Case

```python
@domain.command_handler(part_of=Account)
class AccountCommandHandler:
    @handle(AuthenticateCommand)
    def authenticate(self, command: AuthenticateCommand):
        # Handle authentication...
        # Return a token that can be used by the client
        return {"token": generate_token(command.user_id)}

# In application code:
result = domain.process(AuthenticateCommand(username="user", password="pass"), asynchronous=False)
token = result["token"]  # Access the token returned by the command handler
```

## API Changes

The existing API is unchanged except that `domain.process()` will now return the command handler's return value when processing synchronously. When processing asynchronously, it still returns the position as before.

Fixes #460