### PR TITLE
Rename View to Projection

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -140,7 +140,7 @@ Release History
 * Make views stateful to allow persistence and retrieval
 * Auto-generate Event's `message_id`
 * Support pickling of Protean exceptions
-* Bugfix - Fetch view objects instead of simply IDs in `cache.get_all()`
+* Bugfix - Fetch projection objects instead of simply IDs in `cache.get_all()`
 * Bugfix - Generate embedded ValueObject's data properly in `to_dict()`
 * Bugfix - Derive SQLAlchemy field types correctly for embedded value object fields
 

--- a/docs/core-concepts/domain-elements/events.md
+++ b/docs/core-concepts/domain-elements/events.md
@@ -99,7 +99,7 @@ associated with processing entire aggregates.
 
 Delta events are a good choice when composing internal state via Event Sourcing
 or notifying external consumers for choice events, like `LowInventoryAlert`.
-They are also appropriate for composing a custom view of the state based on
+They are also appropriate for composing a custom projection of the state based on
 events (for example in Command Query Resource Separation).
 
 #### Multiple Event Types

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -76,7 +76,7 @@ A unique identifier for an entity or aggregate, ensuring its distinctness within
 A piece of data sent between components, often used for communication and triggering actions in event-driven architectures.
 
 ### Projection
-A read-only view of data that is constructed by processing one or more event streams, used to support query operations.
+A read-only projection of data that is constructed by processing one or more event streams, used to support query operations.
 
 ### Repository
 A mechanism for encapsulating storage, retrieval, and search behavior for aggregates or entities, typically abstracting the underlying data store.

--- a/docs/guides/compose-a-domain/element-decorators.md
+++ b/docs/guides/compose-a-domain/element-decorators.md
@@ -103,11 +103,11 @@ Read more at Models.
 <!-- FIXME Add link-->
 Read more at Repositories.
 
-## `Domain.view`
+## `Domain.projection`
 
 ```python hl_lines="20-24"
 {! docs_src/guides/composing-a-domain/013.py !}
 ```
 
 <!-- FIXME Add link-->
-Read more at Views.
+Read more at Projections.

--- a/docs/guides/consume-state/projections.md
+++ b/docs/guides/consume-state/projections.md
@@ -1,53 +1,53 @@
-# Views
+# Projections
 
-Views, a.k.a Read models, are representations of data optimized for querying
+Projections, a.k.a Read models, are representations of data optimized for querying
 and reading purposes. It is designed to provide data in a format that makes it
 easy and efficient to read, often tailored to the specific needs of a
 particular view or user interface.
 
-Views are typically populated in response to Domain Events raised in the
+Projections are typically populated in response to Domain Events raised in the
 domain model.
 
-## Defining a View
+## Defining a Projection
 
-Views are defined with the `Domain.view` decorator.
+Projections are defined with the `Domain.projection` decorator.
 
 ```python hl_lines="15-19"
 --8<-- "guides/consume-state/002.py:68:74"
 ```
 
-## View Configuration Options
+## Projection Configuration Options
 
-Views in Protean can be configured with several options passed directly to the view decorator:
+Projections in Protean can be configured with several options passed directly to the projection decorator:
 
 ```python
-@domain.view(
+@domain.projection(
     provider="postgres",      # Database provider to use
     schema_name="product_inventory",  # Custom schema/table name
     limit=50                  # Default limit for queries
 )
 class ProductInventory:
-    # View fields and methods
+    # Projection fields and methods
     pass
 ```
 
 ### Storage Options
 
-Views can be stored in either a database or a cache, but not both simultaneously:
+Projections can be stored in either a database or a cache, but not both simultaneously:
 
 - **Database Storage**: Use the `provider` parameter to specify which database provider to use.
   ```python
-  @domain.view(provider="postgres")  # Connect to a PostgreSQL database
+  @domain.projection(provider="postgres")  # Connect to a PostgreSQL database
   class ProductInventory:
-      # View fields and methods
+      # Projection fields and methods
       pass
   ```
 
 - **Cache Storage**: Use the `cache` parameter to specify which cache provider to use.
   ```python
-  @domain.view(cache="redis")  # Store view data in Redis cache
+  @domain.projection(cache="redis")  # Store projection data in Redis cache
   class ProductInventory:
-      # View fields and methods
+      # Projection fields and methods
       pass
   ```
 
@@ -56,30 +56,30 @@ and the `provider` parameter is ignored.
 
 ### Additional Options
 
-All options are passed directly to the view decorator:
+All options are passed directly to the projection decorator:
 
 ```python
-@domain.view(
-    abstract=False,          # If True, indicates this view is an abstract base class
+@domain.projection(
+    abstract=False,          # If True, indicates this projection is an abstract base class
     database_model="custom_model",    # Custom model name for storage
     order_by=("name",),      # Default ordering for query results
     schema_name="inventory", # Custom schema/table name
     limit=100                # Default query result limit (set to None for no limit)
 )
 class ProductInventory:
-    # View fields and methods
+    # Projection fields and methods
     pass
 ```
 
-## Querying Views
+## Querying Projections
 
-Views are optimized for querying. You can use the repository pattern to query views:
+Projections are optimized for querying. You can use the repository pattern to query projections:
 
 ```python
-# Get a single view record by ID
+# Get a single projection record by ID
 inventory = repository.get(ProductInventory, id=1)
 
-# Query view with filters
+# Query projection with filters
 low_stock_items = repository._dao.filter(
     ProductInventory, 
     quantity__lt=10,
@@ -87,15 +87,15 @@ low_stock_items = repository._dao.filter(
 )
 ```
 
-## View Projection Strategies
+## Projection Projection Strategies
 
-There are different strategies for keeping views up-to-date with your domain model:
+There are different strategies for keeping projections up-to-date with your domain model:
 
-1. **Event-driven**: Respond to domain events to update views (recommended)
-2. **Periodic Refresh**: Schedule periodic rebuilding of views from source data
-3. **On-demand Calculation**: Generate views when they are requested 
+1. **Event-driven**: Respond to domain events to update projections (recommended)
+2. **Periodic Refresh**: Schedule periodic rebuilding of projections from source data
+3. **On-demand Calculation**: Generate projections when they are requested 
 
-The event-driven approach is usually preferred as it ensures views are updated in near real-time.
+The event-driven approach is usually preferred as it ensures projections are updated in near real-time.
 
 ## Workflow
 
@@ -115,7 +115,7 @@ sequenceDiagram
   Repository->>Broker: Publish events
 ```
 
-The events are then consumed by the event handler that loads the view record
+The events are then consumed by the event handler that loads the projection record
 and updates it.
 
 ```mermaid
@@ -131,13 +131,13 @@ sequenceDiagram
 
 ## Supported Field Types
 
-Views can only contain basic field types. References, Associations, and ValueObjects 
-are not supported in views. This is because views are designed to be flattened, 
+Projections can only contain basic field types. References, Associations, and ValueObjects 
+are not supported in projections. This is because projections are designed to be flattened, 
 denormalized representations of data.
 
 ## Example
 
-Below is a full-blown example of a view `ProductInventory` synced with the
+Below is a full-blown example of a projection `ProductInventory` synced with the
 `Product` aggregate with the help of `ProductAdded` and `StockAdjusted` domain
 events.
 

--- a/docs_src/guides/composing-a-domain/013.py
+++ b/docs_src/guides/composing-a-domain/013.py
@@ -17,7 +17,7 @@ class Credentials:
     password_hash = String(max_length=128)
 
 
-@domain.view(part_of=User)
+@domain.projection(part_of=User)
 class Token:
     key = Identifier(identifier=True)
     id = Identifier(required=True)

--- a/docs_src/guides/consume-state/002.py
+++ b/docs_src/guides/consume-state/002.py
@@ -65,7 +65,7 @@ class StockAdjusted:
     new_stock_quantity = Integer(required=True)
 
 
-@domain.view
+@domain.projection
 class ProductInventory:
     product_id = Identifier(identifier=True, required=True)
     name = String(max_length=100, required=True)
@@ -148,7 +148,7 @@ with domain.domain_context():
     )
     domain.process(command)
 
-    # Confirm that Inventory View has the correct stock quantity
+    # Confirm that Inventory Projection has the correct stock quantity
     repository = domain.repository_for(ProductInventory)
     inventory_record = repository.get(command.product_id)
     assert inventory_record.stock_quantity == 100
@@ -157,6 +157,6 @@ with domain.domain_context():
     adjust_command = AdjustStock(product_id=command.product_id, quantity=-50)
     domain.process(adjust_command)
 
-    # Confirm that Inventory View has the correct stock quantity
+    # Confirm that Inventory Projection has the correct stock quantity
     inventory_record = repository.get(command.product_id)
     assert inventory_record.stock_quantity == 50

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -128,7 +128,7 @@ nav:
       - Consume State Changes:
         - guides/consume-state/index.md
         - guides/consume-state/event-handlers.md
-        - guides/consume-state/views.md
+        - guides/consume-state/projections.md
 
     #   - guides/consume-state/events-across-contexts.md
     # - Application Layer:
@@ -138,7 +138,7 @@ nav:
     # - Infrastructure:
     #   - guides/app-layer/index.md (ports-and-adapters)
     #   - guides/app-layer/persisting-data.md (unit-of-work)
-    #   - guides/app-layer/views.md
+    #   - guides/app-layer/projections.md
     #   - guides/app-layer/providers.md
     #   - guides/app-layer/models.md
     #   - guides/app-layer/brokers.md
@@ -221,7 +221,7 @@ nav:
     #   - core-concepts/domain-elements/event-handlers.md
     #   - core-concepts/domain-elements/repositories.md
     #   - core-concepts/domain-elements/models.md
-    #   - core-concepts/domain-elements/view-models.md
+    #   - core-concepts/domain-elements/projection-models.md
     # - Command-Query Responsibility Segregation:
     #   - core-concepts/command-query-responsibility-segregation/index.md
     #   - core-concepts/command-query-responsibility-segregation/commands.md

--- a/src/protean/adapters/cache/__init__.py
+++ b/src/protean/adapters/cache/__init__.py
@@ -73,17 +73,17 @@ class Caches(collections.abc.MutableMapping):
         except KeyError:
             raise AssertionError(f"No Provider registered with name {provider_name}")
 
-    def cache_for(self, view_cls):
-        """Retrieve cache associated with the View"""
+    def cache_for(self, projection_cls):
+        """Retrieve cache associated with the Projection"""
         if self._caches is None:
             self._initialize()
 
-        view_provider = view_cls.meta_.provider
+        projection_provider = projection_cls.meta_.provider
 
-        cache = self.get(view_provider)
+        cache = self.get(projection_provider)
 
-        view_name = underscore(view_cls.__name__)
-        if view_name not in cache._views:
-            cache.register_view(view_cls)
+        projection_name = underscore(projection_cls.__name__)
+        if projection_name not in cache._projections:
+            cache.register_projection(projection_cls)
 
         return cache

--- a/src/protean/adapters/repository/elasticsearch.py
+++ b/src/protean/adapters/repository/elasticsearch.py
@@ -505,7 +505,7 @@ class ESProvider(BaseProvider):
         elements = {
             **self.domain.registry.aggregates,
             **self.domain.registry.entities,
-            **self.domain.registry.views,
+            **self.domain.registry.projections,
         }
         for _, element_record in elements.items():
             provider = current_domain.providers[element_record.cls.meta_.provider]
@@ -528,7 +528,7 @@ class ESProvider(BaseProvider):
         elements = {
             **self.domain.registry.aggregates,
             **self.domain.registry.entities,
-            **self.domain.registry.views,
+            **self.domain.registry.projections,
         }
         for _, element_record in elements.items():
             provider = current_domain.providers[element_record.cls.meta_.provider]
@@ -548,7 +548,7 @@ class ESProvider(BaseProvider):
         elements = {
             **self.domain.registry.aggregates,
             **self.domain.registry.entities,
-            **self.domain.registry.views,
+            **self.domain.registry.projections,
         }
         for _, element_record in elements.items():
             database_model_cls = self.domain.repository_for(

--- a/src/protean/adapters/repository/sqlalchemy.py
+++ b/src/protean/adapters/repository/sqlalchemy.py
@@ -644,11 +644,11 @@ class SAProvider(BaseProvider):
             current_uow.rollback()
 
     def _create_database_artifacts(self):
-        # Create tables for all registered aggregates, entities, and views
+        # Create tables for all registered aggregates, entities, and projections
         elements = {
             **self.domain.registry.aggregates,
             **self.domain.registry.entities,
-            **self.domain.registry.views,
+            **self.domain.registry.projections,
         }
 
         for _, element_record in elements.items():

--- a/src/protean/core/repository.py
+++ b/src/protean/core/repository.py
@@ -6,8 +6,8 @@ from typing import TYPE_CHECKING, Union
 
 from protean.core.aggregate import BaseAggregate
 from protean.core.entity import BaseEntity
+from protean.core.projection import BaseProjection
 from protean.core.unit_of_work import UnitOfWork
-from protean.core.view import BaseView
 from protean.exceptions import IncorrectUsageError, NotSupportedError
 from protean.fields import HasMany, HasOne
 from protean.port.dao import BaseDAO
@@ -101,9 +101,9 @@ class BaseRepository(Element, OptionsMixin):
         return self._provider.get_dao(self.meta_.part_of, self._database_model)
 
     def add(
-        self, item: Union[BaseAggregate, BaseView]
-    ) -> Union[BaseAggregate, BaseView]:  # noqa: C901
-        """This method helps persist or update aggregates or views into the persistence store.
+        self, item: Union[BaseAggregate, BaseProjection]
+    ) -> Union[BaseAggregate, BaseProjection]:  # noqa: C901
+        """This method helps persist or update aggregates or projections into the persistence store.
 
         Returns the persisted item.
 
@@ -239,7 +239,7 @@ class BaseRepository(Element, OptionsMixin):
                     entity._temp_cache[field_name]["change"] = None
                     entity._temp_cache[field_name]["old_value"] = None
 
-    def get(self, identifier) -> Union[BaseAggregate, BaseEntity, BaseView]:
+    def get(self, identifier) -> Union[BaseAggregate, BaseEntity, BaseProjection]:
         """This is a utility method to fetch data from the persistence store by its key identifier. All child objects,
         including enclosed entities, are returned as part of this call.
 

--- a/src/protean/domain/__init__.py
+++ b/src/protean/domain/__init__.py
@@ -503,10 +503,10 @@ class Domain:
         from protean.core.event_sourced_repository import (
             event_sourced_repository_factory,
         )
+        from protean.core.projection import projection_factory
         from protean.core.repository import repository_factory
         from protean.core.subscriber import subscriber_factory
         from protean.core.value_object import value_object_factory
-        from protean.core.view import view_factory
 
         factories = {
             DomainObjects.AGGREGATE.value: aggregate_factory,
@@ -523,7 +523,7 @@ class Domain:
             DomainObjects.REPOSITORY.value: repository_factory,
             DomainObjects.SUBSCRIBER.value: subscriber_factory,
             DomainObjects.VALUE_OBJECT.value: value_object_factory,
-            DomainObjects.VIEW.value: view_factory,
+            DomainObjects.PROJECTION.value: projection_factory,
         }
 
         if domain_object_type.value not in factories:
@@ -1075,9 +1075,9 @@ class Domain:
             **kwargs,
         )
 
-    def view(self, _cls=None, **kwargs):
+    def projection(self, _cls=None, **kwargs):
         return self._domain_element(
-            DomainObjects.VIEW,
+            DomainObjects.PROJECTION,
             _cls=_cls,
             **kwargs,
         )
@@ -1219,15 +1219,15 @@ class Domain:
             # Return an Event Sourced repository
             return self.event_store.repository_for(element_cls)
         else:
-            # This is a regular aggregate or a view
+            # This is a regular aggregate or a projection
             return self.providers.repository_for(element_cls)
 
     #######################
     # Cache Functionality #
     #######################
 
-    def cache_for(self, view_cls):
-        return self.caches.cache_for(view_cls)
+    def cache_for(self, projection_cls):
+        return self.caches.cache_for(projection_cls)
 
     #######################
     # Email Functionality #

--- a/src/protean/port/cache.py
+++ b/src/protean/port/cache.py
@@ -1,7 +1,7 @@
 from abc import ABCMeta, abstractmethod
 from typing import Optional, Union
 
-from protean.core.view import BaseView
+from protean.core.projection import BaseProjection
 from protean.utils.inflection import underscore
 
 
@@ -15,13 +15,13 @@ class BaseCache(metaclass=ABCMeta):
         # Default TTL: 300 seconds
         self.ttl = conn_info.get("TTL", 300)
 
-        # Temporary cache of views
-        self._views = {}
+        # Temporary cache of projections
+        self._projections = {}
 
-    def register_view(self, view_cls):
-        """Registers a view object for data serialization and de-serialization"""
-        view_name = underscore(view_cls.__name__)
-        self._views[view_name] = view_cls
+    def register_projection(self, projection_cls):
+        """Registers a projection object for data serialization and de-serialization"""
+        projection_name = underscore(projection_cls.__name__)
+        self._projections[projection_name] = projection_cls
 
     @abstractmethod
     def ping(self):
@@ -32,21 +32,22 @@ class BaseCache(metaclass=ABCMeta):
         """Get the connection object for the cache"""
 
     @abstractmethod
-    def add(self, view: BaseView, ttl: Optional[Union[int, float]] = None) -> None:
-        """Add view record to cache
+    def add(
+        self, projection: BaseProjection, ttl: Optional[Union[int, float]] = None
+    ) -> None:
+        """Add projection record to cache
 
-        KEY: View ID
-        Value: View Data (derived from `to_dict()`)
+        KEY: Projection ID
+        Value: Projection Data (derived from `to_dict()`)
 
         TTL is in seconds. If not specified explicitly in method call,
         it can be picked up from broker configuration. In the absence of
         configuration, it can be defaulted to an optimum value, say 300 seconds.
 
         Args:
-            view (BaseView): View Instance containing data
+            projection (BaseProjection): Projection Instance containing data
             ttl (int, float, optional): Timeout in seconds. Defaults to None.
         """
-        """Add a key-value to the cache through the view object"""
 
     @abstractmethod
     def get(self, key):
@@ -61,8 +62,8 @@ class BaseCache(metaclass=ABCMeta):
         """Retrieve count of data by key pattern"""
 
     @abstractmethod
-    def remove(self, view):
-        """Remove a cache record by view"""
+    def remove(self, projection):
+        """Remove a cache record by projection object"""
 
     @abstractmethod
     def remove_by_key(self, key):

--- a/src/protean/utils/__init__.py
+++ b/src/protean/utils/__init__.py
@@ -104,7 +104,7 @@ class DomainObjects(Enum):
     REPOSITORY = "REPOSITORY"
     SUBSCRIBER = "SUBSCRIBER"
     VALUE_OBJECT = "VALUE_OBJECT"
-    VIEW = "VIEW"
+    PROJECTION = "PROJECTION"
 
 
 def derive_element_class(

--- a/tests/adapters/cache/redis_cache/tests.py
+++ b/tests/adapters/cache/redis_cache/tests.py
@@ -5,11 +5,11 @@ import pytest
 from redis import Redis
 
 from protean.adapters.cache.redis import RedisCache
-from protean.core.view import BaseView
+from protean.core.projection import BaseProjection
 from protean.fields import Identifier, String
 
 
-class Token(BaseView):
+class Token(BaseProjection):
     key = Identifier(identifier=True)
     user_id = Identifier(required=True)
     email = String(required=True)
@@ -129,7 +129,7 @@ class TestCachePersistenceFlows:
         value = cache.get("token:::qux")
         assert value is None
 
-    def test_removal_by_view_from_cache(self, test_domain):
+    def test_removal_by_projection_from_cache(self, test_domain):
         cache = test_domain.cache_for(Token)
 
         token = Token(key="qux", user_id="foo", email="bar@baz.com")
@@ -216,7 +216,7 @@ class TestCachePersistenceFlows:
 
 @pytest.mark.redis
 class TestCacheSerialization:
-    def test_serializing_view_object_data(self, test_domain):
+    def test_serializing_projection_object_data(self, test_domain):
         cache = test_domain.cache_for(Token)
 
         token = Token(key="qux", user_id="foo", email="bar@baz.com")
@@ -232,7 +232,7 @@ class TestCacheSerialization:
             "email": "bar@baz.com",
         }
 
-    def test_deserializing_view_object_data(self, test_domain):
+    def test_deserializing_projection_object_data(self, test_domain):
         cache = test_domain.cache_for(Token)
 
         token = Token(key="qux", user_id="foo", email="bar@baz.com")

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -3,12 +3,12 @@ import time
 import pytest
 
 from protean.adapters.cache.memory import MemoryCache
-from protean.core.view import BaseView
+from protean.core.projection import BaseProjection
 from protean.fields import Identifier, String
 from protean.port.cache import BaseCache
 
 
-class Token(BaseView):
+class Token(BaseProjection):
     key = Identifier(identifier=True)
     user_id = Identifier(required=True)
     email = String(required=True)
@@ -136,7 +136,7 @@ class TestCachePersistenceFlows:
         value = cache.get("token:::qux")
         assert value is None
 
-    def test_removal_by_view_from_cache(self, test_domain):
+    def test_removal_by_projection_from_cache(self, test_domain):
         cache = test_domain.cache_for(Token)
 
         token = Token(key="qux", user_id="foo", email="bar@baz.com")
@@ -217,7 +217,7 @@ class TestCachePersistenceFlows:
 
 
 class TestCacheSerialization:
-    def test_serializing_view_object_data(self, test_domain):
+    def test_serializing_projection_object_data(self, test_domain):
         cache = test_domain.cache_for(Token)
 
         token = Token(key="qux", user_id="foo", email="bar@baz.com")
@@ -229,7 +229,7 @@ class TestCacheSerialization:
 
         assert raw_value[1] == {"key": "qux", "user_id": "foo", "email": "bar@baz.com"}
 
-    def test_deserializing_view_object_data(self, test_domain):
+    def test_deserializing_projection_object_data(self, test_domain):
         cache = test_domain.cache_for(Token)
 
         token = Token(key="qux", user_id="foo", email="bar@baz.com")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -230,7 +230,7 @@ def db(test_domain):
     method.
 
     It helps create and drop db structures of registered
-    aggregates, entities, and views.
+    aggregates, entities, and projections.
     """
     # Call provider to create structures
     test_domain.providers["default"]._create_database_artifacts()

--- a/tests/event_handler/test_consuming_fact_events.py
+++ b/tests/event_handler/test_consuming_fact_events.py
@@ -2,7 +2,7 @@ import pytest
 
 from protean.core.aggregate import BaseAggregate
 from protean.core.event_handler import BaseEventHandler
-from protean.core.view import BaseView
+from protean.core.projection import BaseProjection
 from protean.fields import String
 from protean.utils.mixins import Message, handle
 
@@ -13,14 +13,14 @@ class User(BaseAggregate):
     status = String(choices=["ACTIVE", "ARCHIVED"])
 
 
-class UserView(BaseView):
+class UserProjection(BaseProjection):
     id = String(identifier=True)
     name = String(max_length=50, required=True)
     email = String(required=True)
     status = String(required=True)
 
 
-class ManageUserView(BaseEventHandler):
+class ManageUserProjection(BaseEventHandler):
     @handle("Test.UserFact.v1")
     def record_user_fact_event(self, message: Message) -> None:
         pass

--- a/tests/field/test_auto.py
+++ b/tests/field/test_auto.py
@@ -6,7 +6,7 @@ from uuid import UUID
 import pytest
 
 from protean.core.aggregate import BaseAggregate
-from protean.core.view import BaseView
+from protean.core.projection import BaseProjection
 from protean.fields import Auto
 from tests.shared import assert_int_is_uuid, assert_str_is_uuid
 
@@ -79,8 +79,10 @@ class TestValueGeneration:
         refreshed_auto2 = test_domain.repository_for(AutoTest)._dao.query.all().items[1]
         assert refreshed_auto2.auto_field == 2
 
-    def test_automatic_uuid_generation_of_identifier_fields_in_views(self, test_domain):
-        class AutoTest(BaseView):
+    def test_automatic_uuid_generation_of_identifier_fields_in_projections(
+        self, test_domain
+    ):
+        class AutoTest(BaseProjection):
             auto_field1 = Auto(identifier=True)
 
         test_domain.register(AutoTest)
@@ -93,10 +95,10 @@ class TestValueGeneration:
             "auto_field1": str(auto.auto_field1),
         }
 
-    def test_automatic_uuid_generation_of_non_identifier_fields_in_views(
+    def test_automatic_uuid_generation_of_non_identifier_fields_in_projections(
         self, test_domain
     ):
-        class AutoTest(BaseView):
+        class AutoTest(BaseProjection):
             identifier = Auto(identifier=True)
             auto_field1 = Auto()
 

--- a/tests/projections/test_projection_persistence.py
+++ b/tests/projections/test_projection_persistence.py
@@ -1,10 +1,10 @@
 import pytest
 
-from protean.core.view import BaseView
+from protean.core.projection import BaseProjection
 from protean.fields import Identifier, Integer, String
 
 
-class Person(BaseView):
+class Person(BaseProjection):
     person_id = Identifier(identifier=True)
     first_name = String(max_length=50, required=True)
     last_name = String(max_length=50)
@@ -17,8 +17,8 @@ def register_elements(test_domain):
     test_domain.init(traverse=False)
 
 
-class TestViewPersistence:
-    def test_view_can_be_persisted(self, test_domain):
+class TestProjectionPersistence:
+    def test_projection_can_be_persisted(self, test_domain):
         person = Person(person_id="1", first_name="John", last_name="Doe", age=25)
         test_domain.repository_for(Person).add(person)
 
@@ -29,7 +29,7 @@ class TestViewPersistence:
         assert refreshed_person.last_name == "Doe"
         assert refreshed_person.age == 25
 
-    def test_view_can_be_updated(self, test_domain):
+    def test_projection_can_be_updated(self, test_domain):
         person = Person(person_id="1", first_name="John", last_name="Doe", age=25)
         test_domain.repository_for(Person).add(person)
 

--- a/tests/projections/test_projection_query_limit_option.py
+++ b/tests/projections/test_projection_query_limit_option.py
@@ -1,12 +1,12 @@
-# Test that limit provided in View options is respected
+# Test that limit provided in Projection options is respected
 
 import pytest
 
-from protean.core.view import BaseView
+from protean.core.projection import BaseProjection
 from protean.fields import Identifier, Integer, String
 
 
-class Person(BaseView):
+class Person(BaseProjection):
     person_id = Identifier(identifier=True)
     first_name = String(max_length=50, required=True)
     last_name = String(max_length=50)

--- a/tests/projections/test_projection_validations_for_fields.py
+++ b/tests/projections/test_projection_validations_for_fields.py
@@ -2,8 +2,8 @@ import pytest
 
 from protean.core.aggregate import BaseAggregate
 from protean.core.entity import BaseEntity
+from protean.core.projection import BaseProjection
 from protean.core.value_object import BaseValueObject
-from protean.core.view import BaseView
 from protean.exceptions import IncorrectUsageError
 from protean.fields import HasOne, Identifier, Reference, String, ValueObject
 
@@ -20,52 +20,53 @@ class Role(BaseEntity):
     name = String(max_length=50)
 
 
-def test_that_views_should_have_at_least_one_identifier_field(test_domain):
-    class User(BaseView):
+def test_that_projections_should_have_at_least_one_identifier_field(test_domain):
+    class User(BaseProjection):
         first_name = String()
 
     with pytest.raises(IncorrectUsageError) as exception:
         test_domain.register(User)
 
     assert (
-        exception.value.args[0] == "View `User` needs to have at least one identifier"
+        exception.value.args[0]
+        == "Projection `User` needs to have at least one identifier"
     )
 
 
-def test_that_views_cannot_have_value_object_fields():
+def test_that_projections_cannot_have_value_object_fields():
     with pytest.raises(IncorrectUsageError) as exception:
 
-        class User(BaseView):
+        class User(BaseProjection):
             user_id = Identifier(identifier=True)
             email = ValueObject(Email)
 
     assert (
         exception.value.args[0]
-        == "Views can only contain basic field types. Remove email (ValueObject) from class User"
+        == "Projections can only contain basic field types. Remove email (ValueObject) from class User"
     )
 
 
-def test_that_views_cannot_have_references():
+def test_that_projections_cannot_have_references():
     with pytest.raises(IncorrectUsageError) as exception:
 
-        class User(BaseView):
+        class User(BaseProjection):
             user_id = Identifier(identifier=True)
             role = Reference(Role)
 
     assert (
         exception.value.args[0]
-        == "Views can only contain basic field types. Remove role (Reference) from class User"
+        == "Projections can only contain basic field types. Remove role (Reference) from class User"
     )
 
 
-def test_that_views_cannot_have_associations():
+def test_that_projections_cannot_have_associations():
     with pytest.raises(IncorrectUsageError) as exception:
 
-        class User(BaseView):
+        class User(BaseProjection):
             user_id = Identifier(identifier=True)
             role = HasOne(Role)
 
     assert (
         exception.value.args[0]
-        == "Views can only contain basic field types. Remove role (HasOne) from class User"
+        == "Projections can only contain basic field types. Remove role (HasOne) from class User"
     )

--- a/tests/projections/test_projection_with_redis.py
+++ b/tests/projections/test_projection_with_redis.py
@@ -1,8 +1,8 @@
-from protean.core.view import BaseView
+from protean.core.projection import BaseProjection
 from protean.fields import Identifier, Integer, String
 
 
-class Person(BaseView):
+class Person(BaseProjection):
     person_id = Identifier(identifier=True)
     first_name = String(max_length=50, required=True)
     last_name = String(max_length=50)

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -1,6 +1,6 @@
 import pytest
 
-from protean.core.view import BaseView
+from protean.core.projection import BaseProjection
 from protean.exceptions import InvalidDataError, NotSupportedError
 from protean.fields import Integer, String
 from protean.utils.container import BaseContainer, OptionsMixin
@@ -32,17 +32,17 @@ class TestContainerInitialization:
             CustomContainerMeta()
 
     def test_abstract_containers_cannot_be_instantiated(self, test_domain):
-        class AbstractView(BaseView):
+        class AbstractProjection(BaseProjection):
             foo = String()
 
-        test_domain.register(AbstractView, abstract=True)
+        test_domain.register(AbstractProjection, abstract=True)
 
         with pytest.raises(NotSupportedError) as exc:
-            AbstractView(foo="bar")
+            AbstractProjection(foo="bar")
 
         assert (
             str(exc.value)
-            == "AbstractView class has been marked abstract and cannot be instantiated"
+            == "AbstractProjection class has been marked abstract and cannot be instantiated"
         )
 
     def test_that_a_concrete_custom_container_can_be_instantiated(self):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -103,7 +103,7 @@ def test_properties_method_returns_a_dictionary_of_all_protean_elements():
         "repositories": DomainObjects.REPOSITORY.value,
         "subscribers": DomainObjects.SUBSCRIBER.value,
         "value_objects": DomainObjects.VALUE_OBJECT.value,
-        "views": DomainObjects.VIEW.value,
+        "projections": DomainObjects.PROJECTION.value,
     }
 
 


### PR DESCRIPTION
The term `projection` better reflects the intention of read models, than `view`. Views and view models can be confused with models that are on the UI side, or models that part of MVVM architecture.