### PR TITLE
Fix 455 allow event sourced aggregates to specify how to initialize themselves from first event

### DIFF
--- a/src/protean/core/aggregate.py
+++ b/src/protean/core/aggregate.py
@@ -163,6 +163,9 @@ class BaseAggregate(BaseEntity):
                 # skip the older event that doesn't mirror latest aggregate anymore
                 base_item += 1
                 cls._meta_events_log[-1]["end_index"] = event_item
+        if aggregate is None:
+            raise ValueError("No valid base event found for aggregate reconstruction")
+
         return aggregate
 
 


### PR DESCRIPTION
### Description:
This pull request refines the aggregate reconstruction process from a sequence of events. The goal is to ensure that the aggregate can be initialized correctly from the first valid event, even if some earlier events in the sequence do not conform to the expected structure of the aggregate.

### Key changes include:

Base Event Initialization: A more robust method for identifying the first valid event from which to initialize the aggregate. The algorithm iterates through the list of events and attempts to apply each event in turn, ensuring the correct structure is found before continuing with further event applications.

Error Handling: If no valid base event is found (i.e., an event that matches the expected structure for the aggregate), an error is raised, providing clear feedback to the user.

Event Log: Introduces a logging mechanism that tracks the meta events and indexes used to reconstruct the aggregate. This provides insight into which events were considered valid and helps with debugging and future improvements.

Event Skipping: If an event does not match the aggregate's expected structure, it is skipped in favor of the next event, ensuring smooth aggregate reconstruction without unnecessary interruptions.

### LIMITATION:-

this is not a complete solution to #455 as pointed before in then form that it requires some major adjustments i will eventually create a pull request on that however if protein framework doesn't need major adjustment then this solution will be a workaround
