### PR TITLE
Improve async loop use and signal handling in Engine

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,8 @@ filterwarnings = [
     "ignore::sqlalchemy.exc.SAWarning",
     "ignore::sqlalchemy.exc.SADeprecationWarning",
     "ignore:No configuration file found.*Using default configuration.*:UserWarning",
-    "ignore:Working outside of domain context"
+    "ignore:Working outside of domain context",
+    "ignore:.*was never awaited:RuntimeWarning"
 ]
 python_files = [
     "test_*.py",

--- a/tests/cli/test_server.py
+++ b/tests/cli/test_server.py
@@ -2,10 +2,9 @@ import logging
 import os
 import sys
 from pathlib import Path
-from unittest.mock import ANY, MagicMock, PropertyMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
-import typer
 from typer.testing import CliRunner
 
 from protean.cli import app

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """Module to setup Factories and other required artifacts for tests"""
 
 import asyncio
+import logging
 import os
 import sys
 
@@ -310,3 +311,17 @@ def auto_set_and_close_loop():
     if not loop.is_closed():
         loop.close()
     asyncio.set_event_loop(None)  # Explicitly unset the loop
+
+
+@pytest.fixture(scope="session", autouse=True)
+def cleanup_logging_handlers():
+    """This fixture avoids closed resources error on logging module
+    after the async app tests have been actually finished.
+    See: https://github.com/pytest-dev/pytest/issues/5502
+    """
+    try:
+        yield
+    finally:
+        for handler in logging.root.handlers[:]:
+            if isinstance(handler, logging.StreamHandler):
+                logging.root.removeHandler(handler)

--- a/tests/server/test_handle_error.py
+++ b/tests/server/test_handle_error.py
@@ -9,7 +9,6 @@ from protean.core.event import BaseEvent
 from protean.core.event_handler import BaseEventHandler
 from protean.core.subscriber import BaseSubscriber
 from protean.fields import Identifier, String
-from protean.port.broker import BaseBroker
 from protean.server import Engine
 from protean.utils import Processing
 from protean.utils.mixins import Message, handle

--- a/tests/server/test_processing_broker_messages.py
+++ b/tests/server/test_processing_broker_messages.py
@@ -1,5 +1,3 @@
-import asyncio
-
 import pytest
 
 from protean.core.subscriber import BaseSubscriber

--- a/tests/server/test_signal_handling.py
+++ b/tests/server/test_signal_handling.py
@@ -1,0 +1,327 @@
+import asyncio
+import signal
+from unittest.mock import Mock, patch
+
+import pytest
+
+from protean.core.aggregate import BaseAggregate
+from protean.core.event import BaseEvent
+from protean.core.event_handler import BaseEventHandler
+from protean.fields import Identifier
+from protean.server.engine import Engine
+from protean.utils import Processing
+from protean.utils.mixins import handle
+
+
+class User(BaseAggregate):
+    user_id = Identifier(identifier=True)
+
+
+class UserLoggedIn(BaseEvent):
+    user_id = Identifier(identifier=True)
+
+
+class UserEventHandler(BaseEventHandler):
+    @handle(UserLoggedIn)
+    def count_users(self, event: UserLoggedIn) -> None:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def register_elements(test_domain):
+    test_domain.config["event_processing"] = Processing.ASYNC.value
+    test_domain.register(User, stream_category="authentication")
+    test_domain.register(UserLoggedIn, part_of=User)
+    test_domain.register(UserEventHandler, stream_category="authentication")
+    test_domain.init(traverse=False)
+
+
+class TestSignalHandling:
+    """Test signal handling functionality across different platforms."""
+
+    def test_signal_handlers_initialization(self, test_domain):
+        """Test that signal handlers are properly initialized."""
+        engine = Engine(domain=test_domain)
+        assert hasattr(engine, "_original_signal_handlers")
+        assert isinstance(engine._original_signal_handlers, dict)
+
+    @patch("platform.system")
+    def test_windows_signal_handling_setup(self, mock_platform, test_domain):
+        """Test signal handler setup on Windows platform."""
+        mock_platform.return_value = "Windows"
+
+        with patch("signal.signal") as mock_signal:
+            engine = Engine(domain=test_domain)
+            engine._setup_signal_handlers()
+
+            # Should call signal.signal for each signal
+            assert mock_signal.call_count >= 3  # SIGHUP, SIGTERM, SIGINT
+
+    @patch("platform.system")
+    def test_unix_signal_handling_setup(self, mock_platform, test_domain):
+        """Test signal handler setup on Unix-like platforms."""
+        mock_platform.return_value = "Linux"
+
+        engine = Engine(domain=test_domain)
+
+        with patch.object(engine.loop, "add_signal_handler") as mock_add_handler:
+            engine._setup_signal_handlers()
+
+            # Should call add_signal_handler for each signal
+            assert mock_add_handler.call_count >= 3  # SIGHUP, SIGTERM, SIGINT
+
+    @patch("platform.system")
+    def test_windows_signal_cleanup(self, mock_platform, test_domain):
+        """Test signal handler cleanup on Windows platform."""
+        mock_platform.return_value = "Windows"
+
+        engine = Engine(domain=test_domain)
+
+        # Mock original signal handlers
+        engine._original_signal_handlers = {
+            signal.SIGINT: Mock(),
+            signal.SIGTERM: Mock(),
+        }
+
+        with patch("signal.signal") as mock_signal:
+            engine._cleanup_signal_handlers()
+
+            # Should restore original handlers
+            assert mock_signal.call_count == 2
+
+    @patch("platform.system")
+    def test_unix_signal_cleanup(self, mock_platform, test_domain):
+        """Test signal handler cleanup on Unix-like platforms."""
+        mock_platform.return_value = "Linux"
+
+        engine = Engine(domain=test_domain)
+
+        with patch.object(engine.loop, "remove_signal_handler") as mock_remove_handler:
+            engine._cleanup_signal_handlers()
+
+            # Should remove signal handlers
+            assert mock_remove_handler.call_count >= 3
+
+    @patch("platform.system")
+    def test_signal_handler_exception_handling(self, mock_platform, test_domain):
+        """Test that signal handler setup handles exceptions gracefully."""
+        mock_platform.return_value = "Windows"
+
+        def signal_side_effect(*args):
+            raise OSError("Signal not available")
+
+        with patch("signal.signal", side_effect=signal_side_effect):
+            engine = Engine(domain=test_domain)
+            # Should not raise exception
+            try:
+                engine._setup_signal_handlers()
+                # Should complete without raising exception
+            except Exception as e:
+                pytest.fail(
+                    f"_setup_signal_handlers should handle signal exceptions gracefully: {e}"
+                )
+
+    @patch("platform.system")
+    def test_windows_signal_handler_callback(self, mock_platform, test_domain):
+        """Test that Windows signal handler callback works correctly."""
+        mock_platform.return_value = "Windows"
+
+        engine = Engine(domain=test_domain, test_mode=True)
+
+        # Mock asyncio.run_coroutine_threadsafe to verify it gets called
+        coroutine_called = False
+
+        def mock_run_coroutine_threadsafe(coro, loop):
+            nonlocal coroutine_called
+            coroutine_called = True
+            # Just close the coroutine without actually running it
+            coro.close()
+            return Mock()
+
+        # Capture the signal handler that gets registered
+        captured_handler = None
+
+        def mock_signal_func(sig, handler):
+            nonlocal captured_handler
+            if sig == signal.SIGTERM:  # Capture only SIGTERM handler for testing
+                captured_handler = handler
+            return Mock()
+
+        with patch(
+            "asyncio.run_coroutine_threadsafe",
+            side_effect=mock_run_coroutine_threadsafe,
+        ):
+            with patch("signal.signal", side_effect=mock_signal_func):
+                engine._setup_signal_handlers()
+
+                # Simulate signal reception when the loop is "running"
+                if captured_handler:
+                    # Mock that the loop is running
+                    with patch.object(engine.loop, "is_running", return_value=True):
+                        captured_handler(signal.SIGTERM)
+
+        assert coroutine_called
+
+    def test_signal_attribute_access_in_shutdown(self, test_domain):
+        """Test that shutdown handles signal objects without 'name' attribute."""
+        engine = Engine(domain=test_domain)
+
+        # Test with a signal that has a name attribute
+        with patch.object(engine, "shutting_down", True):
+            try:
+                asyncio.run(engine.shutdown(signal=signal.SIGTERM))
+                # Should not raise exception
+            except Exception as e:
+                pytest.fail(
+                    f"shutdown should handle signals with name attribute gracefully: {e}"
+                )
+
+        # Test with a signal-like object without name attribute
+        class MockSignal:
+            pass
+
+        mock_signal = MockSignal()
+        with patch.object(engine, "shutting_down", True):
+            try:
+                asyncio.run(engine.shutdown(signal=mock_signal))
+                # Should not raise exception
+            except Exception as e:
+                pytest.fail(
+                    f"shutdown should handle signals without name attribute gracefully: {e}"
+                )
+
+    @patch("platform.system")
+    def test_fallback_when_add_signal_handler_not_available(
+        self, mock_platform, test_domain
+    ):
+        """Test fallback to signal.signal when add_signal_handler is not available."""
+        mock_platform.return_value = "Linux"  # Normally would use add_signal_handler
+
+        engine = Engine(domain=test_domain)
+
+        # Mock the condition directly in the engine method
+        original_setup = engine._setup_signal_handlers
+
+        def mock_setup():
+            # Force the Windows path by mocking hasattr to return False
+            original_hasattr = hasattr
+
+            def mock_hasattr(obj, name):
+                if name == "add_signal_handler" and obj is engine.loop:
+                    return False
+                return original_hasattr(obj, name)
+
+            import builtins
+
+            builtins.hasattr = mock_hasattr
+            try:
+                original_setup()
+            finally:
+                builtins.hasattr = original_hasattr
+
+        with patch("signal.signal") as mock_signal:
+            try:
+                mock_setup()
+                # Should complete without raising exception
+            except Exception as e:
+                pytest.fail(
+                    f"signal handler setup should work with fallback gracefully: {e}"
+                )
+
+            # Should fall back to signal.signal
+            assert mock_signal.call_count >= 3
+
+    def test_cleanup_during_shutdown(self, test_domain):
+        """Test that signal handlers are cleaned up during shutdown."""
+        engine = Engine(domain=test_domain)
+
+        cleanup_called = False
+        original_cleanup = engine._cleanup_signal_handlers
+
+        def mock_cleanup():
+            nonlocal cleanup_called
+            cleanup_called = True
+            original_cleanup()
+
+        engine._cleanup_signal_handlers = mock_cleanup
+
+        # Run shutdown
+        try:
+            asyncio.run(engine.shutdown())
+            # Should complete without raising exception
+        except Exception as e:
+            pytest.fail(f"shutdown should handle signal cleanup gracefully: {e}")
+
+        assert cleanup_called
+
+    def test_cleanup_during_run_finally_block(self, test_domain):
+        """Test that signal handlers are cleaned up in the finally block of run()."""
+        engine = Engine(domain=test_domain, test_mode=True)
+
+        cleanup_called = False
+        original_cleanup = engine._cleanup_signal_handlers
+
+        def mock_cleanup():
+            nonlocal cleanup_called
+            cleanup_called = True
+            original_cleanup()
+
+        engine._cleanup_signal_handlers = mock_cleanup
+
+        # Run the engine (will exit immediately due to no subscriptions)
+        try:
+            engine.run()
+            # Should complete without raising exception
+        except Exception as e:
+            pytest.fail(f"engine.run() should handle signal cleanup gracefully: {e}")
+
+        assert cleanup_called
+
+    @patch("platform.system")
+    def test_debug_logging_for_signal_setup(self, mock_platform, test_domain, caplog):
+        """Test that debug logging works for signal setup."""
+        mock_platform.return_value = "Windows"
+
+        engine = Engine(domain=test_domain, debug=True)
+
+        with caplog.at_level("DEBUG"):
+            try:
+                engine._setup_signal_handlers()
+                # Should complete without raising exception
+            except Exception as e:
+                pytest.fail(
+                    f"_setup_signal_handlers should handle debug logging gracefully: {e}"
+                )
+
+            assert any(
+                "Using signal.signal() for signal handling" in record.message
+                for record in caplog.records
+            )
+
+    @patch("platform.system")
+    def test_unavailable_signal_handling(self, mock_platform, test_domain, caplog):
+        """Test handling of unavailable signals."""
+        mock_platform.return_value = "Windows"
+
+        def signal_side_effect(sig, handler):
+            if sig == signal.SIGHUP:
+                raise OSError("Signal not available on this platform")
+            return Mock()
+
+        engine = Engine(domain=test_domain, debug=True)
+
+        with patch("signal.signal", side_effect=signal_side_effect):
+            with caplog.at_level("DEBUG"):
+                try:
+                    engine._setup_signal_handlers()
+                    # Should complete without raising exception
+                except Exception as e:
+                    pytest.fail(
+                        f"_setup_signal_handlers should handle unavailable signals gracefully: {e}"
+                    )
+
+                # Should log that SIGHUP is not available
+                assert any(
+                    "Signal" in record.message and "not available" in record.message
+                    for record in caplog.records
+                )

--- a/tests/server2/test_cli_command.py
+++ b/tests/server2/test_cli_command.py
@@ -74,7 +74,7 @@ class TestServerCliCommand:
         domain = derive_domain("publishing7.py")
 
         # Run the command with early exit to avoid actually starting the server
-        with patch.object(mock_instance, "run") as mock_run:
+        with patch.object(mock_instance, "run"):
             args = [
                 "server2",
                 "--domain",


### PR DESCRIPTION
Observation: `self.loop = asyncio.get_event_loop()` is fragile when the caller already has a running loop.
Change: Use `asyncio.new_event_loop()` inside `Engine.__init__`

Observation: `add_signal_handler()` is a no‑op on Windows
Change: Fall back to signal.signal where unsupported

Observation: The custom exception handler logs and calls `raise context["exception"]` inside the handler itself, which can crash before the shutdown() task runs.
Change: Let the handler schedule `shutdown(exit_code=1)` and return; avoid re‑raising so the loop can drain.