### PR TITLE
Fixed Reference field's get_attribute_name.

### DIFF
--- a/src/protean/fields/association.py
+++ b/src/protean/fields/association.py
@@ -109,7 +109,7 @@ class Reference(FieldCacheMixin, Field):
 
     def get_attribute_name(self):
         """Return formatted attribute name for the shadow field"""
-        return "{}_{}".format(self.field_name, self.linked_attribute)
+        return self.referenced_as if self.referenced_as else "{}_{}".format(self.field_name, self.linked_attribute)
 
     def get_shadow_field(self):
         """Return shadow field


### PR DESCRIPTION
Summary
This pull request fixes the behavior of Protean's Reference field by ensuring that the get_attribute_name method uses self.referenced_as when it is defined.

Details
Updated get_attribute_name to prioritize self.referenced_as if present.
Falls back to the default behavior when referenced_as is not defined.
This ensures more predictable and explicit attribute resolution when working with Reference fields.