### PR TITLE
Mark aggregate dirty when ValueObject field is updated

### DIFF
--- a/docs_src/guides/consume-state/002.py
+++ b/docs_src/guides/consume-state/002.py
@@ -100,7 +100,7 @@ class ProductInventoryProjector:
             description=event.description,
             price=event.price,
             stock_quantity=event.stock_quantity,
-            last_updated=event._metadata.timestamp,
+            last_updated=event._metadata.headers.time,
         )
 
         repository.add(inventory)
@@ -112,7 +112,7 @@ class ProductInventoryProjector:
         inventory = repository.get(event.product_id)
 
         inventory.stock_quantity = event.new_stock_quantity
-        inventory.last_updated = event._metadata.timestamp
+        inventory.last_updated = event._metadata.headers.time
 
         repository.add(inventory)
 

--- a/src/protean/fields/embedded.py
+++ b/src/protean/fields/embedded.py
@@ -177,6 +177,10 @@ class ValueObject(Field):
         else:
             self._reset_values(instance)
 
+        # Mark Entity as Dirty
+        if hasattr(instance, "state_"):
+            instance.state_.mark_changed()
+
     def _set_own_value(self, instance, value):
         if value is None:
             instance.__dict__.pop(self.field_name, None)


### PR DESCRIPTION
Also use correct metadata path in consume-state example 002.py

Closes #648
Closes #650