### PR TITLE
Make `@apply` the single source of truth for event-sourced aggregate state mutations

### DIFF
--- a/docs/core-concepts/event-sourcing.md
+++ b/docs/core-concepts/event-sourcing.md
@@ -31,7 +31,7 @@ reconstruct the state of the system at any point in time.
 3. **Command Handler**: The Command Handler processes the Command, interacting with the Repository to retrieve the relevant Aggregate.
 4. **Hydrate**: The Repository hydrates the Aggregate by reconstructing its state from past events stored in the Event Store.
 5. **Aggregate**: The Command Handler invokes the appropriate method on the Aggregate to perform the required business operation.
-6. **Output**: The Aggregate processes the command, which results in a state change. Instead of directly updating the state in a persistence store, the Aggregate generates an Event that describes the change.
+6. **Output**: The business method calls `raise_()` to generate an Event that describes the change. `raise_()` automatically invokes the corresponding `@apply` handler to mutate the aggregate's state — the same handler that runs during event replay. This ensures the live path and the replay path always produce identical results.
 7. **Repository**: The generated Event is passed back to the Repository, which is responsible for persisting the Event.
 8. **Event Store**: The Repository saves the Event in the Event Store, ensuring that all changes in the domain are captured as a series of events.
 9. **Event Handler**: The Event is then processed by an Event Handler, which reacts to the event by performing additional business logic or updating projections.

--- a/docs/core-concepts/philosophy.md
+++ b/docs/core-concepts/philosophy.md
@@ -151,7 +151,8 @@ This event-centric approach enables:
 - **Loose coupling** between bounded contexts that evolve independently
 - **State synchronization** without shared databases or direct API calls
 - **Event Sourcing** where aggregate state is derived entirely from
-  event replay
+  events — with `@apply` handlers as the single source of truth for
+  state mutations during both live operations and replay
 - **Async processing** via the Protean server engine for production
   workloads
 

--- a/docs/internals/event-sourcing.md
+++ b/docs/internals/event-sourcing.md
@@ -1,0 +1,181 @@
+# Event Sourcing Internals
+
+This page documents the internal mechanics of event-sourced aggregates in
+Protean — how `raise_()` triggers `@apply` handlers, how aggregates are
+reconstructed from events, and how version tracking works.
+
+## The Single Source of Truth
+
+The central design principle: **`@apply` handlers are the only place where
+event-sourced aggregate state is mutated.** Both the live path (processing
+commands) and the replay path (loading from event store) converge on the
+same `@apply` handlers, eliminating an entire class of bugs where live
+behavior diverges from replay behavior.
+
+```
+Live path:    business_method() → raise_() → @apply handler → state mutated
+Replay path:  from_events()    → _apply()  → @apply handler → state mutated
+```
+
+## `raise_()` for Event-Sourced Aggregates
+
+When `raise_()` is called on an event-sourced aggregate, it performs these
+steps in order:
+
+1. **Validate** the event is associated with this aggregate
+2. **Increment** `_version` (for non-fact events)
+3. **Build metadata** — identity, stream name, sequence ID, headers, checksum
+4. **Append** the enriched event to `_events`
+5. **Invoke `@apply` handler** — wrapped in `atomic_change()` so invariants
+   are checked before and after the handler runs
+
+Step 5 is the key difference from non-ES aggregates, where `raise_()` only
+collects events without calling handlers.
+
+```python
+# Inside raise_(), for ES aggregates:
+if self.meta_.is_event_sourced:
+    is_fact_event = event.__class__.__name__.endswith("FactEvent")
+    if not is_fact_event:
+        with atomic_change(self):
+            self._apply_handler(event_with_metadata)
+```
+
+Fact events are excluded because they are auto-generated snapshots that
+don't carry domain semantics — they don't have `@apply` handlers.
+
+## `_apply_handler()` vs `_apply()`
+
+These two methods serve different roles:
+
+### `_apply_handler(event)`
+
+Invokes the registered `@apply` handler(s) for an event **without**
+touching `_version`. This is the shared core used by both paths:
+
+- Called by `raise_()` during live operations (version already incremented
+  by `raise_()` before the handler runs)
+- Called by `_apply()` during replay (version incremented by `_apply()`
+  after the handler runs)
+
+Raises `NotImplementedError` if no handler is registered.
+
+### `_apply(event)`
+
+The replay-specific method. Calls `_apply_handler()` then increments
+`_version`. Used exclusively during aggregate reconstitution from events:
+
+```python
+def _apply(self, event):
+    self._apply_handler(event)
+    self._version += 1
+```
+
+## Aggregate Construction
+
+### `_create_for_reconstitution()`
+
+Creates a blank aggregate instance for event replay, **bypassing all
+Pydantic validation**. Uses `__new__` to skip `__init__` entirely:
+
+1. Creates instance via `cls.__new__(cls)`
+2. Initializes Pydantic internals (`__dict__`, `__pydantic_extra__`, etc.)
+3. Sets private attributes with defaults (`_version=-1`, `_events=[]`, etc.)
+4. **Suppresses invariant checks** (`_disable_invariant_checks=True`) —
+   intermediate states during replay may violate invariants that will be
+   satisfied once all events are applied
+5. Initializes all model fields to `None`
+6. Initializes ValueObject and Reference shadow fields to `None`
+7. Sets up HasMany pseudo-methods (`add_*`, `remove_*`, etc.)
+8. Discovers invariants from the MRO
+
+This follows the same pattern as `BaseEntity.__deepcopy__`.
+
+### `_create_new(**identity_kwargs)`
+
+Used by factory methods to create a new ES aggregate with identity:
+
+1. Calls `_create_for_reconstitution()` to get a blank aggregate
+2. **Enables invariant checks** (`_disable_invariant_checks=False`)
+3. Sets identity — from `identity_kwargs` if provided, otherwise
+   auto-generates via `generate_identity()`
+
+All state beyond identity is populated by the creation event's `@apply`
+handler when the factory calls `raise_()`:
+
+```python
+@classmethod
+def place(cls, customer_name):
+    order = cls._create_new()
+    order.raise_(OrderPlaced(
+        order_id=str(order.id),
+        customer_name=customer_name,
+    ))
+    return order
+```
+
+### `from_events(events)`
+
+Reconstructs an aggregate from a list of stored events:
+
+1. Calls `_create_for_reconstitution()` to get a blank aggregate
+2. Applies each event via `_apply()` (handler + version increment)
+3. Enables invariant checks after all events are applied
+
+```python
+@classmethod
+def from_events(cls, events):
+    aggregate = cls._create_for_reconstitution()
+    for event in events:
+        aggregate._apply(event)
+    aggregate._disable_invariant_checks = False
+    return aggregate
+```
+
+The first event's `@apply` handler must set **all** fields including
+identity — there is no special treatment of the first event.
+
+## Version Tracking
+
+Version management is split between the live path and replay path to
+avoid double-incrementing:
+
+| Path | Who increments `_version` | When |
+|------|---------------------------|------|
+| Live (`raise_()`) | `raise_()` itself | Before calling `_apply_handler()` |
+| Replay (`_apply()`) | `_apply()` | After calling `_apply_handler()` |
+
+This ensures each event increments the version exactly once regardless of
+which path processes it.
+
+## Invariant Checking
+
+During live operations, `raise_()` wraps the `@apply` call in
+`atomic_change()`. This context manager:
+
+1. Runs `_precheck()` before the handler (pre-invariants)
+2. Suppresses per-field invariant checks during the handler
+3. Runs `_postcheck()` after the handler (post-invariants)
+
+During replay, invariant checks are disabled entirely
+(`_disable_invariant_checks=True`) because intermediate states may
+violate invariants that are only satisfied after all events are applied.
+Checks are re-enabled when `from_events()` completes.
+
+## Association Handling for ES Aggregates
+
+Event-sourced aggregates don't have traditional database tables for child
+entities. When a `HasMany` field's cache misses during a `__get__` call
+on an ES aggregate, the framework returns an empty list instead of
+attempting a database query:
+
+```python
+# In Association.__get__:
+root = getattr(instance, "_root", None) or instance
+if getattr(getattr(root, "meta_", None), "is_event_sourced", False):
+    reference_obj = []
+    self.set_cached_value(instance, reference_obj)
+```
+
+State for associated entities in ES aggregates is managed entirely through
+events and `@apply` handlers using the `add_*` pseudo-methods.

--- a/docs/internals/index.md
+++ b/docs/internals/index.md
@@ -20,3 +20,6 @@ shaped it.
 - [Query system](./query-system.md) -- How the Repository → DAO → QuerySet →
   Provider chain works, Q object expression trees, lookup resolution, lazy
   evaluation, and entity state tracking.
+- [Event sourcing](./event-sourcing.md) -- How `raise_()` invokes `@apply`
+  handlers, aggregate reconstitution via `_create_for_reconstitution()` and
+  `from_events()`, version tracking, and invariant checking during replay.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -292,6 +292,7 @@ nav:
     - internals/field-system.md
     - internals/shadow-fields.md
     - internals/query-system.md
+    - internals/event-sourcing.md
 
   - Migration:
     - migration/v0-15.md

--- a/tests/aggregate/events/test_event_association_with_aggregate.py
+++ b/tests/aggregate/events/test_event_association_with_aggregate.py
@@ -1,5 +1,6 @@
 import pytest
 
+from protean import apply
 from protean.core.aggregate import BaseAggregate
 from protean.core.event import BaseEvent
 from protean.exceptions import ConfigurationError
@@ -43,9 +44,24 @@ class User(BaseAggregate):
     def change_name(self, name):
         self.raise_(UserRenamed(user_id=self.user_id, name=name))
 
+    @apply
+    def on_registered(self, event: UserRegistered) -> None:
+        self.user_id = event.user_id
+        self.name = event.name
+        self.email = event.email
 
-class User2(User):
-    pass
+    @apply
+    def on_activated(self, event: UserActivated) -> None:
+        self.status = "ACTIVE"
+
+    @apply
+    def on_renamed(self, event: UserRenamed) -> None:
+        self.name = event.name
+
+
+class User2(BaseAggregate):
+    user_id: Identifier(identifier=True)
+    name: String(max_length=50)
 
 
 class UserUnknownEvent(BaseEvent):

--- a/tests/event/test_event_metadata.py
+++ b/tests/event/test_event_metadata.py
@@ -3,12 +3,17 @@ from uuid import uuid4
 
 import pytest
 
+from protean import apply
 from protean.core.aggregate import BaseAggregate
 from protean.core.event import BaseEvent
 from protean.fields import String
 from protean.fields.basic import Identifier
 from protean.utils import Processing, fqn
 from protean.utils.eventing import MessageEnvelope, MessageHeaders, Metadata, DomainMeta
+
+
+class UserLoggedIn(BaseEvent):
+    user_id: Identifier(identifier=True)
 
 
 class User(BaseAggregate):
@@ -19,9 +24,9 @@ class User(BaseAggregate):
     def login(self):
         self.raise_(UserLoggedIn(user_id=self.id))
 
-
-class UserLoggedIn(BaseEvent):
-    user_id: Identifier(identifier=True)
+    @apply
+    def on_logged_in(self, event: UserLoggedIn) -> None:
+        pass
 
 
 @pytest.fixture(autouse=True)

--- a/tests/event/test_event_payload.py
+++ b/tests/event/test_event_payload.py
@@ -2,12 +2,17 @@ from uuid import uuid4
 
 import pytest
 
+from protean import apply
 from protean.core.aggregate import BaseAggregate
 from protean.core.event import BaseEvent
 from protean.fields import String
 from protean.fields.basic import Identifier
 from protean.utils import fqn
 from protean.utils.eventing import MessageEnvelope
+
+
+class UserLoggedIn(BaseEvent):
+    user_id: Identifier(identifier=True)
 
 
 class User(BaseAggregate):
@@ -18,9 +23,9 @@ class User(BaseAggregate):
     def login(self):
         self.raise_(UserLoggedIn(user_id=self.id))
 
-
-class UserLoggedIn(BaseEvent):
-    user_id: Identifier(identifier=True)
+    @apply
+    def on_logged_in(self, event: UserLoggedIn) -> None:
+        pass
 
 
 @pytest.fixture(autouse=True)

--- a/tests/event/test_event_properties.py
+++ b/tests/event/test_event_properties.py
@@ -2,6 +2,7 @@ import json
 
 import pytest
 
+from protean import apply
 from protean.core.aggregate import BaseAggregate
 from protean.core.event import BaseEvent
 from protean.exceptions import IncorrectUsageError
@@ -9,16 +10,22 @@ from protean.fields import Identifier, String
 from protean.utils.reflection import id_field
 
 
+class Registered(BaseEvent):
+    user_id: Identifier(identifier=True)
+    email: String()
+    name: String()
+
+
 class User(BaseAggregate):
     user_id: Identifier(identifier=True)
     email: String()
     name: String()
 
-
-class Registered(BaseEvent):
-    user_id: Identifier(identifier=True)
-    email: String()
-    name: String()
+    @apply
+    def on_registered(self, event: Registered) -> None:
+        self.user_id = event.user_id
+        self.email = event.email
+        self.name = event.name
 
 
 @pytest.fixture(autouse=True)

--- a/tests/event/test_raising_events.py
+++ b/tests/event/test_raising_events.py
@@ -2,10 +2,15 @@ from uuid import uuid4
 
 import pytest
 
+from protean import apply
 from protean.core.aggregate import BaseAggregate
 from protean.core.event import BaseEvent
 from protean.fields import String
 from protean.fields.basic import Identifier
+
+
+class UserLoggedIn(BaseEvent):
+    user_id: Identifier(identifier=True)
 
 
 class User(BaseAggregate):
@@ -13,9 +18,9 @@ class User(BaseAggregate):
     email: String()
     name: String()
 
-
-class UserLoggedIn(BaseEvent):
-    user_id: Identifier(identifier=True)
+    @apply
+    def on_logged_in(self, event: UserLoggedIn) -> None:
+        pass
 
 
 @pytest.mark.eventstore

--- a/tests/event_sourced_aggregates/events/test_event_es_metadata_id_and_sequence.py
+++ b/tests/event_sourced_aggregates/events/test_event_es_metadata_id_and_sequence.py
@@ -2,10 +2,14 @@ from uuid import uuid4
 
 import pytest
 
-from protean.core.aggregate import BaseAggregate
+from protean.core.aggregate import BaseAggregate, apply
 from protean.core.event import BaseEvent
 from protean.fields import String
 from protean.fields.basic import Identifier
+
+
+class UserLoggedIn(BaseEvent):
+    user_id: Identifier(identifier=True)
 
 
 class User(BaseAggregate):
@@ -16,9 +20,9 @@ class User(BaseAggregate):
     def login(self):
         self.raise_(UserLoggedIn(user_id=self.id))
 
-
-class UserLoggedIn(BaseEvent):
-    user_id: Identifier(identifier=True)
+    @apply
+    def on_logged_in(self, event: UserLoggedIn):
+        pass
 
 
 @pytest.fixture(autouse=True)

--- a/tests/event_sourced_aggregates/events/test_fact_event_generation.py
+++ b/tests/event_sourced_aggregates/events/test_fact_event_generation.py
@@ -22,6 +22,7 @@ class User(BaseAggregate):
 
     @apply
     def registered(self, event: Registered) -> None:
+        self.id = event.id
         self.email = event.email
         self.name = event.name
 

--- a/tests/event_sourced_aggregates/test_expected_version_error.py
+++ b/tests/event_sourced_aggregates/test_expected_version_error.py
@@ -50,7 +50,10 @@ class User(BaseAggregate):
         self.raise_(UserRenamed(user_id=self.user_id, name=name))
 
     @apply
-    def registered(self, _: UserRegistered):
+    def registered(self, event: UserRegistered):
+        self.user_id = event.user_id
+        self.name = event.name
+        self.email = event.email
         self.status = UserStatus.INACTIVE.value
 
     @apply

--- a/tests/event_sourced_aggregates/test_generated_event_version.py
+++ b/tests/event_sourced_aggregates/test_generated_event_version.py
@@ -47,7 +47,10 @@ class User(BaseAggregate):
         self.raise_(UserRenamed(user_id=self.user_id, name=name))
 
     @apply
-    def registered(self, _: UserRegistered):
+    def registered(self, event: UserRegistered):
+        self.user_id = event.user_id
+        self.name = event.name
+        self.email = event.email
         self.status = UserStatus.INACTIVE.value
 
     @apply

--- a/tests/event_sourced_aggregates/test_initialization_from_events.py
+++ b/tests/event_sourced_aggregates/test_initialization_from_events.py
@@ -36,6 +36,9 @@ class User(BaseAggregate):
 
     @apply
     def registered(self, event: UserRegistered):
+        self.user_id = event.user_id
+        self.name = event.name
+        self.email = event.email
         self.status = "INACTIVE"
 
     def activate(self):

--- a/tests/event_sourced_aggregates/test_multi_level_aggregate_persistence.py
+++ b/tests/event_sourced_aggregates/test_multi_level_aggregate_persistence.py
@@ -75,9 +75,26 @@ class University(BaseAggregate):
 
     @apply
     def on_university_created(self, event: UniversityCreated):
-        # We are not doing anything here, because Protean applies
-        #   the first event automatically, with from_events
-        pass
+        self.id = event.id
+        self.name = event.name
+        departments = []
+        for dept_vo in event.departments or []:
+            dean_vo = dept_vo.dean
+            office = None
+            dean = None
+            if dean_vo:
+                if dean_vo.office:
+                    office = Office(
+                        building=dean_vo.office.building,
+                        room=dean_vo.office.room,
+                    )
+                dean = Dean(
+                    name=dean_vo.name,
+                    age=dean_vo.age,
+                    office=office,
+                )
+            departments.append(Department(name=dept_vo.name, dean=dean))
+        self.departments = departments
 
     @apply
     def on_name_changed(self, event: NameChanged):

--- a/tests/event_sourced_aggregates/test_raise_apply_integration.py
+++ b/tests/event_sourced_aggregates/test_raise_apply_integration.py
@@ -1,0 +1,569 @@
+"""Regression tests for the raise_() → @apply integration.
+
+Validates the core ES invariant: raise_() calls @apply handlers so they
+are the single source of truth for state mutations. Also tests
+_create_for_reconstitution(), _create_new(), and the simplified from_events().
+"""
+
+from enum import Enum
+from uuid import uuid4
+
+import pytest
+
+from protean.core.aggregate import BaseAggregate, apply
+from protean.core.entity import BaseEntity
+from protean.core.event import BaseEvent
+from protean.core.value_object import BaseValueObject
+from protean.fields import Float, HasMany, Identifier, String, ValueObject
+
+
+# ---------------------------------------------------------------------------
+# Test aggregates
+# ---------------------------------------------------------------------------
+class UserStatus(Enum):
+    ACTIVE = "ACTIVE"
+    INACTIVE = "INACTIVE"
+
+
+class UserRegistered(BaseEvent):
+    user_id: Identifier(required=True)
+    name: String(max_length=50, required=True)
+    email: String(required=True)
+
+
+class UserActivated(BaseEvent):
+    user_id: Identifier(required=True)
+
+
+class UserRenamed(BaseEvent):
+    user_id: Identifier(required=True)
+    name: String(required=True, max_length=50)
+
+
+class User(BaseAggregate):
+    user_id: Identifier(identifier=True)
+    name: String(max_length=50, required=True)
+    email: String(required=True)
+    status: String(choices=UserStatus)
+
+    @classmethod
+    def register(cls, user_id, name, email):
+        user = cls._create_new(user_id=user_id)
+        user.raise_(UserRegistered(user_id=user_id, name=name, email=email))
+        return user
+
+    def activate(self):
+        self.raise_(UserActivated(user_id=self.user_id))
+
+    def change_name(self, name):
+        self.raise_(UserRenamed(user_id=self.user_id, name=name))
+
+    @apply
+    def registered(self, event: UserRegistered):
+        self.user_id = event.user_id
+        self.name = event.name
+        self.email = event.email
+        self.status = UserStatus.INACTIVE.value
+
+    @apply
+    def activated(self, event: UserActivated):
+        self.status = UserStatus.ACTIVE.value
+
+    @apply
+    def renamed(self, event: UserRenamed):
+        self.name = event.name
+
+
+# Aggregate with event shape != constructor shape (no matching required fields)
+class AccountOpened(BaseEvent):
+    account_number: String(required=True)
+    holder_name: String(required=True)
+    initial_balance: Float(required=True)
+
+
+class DepositMade(BaseEvent):
+    account_number: String(required=True)
+    amount: Float(required=True)
+
+
+class Account(BaseAggregate):
+    account_number: String(identifier=True)
+    holder_name: String(required=True)
+    balance: Float(default=0.0)
+
+    @classmethod
+    def open(cls, account_number, holder_name, initial_balance):
+        account = cls._create_new(account_number=account_number)
+        account.raise_(
+            AccountOpened(
+                account_number=account_number,
+                holder_name=holder_name,
+                initial_balance=initial_balance,
+            )
+        )
+        return account
+
+    def deposit(self, amount):
+        self.raise_(DepositMade(account_number=self.account_number, amount=amount))
+
+    @apply
+    def on_opened(self, event: AccountOpened):
+        self.account_number = event.account_number
+        self.holder_name = event.holder_name
+        self.balance = event.initial_balance
+
+    @apply
+    def on_deposit(self, event: DepositMade):
+        self.balance = (self.balance or 0.0) + event.amount
+
+
+# Aggregate with ValueObject field (for VO shadow field reconstitution coverage)
+class Address(BaseValueObject):
+    street: String(max_length=100)
+    city: String(max_length=50)
+
+
+class PersonCreated(BaseEvent):
+    person_id: Identifier(required=True)
+    name: String(required=True)
+    street: String()
+    city: String()
+
+
+class Person(BaseAggregate):
+    person_id: Identifier(identifier=True)
+    name: String(required=True)
+    address: ValueObject(Address)
+
+    @classmethod
+    def create(cls, person_id, name, street=None, city=None):
+        person = cls._create_new(person_id=person_id)
+        person.raise_(
+            PersonCreated(person_id=person_id, name=name, street=street, city=city)
+        )
+        return person
+
+    @apply
+    def on_created(self, event: PersonCreated):
+        self.person_id = event.person_id
+        self.name = event.name
+        if event.street and event.city:
+            self.address = Address(street=event.street, city=event.city)
+
+
+# Aggregate with HasMany field (for association reconstitution coverage)
+class LineItem(BaseEntity):
+    product_name: String(max_length=100)
+    quantity: Float(default=1.0)
+
+
+class OrderPlaced(BaseEvent):
+    order_id: Identifier(required=True)
+    customer: String(required=True)
+
+
+class ItemAdded(BaseEvent):
+    order_id: Identifier(required=True)
+    product_name: String(required=True)
+    quantity: Float(required=True)
+
+
+class Order(BaseAggregate):
+    order_id: Identifier(identifier=True)
+    customer: String(required=True)
+    items: HasMany(LineItem)
+
+    @classmethod
+    def place(cls, order_id, customer):
+        order = cls._create_new(order_id=order_id)
+        order.raise_(OrderPlaced(order_id=order_id, customer=customer))
+        return order
+
+    def add_item(self, product_name, quantity):
+        self.raise_(
+            ItemAdded(
+                order_id=self.order_id,
+                product_name=product_name,
+                quantity=quantity,
+            )
+        )
+
+    @apply
+    def on_placed(self, event: OrderPlaced):
+        self.order_id = event.order_id
+        self.customer = event.customer
+
+    @apply
+    def on_item_added(self, event: ItemAdded):
+        self.add_items(
+            LineItem(product_name=event.product_name, quantity=event.quantity)
+        )
+
+
+# Aggregate with two @apply handlers for the same event (for double-increment test)
+class ItemCreated(BaseEvent):
+    item_id: Identifier(required=True)
+    name: String(required=True)
+
+
+class Item(BaseAggregate):
+    item_id: Identifier(identifier=True)
+    name: String(required=True)
+    audit_log: String(default="")
+
+    @apply
+    def on_created_set_fields(self, event: ItemCreated):
+        self.item_id = event.item_id
+        self.name = event.name
+
+    @apply
+    def on_created_set_audit(self, event: ItemCreated):
+        self.audit_log = f"created:{event.name}"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+@pytest.fixture(autouse=True)
+def register_elements(test_domain):
+    test_domain.register(User, is_event_sourced=True)
+    test_domain.register(UserRegistered, part_of=User)
+    test_domain.register(UserActivated, part_of=User)
+    test_domain.register(UserRenamed, part_of=User)
+    test_domain.register(Account, is_event_sourced=True)
+    test_domain.register(AccountOpened, part_of=Account)
+    test_domain.register(DepositMade, part_of=Account)
+    test_domain.register(Item, is_event_sourced=True)
+    test_domain.register(ItemCreated, part_of=Item)
+    test_domain.register(Person, is_event_sourced=True)
+    test_domain.register(PersonCreated, part_of=Person)
+    test_domain.register(Order, is_event_sourced=True)
+    test_domain.register(LineItem, part_of=Order)
+    test_domain.register(OrderPlaced, part_of=Order)
+    test_domain.register(ItemAdded, part_of=Order)
+    test_domain.init(traverse=False)
+
+
+# ---------------------------------------------------------------------------
+# Test: raise_() applies state immediately for ES aggregates
+# ---------------------------------------------------------------------------
+class TestRaiseAppliesState:
+    def test_raise_applies_state_immediately(self):
+        """After raise_(), the aggregate's in-memory state reflects
+        the @apply handler — not just whatever the business method set."""
+        user = User.register(user_id=str(uuid4()), name="John", email="j@example.com")
+        assert user.name == "John"
+        assert user.email == "j@example.com"
+        assert user.status == UserStatus.INACTIVE.value
+
+    def test_raise_applies_subsequent_events(self):
+        """Subsequent raise_() calls also apply handlers."""
+        user = User.register(user_id=str(uuid4()), name="John", email="j@example.com")
+        user.activate()
+        assert user.status == UserStatus.ACTIVE.value
+
+        user.change_name("Jane")
+        assert user.name == "Jane"
+
+    def test_create_new_produces_valid_aggregate(self):
+        """_create_new() yields an aggregate with identity but no other state."""
+        uid = str(uuid4())
+        user = User._create_new(user_id=uid)
+        assert user.user_id == uid
+        assert user.name is None  # Not yet set — no event applied
+
+
+# ---------------------------------------------------------------------------
+# Test: live vs replay state equivalence
+# ---------------------------------------------------------------------------
+class TestLiveReplayEquivalence:
+    def test_live_and_replay_produce_identical_state(self):
+        """Aggregate created via factory must match one reconstructed
+        from the same events via from_events()."""
+        live = User.register(user_id=str(uuid4()), name="John", email="j@example.com")
+        live.activate()
+        live.change_name("Jane")
+
+        replayed = User.from_events(live._events)
+
+        assert replayed.user_id == live.user_id
+        assert replayed.name == live.name
+        assert replayed.email == live.email
+        assert replayed.status == live.status
+        assert replayed._version == live._version
+
+    def test_equivalence_with_single_event(self):
+        """Works even with just the creation event."""
+        live = User.register(
+            user_id=str(uuid4()), name="Alice", email="alice@example.com"
+        )
+
+        replayed = User.from_events(live._events)
+
+        assert replayed.user_id == live.user_id
+        assert replayed.name == live.name
+        assert replayed.status == live.status
+
+
+# ---------------------------------------------------------------------------
+# Test: from_events() works without constructor constraint
+# ---------------------------------------------------------------------------
+class TestFromEventsDecoupled:
+    def test_from_events_does_not_require_matching_constructor(self):
+        """First event can have fields that don't match aggregate's
+        required constructor parameters. AccountOpened has initial_balance
+        but Account's constructor requires holder_name — from_events()
+        bypasses the constructor entirely."""
+        account = Account.open("ACC-001", "Alice", 1000.0)
+
+        # Reconstruct purely from events
+        replayed = Account.from_events(account._events)
+
+        assert replayed.account_number == "ACC-001"
+        assert replayed.holder_name == "Alice"
+        assert replayed.balance == 1000.0
+
+    def test_from_events_handles_multiple_events(self):
+        """Reconstruction handles creation + subsequent events."""
+        account = Account.open("ACC-002", "Bob", 500.0)
+        account.deposit(250.0)
+        account.deposit(100.0)
+
+        replayed = Account.from_events(account._events)
+
+        assert replayed.balance == 850.0
+        assert replayed._version == 2  # 3 events → versions 0, 1, 2
+
+
+# ---------------------------------------------------------------------------
+# Test: version increments once per event, not per projection
+# ---------------------------------------------------------------------------
+class TestVersionPerEvent:
+    def test_version_increments_once_per_event_not_per_projection(self):
+        """Regression: old _apply() had version++ inside the for-loop
+        over projection functions, which would double-increment if an
+        event had two handlers registered.
+
+        The Item aggregate has TWO @apply handlers for ItemCreated.
+        After applying one event via from_events, _version must be 0
+        (not 1, which would happen with double-increment)."""
+        item_id = str(uuid4())
+        event = ItemCreated(item_id=item_id, name="Widget")
+
+        # Apply single event via from_events
+        item = Item.from_events([event])
+
+        assert item.name == "Widget"
+        assert item.audit_log == "created:Widget"
+        assert item._version == 0  # One event → version 0
+
+    def test_version_correct_after_raise(self):
+        """Version is also correct on the live path via raise_()."""
+        item = Item._create_new(item_id=str(uuid4()))
+        item.raise_(ItemCreated(item_id=str(item.item_id), name="Gadget"))
+
+        # raise_() increments version once
+        assert item._version == 0
+
+    def test_version_correct_through_multiple_events(self):
+        """Version tracks correctly through multiple events."""
+        user = User.register(user_id=str(uuid4()), name="John", email="j@example.com")
+        assert user._version == 0
+
+        user.activate()
+        assert user._version == 1
+
+        user.change_name("Jane")
+        assert user._version == 2
+
+        # Replay should produce same version
+        replayed = User.from_events(user._events)
+        assert replayed._version == 2
+
+
+# ---------------------------------------------------------------------------
+# Test: event store round-trip
+# ---------------------------------------------------------------------------
+class TestEventStoreRoundTrip:
+    @pytest.mark.eventstore
+    def test_create_persist_reload_produces_identical_state(self, test_domain):
+        """Create → persist → reload produces identical aggregate state."""
+        user = User.register(user_id=str(uuid4()), name="John", email="j@example.com")
+        user.activate()
+        user.change_name("Jane")
+
+        test_domain.repository_for(User).add(user)
+
+        loaded = test_domain.repository_for(User).get(user.user_id)
+
+        assert loaded.user_id == user.user_id
+        assert loaded.name == user.name
+        assert loaded.email == user.email
+        assert loaded.status == user.status
+        assert loaded._version == user._version
+
+
+# ---------------------------------------------------------------------------
+# Test: _create_new() with auto-generated identity
+# ---------------------------------------------------------------------------
+class TestCreateNewAutoIdentity:
+    def test_auto_generates_identity_when_not_provided(self):
+        """_create_new() without identity kwargs auto-generates an ID."""
+        user = User._create_new()
+        assert user.user_id is not None
+        assert isinstance(user.user_id, str)
+        assert len(user.user_id) > 0
+
+    def test_auto_identity_is_unique_each_call(self):
+        """Each _create_new() call generates a unique identity."""
+        u1 = User._create_new()
+        u2 = User._create_new()
+        assert u1.user_id != u2.user_id
+
+    def test_auto_identity_can_raise_events(self):
+        """Auto-generated identity works with subsequent raise_()."""
+        user = User._create_new()
+        uid = user.user_id
+        user.raise_(UserRegistered(user_id=uid, name="Auto", email="auto@test.com"))
+        assert user.name == "Auto"
+        assert user.user_id == uid
+
+
+# ---------------------------------------------------------------------------
+# Test: reconstitution with ValueObject fields
+# ---------------------------------------------------------------------------
+class TestReconstitutionWithValueObject:
+    def test_create_for_reconstitution_initializes_vo_shadow_fields(self):
+        """_create_for_reconstitution sets VO shadow fields to None."""
+        person = Person._create_for_reconstitution()
+        # VO shadow fields (address_street, address_city) should be None
+        assert person.address is None
+
+    def test_from_events_with_value_object(self):
+        """from_events correctly reconstructs aggregates with VO fields."""
+        person = Person.create("P-001", "Alice", street="123 Main", city="Springfield")
+
+        replayed = Person.from_events(person._events)
+        assert replayed.person_id == "P-001"
+        assert replayed.name == "Alice"
+        assert replayed.address is not None
+        assert replayed.address.street == "123 Main"
+        assert replayed.address.city == "Springfield"
+
+    def test_from_events_with_none_value_object(self):
+        """from_events handles None VO fields gracefully."""
+        person = Person.create("P-002", "Bob")
+
+        replayed = Person.from_events(person._events)
+        assert replayed.name == "Bob"
+        assert replayed.address is None
+
+
+# ---------------------------------------------------------------------------
+# Test: reconstitution with HasMany fields
+# ---------------------------------------------------------------------------
+class TestReconstitutionWithHasMany:
+    def test_create_for_reconstitution_sets_up_association_methods(self):
+        """_create_for_reconstitution creates add_*/remove_* pseudo-methods."""
+        order = Order._create_for_reconstitution()
+        assert hasattr(order, "add_items")
+        assert hasattr(order, "remove_items")
+        assert hasattr(order, "get_one_from_items")
+        assert hasattr(order, "filter_items")
+
+    def test_raise_with_has_many_child_entities(self):
+        """raise_() + @apply can add child entities via HasMany."""
+        order = Order.place("ORD-001", "Alice")
+        order.add_item("Widget", 3.0)
+        order.add_item("Gadget", 1.0)
+
+        assert order.customer == "Alice"
+        assert len(order.items) == 2
+        assert order.items[0].product_name == "Widget"
+        assert order.items[1].product_name == "Gadget"
+
+    def test_from_events_with_has_many(self):
+        """from_events correctly replays events that add child entities."""
+        order = Order.place("ORD-002", "Bob")
+        order.add_item("Widget", 2.0)
+
+        replayed = Order.from_events(order._events)
+        assert replayed.customer == "Bob"
+        assert len(replayed.items) == 1
+        assert replayed.items[0].product_name == "Widget"
+        assert replayed.items[0].quantity == 2.0
+
+
+# ---------------------------------------------------------------------------
+# Test: backward compatibility with dual-mutation pattern
+# ---------------------------------------------------------------------------
+class TestBackwardCompatibility:
+    def test_dual_mutation_pattern_still_works(self):
+        """Existing code that mutates state directly AND raises events
+        continues to work. The @apply handler overwrites the direct mutation
+        with identical values, so the final state is correct."""
+        uid = str(uuid4())
+        user = User(user_id=uid, name="Initial", email="init@test.com")
+        # Direct mutation + raise_ (the old pattern)
+        user.name = "Direct"
+        user.raise_(UserRenamed(user_id=uid, name="Direct"))
+
+        # @apply handler overwrites name with event.name = "Direct"
+        assert user.name == "Direct"
+
+    def test_non_es_aggregate_unaffected(self, test_domain):
+        """Non-ES aggregates do not invoke @apply on raise_()."""
+
+        class SimpleEvent(BaseEvent):
+            msg: String()
+
+        class Simple(BaseAggregate):
+            msg: String()
+
+        test_domain.register(Simple)
+        test_domain.register(SimpleEvent, part_of=Simple)
+        test_domain.init(traverse=False)
+
+        s = Simple(msg="hello")
+        s.raise_(SimpleEvent(msg="world"))
+
+        # Non-ES: raise_ only appends the event, no @apply call
+        assert s.msg == "hello"  # Not overwritten
+        assert len(s._events) == 1
+
+
+# ---------------------------------------------------------------------------
+# Test: missing @apply handler raises NotImplementedError
+# ---------------------------------------------------------------------------
+class TestMissingApplyHandler:
+    def test_raise_without_handler_raises_error(self, test_domain):
+        """Raising an event with no @apply handler is an error for ES aggregates."""
+
+        class OrphanEvent(BaseEvent):
+            data: String()
+
+        class Orphan(BaseAggregate):
+            data: String()
+
+        test_domain.register(Orphan, is_event_sourced=True)
+        test_domain.register(OrphanEvent, part_of=Orphan)
+        test_domain.init(traverse=False)
+
+        orphan = Orphan(data="test")
+        with pytest.raises(NotImplementedError, match="No handler registered"):
+            orphan.raise_(OrphanEvent(data="boom"))
+
+
+# ---------------------------------------------------------------------------
+# Test: fact events are excluded from @apply
+# ---------------------------------------------------------------------------
+class TestFactEventExclusion:
+    def test_fact_events_do_not_trigger_apply(self):
+        """Fact events (auto-generated state snapshots) are excluded
+        from @apply because they have no handlers."""
+        user = User.register(user_id=str(uuid4()), name="John", email="j@example.com")
+        # Fact events end with "FactEvent" in name — they are auto-generated
+        # by the framework and should not look for @apply handlers.
+        # This is tested implicitly: if fact events tried @apply, they'd
+        # get NotImplementedError since no handler exists for them.
+        assert len(user._events) == 1  # Only the UserRegistered event

--- a/tests/event_sourced_aggregates/test_raising_multiple_events_for_one_aggregate_in_a_uow.py
+++ b/tests/event_sourced_aggregates/test_raising_multiple_events_for_one_aggregate_in_a_uow.py
@@ -41,6 +41,7 @@ class User(BaseAggregate):
 
     @apply
     def registered(self, event: Registered) -> None:
+        self.id = event.id
         self.email = event.email
 
     @apply

--- a/tests/event_sourced_repository/test_add.py
+++ b/tests/event_sourced_repository/test_add.py
@@ -2,7 +2,7 @@ from uuid import uuid4
 
 import pytest
 
-from protean.core.aggregate import BaseAggregate
+from protean.core.aggregate import BaseAggregate, apply
 from protean.core.event import BaseEvent
 from protean.exceptions import IncorrectUsageError
 from protean.fields import Identifier, String
@@ -24,6 +24,12 @@ class User(BaseAggregate):
         user = cls(id=id, name=name, email=email)
         user.raise_(UserRegistered(id=id, name=name, email=email))
         return user
+
+    @apply
+    def on_registered(self, event: UserRegistered):
+        self.id = event.id
+        self.email = event.email
+        self.name = event.name
 
 
 @pytest.fixture(autouse=True)

--- a/tests/event_sourced_repository/test_add_uow.py
+++ b/tests/event_sourced_repository/test_add_uow.py
@@ -1,9 +1,15 @@
 import mock
 import pytest
 
-from protean.core.aggregate import BaseAggregate
+from protean.core.aggregate import BaseAggregate, apply
 from protean.core.event import BaseEvent
 from protean.fields import Identifier, String
+
+
+class Registered(BaseEvent):
+    id: Identifier()
+    email: String()
+    name: String()
 
 
 class User(BaseAggregate):
@@ -11,11 +17,11 @@ class User(BaseAggregate):
     email: String()
     name: String()
 
-
-class Registered(BaseEvent):
-    id: Identifier()
-    email: String()
-    name: String()
+    @apply
+    def on_registered(self, event: Registered):
+        self.id = event.id
+        self.email = event.email
+        self.name = event.name
 
 
 @pytest.fixture(autouse=True)

--- a/tests/event_sourced_repository/test_loading_aggregates.py
+++ b/tests/event_sourced_repository/test_loading_aggregates.py
@@ -72,6 +72,10 @@ class User(BaseAggregate):
 
     @apply
     def registered(self, event: Registered) -> None:
+        self.user_id = event.user_id
+        self.email = event.email
+        self.name = event.name
+        self.password_hash = event.password_hash
         self.is_registered = True
 
     @apply

--- a/tests/event_store/test_appending_events.py
+++ b/tests/event_store/test_appending_events.py
@@ -2,18 +2,22 @@ from uuid import uuid4
 
 import pytest
 
-from protean.core.aggregate import BaseAggregate
+from protean.core.aggregate import BaseAggregate, apply
 from protean.core.event import BaseEvent
 from protean.fields.basic import Identifier
 from protean.utils.eventing import Message
 
 
+class UserLoggedIn(BaseEvent):
+    user_id = Identifier(identifier=True)
+
+
 class User(BaseAggregate):
     user_id = Identifier(identifier=True)
 
-
-class UserLoggedIn(BaseEvent):
-    user_id = Identifier(identifier=True)
+    @apply
+    def on_logged_in(self, event: UserLoggedIn):
+        pass
 
 
 @pytest.mark.eventstore

--- a/tests/event_store/test_reading_messages.py
+++ b/tests/event_store/test_reading_messages.py
@@ -2,16 +2,11 @@ from uuid import uuid4
 
 import pytest
 
-from protean.core.aggregate import BaseAggregate
+from protean.core.aggregate import BaseAggregate, apply
 from protean.core.event import BaseEvent
 from protean.fields import String
 from protean.fields.basic import Identifier
 from protean.utils.eventing import Message
-
-
-class User(BaseAggregate):
-    email = String()
-    name = String(max_length=50)
 
 
 class Registered(BaseEvent):
@@ -26,6 +21,24 @@ class Activated(BaseEvent):
 class Renamed(BaseEvent):
     id = Identifier(required=True)
     name = String(required=True, max_length=50)
+
+
+class User(BaseAggregate):
+    email = String()
+    name = String(max_length=50)
+
+    @apply
+    def on_registered(self, event: Registered):
+        self.id = event.id
+        self.email = event.email
+
+    @apply
+    def on_activated(self, event: Activated):
+        pass
+
+    @apply
+    def on_renamed(self, event: Renamed):
+        self.name = event.name
 
 
 @pytest.fixture(autouse=True)

--- a/tests/event_store/test_snapshotting.py
+++ b/tests/event_store/test_snapshotting.py
@@ -50,6 +50,9 @@ class User(BaseAggregate):
 
     @apply
     def registered(self, event: UserRegistered):
+        self.user_id = event.user_id
+        self.name = event.name
+        self.email = event.email
         self.status = UserStatus.INACTIVE.value
 
     @apply

--- a/tests/message/test_message_error_handling.py
+++ b/tests/message/test_message_error_handling.py
@@ -2,6 +2,7 @@ from uuid import uuid4
 
 import pytest
 
+from protean import apply
 from protean.core.aggregate import BaseAggregate
 from protean.core.command import BaseCommand
 from protean.core.event import BaseEvent
@@ -15,11 +16,6 @@ from protean.utils.eventing import (
     Metadata,
     EventStoreMeta,
 )
-
-
-class User(BaseAggregate):
-    email: String()
-    name: String()
 
 
 class Register(BaseCommand):
@@ -39,6 +35,16 @@ class UnregisteredEvent(BaseEvent):
 
     id: Identifier()
     data: String()
+
+
+class User(BaseAggregate):
+    email: String()
+    name: String()
+
+    @apply
+    def on_registered(self, event: Registered) -> None:
+        self.email = event.email
+        self.name = event.name
 
 
 @pytest.fixture(autouse=True)

--- a/tests/message/test_message_format_versioning.py
+++ b/tests/message/test_message_format_versioning.py
@@ -2,6 +2,7 @@ from uuid import uuid4
 
 import pytest
 
+from protean import apply
 from protean.core.aggregate import BaseAggregate
 from protean.core.command import BaseCommand
 from protean.core.event import BaseEvent
@@ -15,11 +16,6 @@ from protean.utils.eventing import (
 )
 
 
-class User(BaseAggregate):
-    email: String()
-    name: String()
-
-
 class Register(BaseCommand):
     id: Identifier(identifier=True)
     email: String()
@@ -30,6 +26,16 @@ class Registered(BaseEvent):
     id: Identifier(identifier=True)
     email: String()
     name: String()
+
+
+class User(BaseAggregate):
+    email: String()
+    name: String()
+
+    @apply
+    def on_registered(self, event: Registered) -> None:
+        self.email = event.email
+        self.name = event.name
 
 
 @pytest.fixture(autouse=True)

--- a/tests/message/test_message_headers.py
+++ b/tests/message/test_message_headers.py
@@ -2,6 +2,7 @@ from uuid import uuid4
 
 import pytest
 
+from protean import apply
 from protean.core.aggregate import BaseAggregate
 from protean.core.event import BaseEvent
 from protean.core.command import BaseCommand
@@ -17,11 +18,6 @@ from protean.utils.eventing import (
 )
 
 
-class User(BaseAggregate):
-    email: String()
-    name: String()
-
-
 class Register(BaseCommand):
     id: Identifier(identifier=True)
     email: String()
@@ -32,6 +28,16 @@ class Registered(BaseEvent):
     id: Identifier(identifier=True)
     email: String()
     name: String()
+
+
+class User(BaseAggregate):
+    email: String()
+    name: String()
+
+    @apply
+    def on_registered(self, event: Registered) -> None:
+        self.email = event.email
+        self.name = event.name
 
 
 @pytest.fixture(autouse=True)

--- a/tests/message/test_message_integrity.py
+++ b/tests/message/test_message_integrity.py
@@ -2,6 +2,7 @@ from uuid import uuid4
 
 import pytest
 
+from protean import apply
 from protean.core.aggregate import BaseAggregate
 from protean.core.command import BaseCommand
 from protean.core.event import BaseEvent
@@ -9,11 +10,6 @@ from protean.exceptions import DeserializationError
 from protean.fields import Identifier, String
 from protean.utils.eventing import Message, MessageEnvelope, MessageHeaders
 from protean.utils.eventing import Metadata, DomainMeta, EventStoreMeta
-
-
-class User(BaseAggregate):
-    email: String()
-    name: String()
 
 
 class Register(BaseCommand):
@@ -26,6 +22,16 @@ class Registered(BaseEvent):
     id: Identifier(identifier=True)
     email: String()
     name: String()
+
+
+class User(BaseAggregate):
+    email: String()
+    name: String()
+
+    @apply
+    def on_registered(self, event: Registered) -> None:
+        self.email = event.email
+        self.name = event.name
 
 
 @pytest.fixture(autouse=True)

--- a/tests/message/test_message_to_object.py
+++ b/tests/message/test_message_to_object.py
@@ -3,17 +3,13 @@ from uuid import uuid4
 
 import pytest
 
+from protean import apply
 from protean.core.aggregate import BaseAggregate
 from protean.core.command import BaseCommand
 from protean.core.event import BaseEvent
 from protean.exceptions import InvalidDataError, DeserializationError
 from protean.fields import Identifier, String
 from protean.utils.eventing import Message, Metadata, DomainMeta, MessageHeaders
-
-
-class User(BaseAggregate):
-    email: String()
-    name: String()
 
 
 class Register(BaseCommand):
@@ -30,6 +26,16 @@ class Registered(BaseEvent):
     id: Identifier()
     email: String()
     name: String()
+
+
+class User(BaseAggregate):
+    email: String()
+    name: String()
+
+    @apply
+    def on_registered(self, event: Registered) -> None:
+        self.email = event.email
+        self.name = event.name
 
 
 class SendEmail(BaseAggregate):

--- a/tests/message/test_object_to_message.py
+++ b/tests/message/test_object_to_message.py
@@ -2,17 +2,13 @@ from uuid import UUID, uuid4
 
 import pytest
 
+from protean import apply
 from protean.core.aggregate import BaseAggregate
 from protean.core.command import BaseCommand
 from protean.core.event import BaseEvent
 from protean.exceptions import ConfigurationError
 from protean.fields import Identifier, String
 from protean.utils.eventing import Message
-
-
-class User(BaseAggregate):
-    email: String()
-    name: String()
 
 
 class Register(BaseCommand):
@@ -29,6 +25,16 @@ class Registered(BaseEvent):
     id: Identifier(identifier=True)
     email: String()
     name: String()
+
+
+class User(BaseAggregate):
+    email: String()
+    name: String()
+
+    @apply
+    def on_registered(self, event: Registered) -> None:
+        self.email = event.email
+        self.name = event.name
 
 
 class SendEmail(BaseAggregate):

--- a/tests/message/test_origin_stream_name_in_metadata.py
+++ b/tests/message/test_origin_stream_name_in_metadata.py
@@ -2,6 +2,7 @@ from uuid import uuid4
 
 import pytest
 
+from protean import apply
 from protean.core.aggregate import BaseAggregate
 from protean.core.command import BaseCommand
 from protean.core.event import BaseEvent
@@ -9,12 +10,6 @@ from protean.fields import String
 from protean.fields.basic import Identifier
 from protean.utils.globals import g
 from protean.utils.eventing import DomainMeta, Message, Metadata
-
-
-class User(BaseAggregate):
-    id: Identifier(identifier=True)
-    email: String()
-    name: String()
 
 
 class Register(BaseCommand):
@@ -27,6 +22,17 @@ class Registered(BaseEvent):
     user_id: Identifier(identifier=True)
     email: String()
     name: String()
+
+
+class User(BaseAggregate):
+    id: Identifier(identifier=True)
+    email: String()
+    name: String()
+
+    @apply
+    def on_registered(self, event: Registered) -> None:
+        self.email = event.email
+        self.name = event.name
 
 
 @pytest.fixture(autouse=True)

--- a/tests/server/observability/test_engine_instrumentation.py
+++ b/tests/server/observability/test_engine_instrumentation.py
@@ -14,6 +14,7 @@ from protean.core.command import BaseCommand
 from protean.core.command_handler import BaseCommandHandler
 from protean.core.event import BaseEvent
 from protean.core.event_handler import BaseEventHandler
+from protean import apply
 from protean.fields import Identifier, String
 from protean.server import Engine
 from protean.server.engine import CommandDispatcher
@@ -23,12 +24,6 @@ from protean.utils.mixins import handle
 
 
 # Domain elements for testing
-class User(BaseAggregate):
-    id: Identifier(identifier=True)
-    email: String()
-    name: String()
-
-
 class Registered(BaseEvent):
     id: Identifier()
     email: String()
@@ -37,6 +32,16 @@ class Registered(BaseEvent):
 class Register(BaseCommand):
     user_id: Identifier()
     email: String()
+
+
+class User(BaseAggregate):
+    id: Identifier(identifier=True)
+    email: String()
+    name: String()
+
+    @apply
+    def on_registered(self, event: Registered) -> None:
+        self.email = event.email
 
 
 handler_calls = []

--- a/tests/server/test_any_event_handler.py
+++ b/tests/server/test_any_event_handler.py
@@ -5,6 +5,7 @@ import pytest
 from protean.core.aggregate import BaseAggregate
 from protean.core.event import BaseEvent
 from protean.core.event_handler import BaseEventHandler
+from protean import apply
 from protean.fields import Identifier, String
 from protean.server import Engine
 from protean.utils.eventing import Message
@@ -18,17 +19,23 @@ def count_up():
     counter += 1
 
 
-class User(BaseAggregate):
-    email: String()
-    name: String()
-    password_hash: String()
-
-
 class Registered(BaseEvent):
     id: Identifier()
     email: String()
     name: String()
     password_hash: String()
+
+
+class User(BaseAggregate):
+    email: String()
+    name: String()
+    password_hash: String()
+
+    @apply
+    def on_registered(self, event: Registered) -> None:
+        self.email = event.email
+        self.name = event.name
+        self.password_hash = event.password_hash
 
 
 class UserEventHandler(BaseEventHandler):

--- a/tests/server/test_error_handling.py
+++ b/tests/server/test_error_handling.py
@@ -5,6 +5,7 @@ import pytest
 from protean.core.aggregate import BaseAggregate
 from protean.core.event import BaseEvent
 from protean.core.event_handler import BaseEventHandler
+from protean import apply
 from protean.fields import Identifier, String
 from protean.server import Engine
 from protean.utils import Processing
@@ -12,17 +13,23 @@ from protean.utils.eventing import Message
 from protean.utils.mixins import handle
 
 
-class User(BaseAggregate):
-    email: String()
-    name: String()
-    password_hash: String()
-
-
 class Registered(BaseEvent):
     id: Identifier()
     email: String()
     name: String()
     password_hash: String()
+
+
+class User(BaseAggregate):
+    email: String()
+    name: String()
+    password_hash: String()
+
+    @apply
+    def on_registered(self, event: Registered) -> None:
+        self.email = event.email
+        self.name = event.name
+        self.password_hash = event.password_hash
 
 
 def some_function():

--- a/tests/server/test_event_handling.py
+++ b/tests/server/test_event_handling.py
@@ -5,6 +5,7 @@ import pytest
 from protean.core.aggregate import BaseAggregate
 from protean.core.event import BaseEvent
 from protean.core.event_handler import BaseEventHandler
+from protean import apply
 from protean.fields import Identifier, String
 from protean.server import Engine
 from protean.utils import Processing
@@ -14,17 +15,23 @@ from protean.utils.mixins import handle
 counter = 0
 
 
-class User(BaseAggregate):
-    email = String()
-    name = String()
-    password_hash = String()
-
-
 class Registered(BaseEvent):
     id = Identifier()
     email = String()
     name = String()
     password_hash = String()
+
+
+class User(BaseAggregate):
+    email = String()
+    name = String()
+    password_hash = String()
+
+    @apply
+    def on_registered(self, event: Registered) -> None:
+        self.email = event.email
+        self.name = event.name
+        self.password_hash = event.password_hash
 
 
 def count_up():

--- a/tests/server/test_handle_error.py
+++ b/tests/server/test_handle_error.py
@@ -8,6 +8,7 @@ from protean.core.command_handler import BaseCommandHandler
 from protean.core.event import BaseEvent
 from protean.core.event_handler import BaseEventHandler
 from protean.core.subscriber import BaseSubscriber
+from protean import apply
 from protean.fields import Identifier, String
 from protean.server import Engine
 from protean.utils import Processing
@@ -35,12 +36,6 @@ def reset_counters():
     broker_error_handler_counter = 0
 
 
-class User(BaseAggregate):
-    email: String()
-    name: String()
-    password_hash: String()
-
-
 class Registered(BaseEvent):
     id: Identifier()
     email: String()
@@ -52,6 +47,18 @@ class Register(BaseCommand):
     email: String()
     name: String()
     password_hash: String()
+
+
+class User(BaseAggregate):
+    email: String()
+    name: String()
+    password_hash: String()
+
+    @apply
+    def on_registered(self, event: Registered) -> None:
+        self.email = event.email
+        self.name = event.name
+        self.password_hash = event.password_hash
 
 
 class NormalEventHandler(BaseEventHandler):

--- a/tests/server/test_handling_all_events.py
+++ b/tests/server/test_handling_all_events.py
@@ -5,6 +5,7 @@ import pytest
 from protean.core.aggregate import BaseAggregate
 from protean.core.event import BaseEvent
 from protean.core.event_handler import BaseEventHandler
+from protean import apply
 from protean.fields import Identifier, String, Text
 from protean.server import Engine
 from protean.utils.eventing import Message
@@ -18,12 +19,6 @@ def count_up():
     counter += 1
 
 
-class User(BaseAggregate):
-    email: String()
-    name: String()
-    password_hash: String()
-
-
 class Registered(BaseEvent):
     id: Identifier()
     email: String()
@@ -31,15 +26,32 @@ class Registered(BaseEvent):
     password_hash: String()
 
 
-class Post(BaseAggregate):
-    topic: String()
-    content: Text()
+class User(BaseAggregate):
+    email: String()
+    name: String()
+    password_hash: String()
+
+    @apply
+    def on_registered(self, event: Registered) -> None:
+        self.email = event.email
+        self.name = event.name
+        self.password_hash = event.password_hash
 
 
 class Created(BaseEvent):
     id: Identifier(identifier=True)
     topic: String()
     content: Text()
+
+
+class Post(BaseAggregate):
+    topic: String()
+    content: Text()
+
+    @apply
+    def on_created(self, event: Created) -> None:
+        self.topic = event.topic
+        self.content = event.content
 
 
 class SystemMetrics(BaseEventHandler):

--- a/tests/server/test_subscription_error_handling.py
+++ b/tests/server/test_subscription_error_handling.py
@@ -4,6 +4,7 @@ from protean.core.aggregate import BaseAggregate
 from protean.core.event import BaseEvent
 from protean.core.event_handler import BaseEventHandler
 from protean.core.subscriber import BaseSubscriber
+from protean import apply
 from protean.fields import Identifier, String
 from protean.server import Engine
 from protean.utils import Processing
@@ -23,15 +24,20 @@ def reset_counters():
     error_handler_error_counter = 0
 
 
-class User(BaseAggregate):
-    email: String()
-    name: String()
-
-
 class Registered(BaseEvent):
     id: Identifier()
     email: String()
     name: String()
+
+
+class User(BaseAggregate):
+    email: String()
+    name: String()
+
+    @apply
+    def on_registered(self, event: Registered) -> None:
+        self.email = event.email
+        self.name = event.name
 
 
 # Test Event Handlers

--- a/tests/subscription/test_message_filtering_with_origin_stream.py
+++ b/tests/subscription/test_message_filtering_with_origin_stream.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 import mock
 import pytest
 
-from protean.core.aggregate import BaseAggregate
+from protean.core.aggregate import BaseAggregate, apply
 from protean.core.event import BaseEvent, Metadata
 from protean.core.event_handler import BaseEventHandler
 from protean.fields import DateTime, Identifier, String
@@ -12,17 +12,6 @@ from protean.server import Engine
 from protean.utils import fqn
 from protean.utils.eventing import Message
 from protean.utils.mixins import handle
-
-
-class User(BaseAggregate):
-    email = String()
-    name = String()
-    password_hash = String()
-
-
-class Email(BaseAggregate):
-    email = String()
-    sent_at = DateTime()
 
 
 def dummy(*args):
@@ -44,6 +33,33 @@ class Activated(BaseEvent):
 class Sent(BaseEvent):
     email = String()
     sent_at = DateTime()
+
+
+class User(BaseAggregate):
+    email = String()
+    name = String()
+    password_hash = String()
+
+    @apply
+    def on_registered(self, event: Registered) -> None:
+        self.id = event.id
+        self.email = event.email
+        self.name = event.name
+        self.password_hash = event.password_hash
+
+    @apply
+    def on_activated(self, event: Activated) -> None:
+        pass
+
+
+class Email(BaseAggregate):
+    email = String()
+    sent_at = DateTime()
+
+    @apply
+    def on_sent(self, event: Sent) -> None:
+        self.email = event.email
+        self.sent_at = event.sent_at
 
 
 class UserEventHandler(BaseEventHandler):

--- a/tests/subscription/test_message_handover_to_engine.py
+++ b/tests/subscription/test_message_handover_to_engine.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 import mock
 import pytest
 
-from protean.core.aggregate import BaseAggregate
+from protean.core.aggregate import BaseAggregate, apply
 from protean.core.event import BaseEvent
 from protean.core.event_handler import BaseEventHandler
 from protean.fields import Identifier, String
@@ -36,6 +36,13 @@ class User(BaseAggregate):
         )
 
         return user
+
+    @apply
+    def on_registered(self, event: Registered) -> None:
+        self.id = event.id
+        self.email = event.email
+        self.name = event.name
+        self.password_hash = event.password_hash
 
 
 def count_up():

--- a/tests/subscription/test_no_message_filtering.py
+++ b/tests/subscription/test_no_message_filtering.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 import mock
 import pytest
 
-from protean.core.aggregate import BaseAggregate
+from protean.core.aggregate import BaseAggregate, apply
 from protean.core.event import BaseEvent, Metadata
 from protean.core.event_handler import BaseEventHandler
 from protean.fields import DateTime, Identifier, String
@@ -12,17 +12,6 @@ from protean.server import Engine
 from protean.utils import fqn
 from protean.utils.eventing import Message
 from protean.utils.mixins import handle
-
-
-class User(BaseAggregate):
-    email = String()
-    name = String()
-    password_hash = String()
-
-
-class Email(BaseAggregate):
-    email = String()
-    sent_at = DateTime()
 
 
 def dummy(*args):
@@ -44,6 +33,33 @@ class Activated(BaseEvent):
 class Sent(BaseEvent):
     email = String()
     sent_at = DateTime()
+
+
+class User(BaseAggregate):
+    email = String()
+    name = String()
+    password_hash = String()
+
+    @apply
+    def on_registered(self, event: Registered) -> None:
+        self.id = event.id
+        self.email = event.email
+        self.name = event.name
+        self.password_hash = event.password_hash
+
+    @apply
+    def on_activated(self, event: Activated) -> None:
+        pass
+
+
+class Email(BaseAggregate):
+    email = String()
+    sent_at = DateTime()
+
+    @apply
+    def on_sent(self, event: Sent) -> None:
+        self.email = event.email
+        self.sent_at = event.sent_at
 
 
 class UserEventHandler(BaseEventHandler):

--- a/tests/subscription/test_read_position_updates.py
+++ b/tests/subscription/test_read_position_updates.py
@@ -5,24 +5,13 @@ from uuid import uuid4
 
 import pytest
 
-from protean.core.aggregate import BaseAggregate
+from protean.core.aggregate import BaseAggregate, apply
 from protean.core.event import BaseEvent
 from protean.core.event_handler import BaseEventHandler
 from protean.fields import DateTime, Identifier, String
 from protean.server import Engine
 from protean.utils import Processing, fqn
 from protean.utils.mixins import handle
-
-
-class User(BaseAggregate):
-    email = String()
-    name = String()
-    password_hash = String()
-
-
-class Email(BaseAggregate):
-    email = String()
-    sent_at = DateTime()
 
 
 def dummy(*args):
@@ -44,6 +33,33 @@ class Activated(BaseEvent):
 class Sent(BaseEvent):
     email = String()
     sent_at = DateTime()
+
+
+class User(BaseAggregate):
+    email = String()
+    name = String()
+    password_hash = String()
+
+    @apply
+    def on_registered(self, event: Registered) -> None:
+        self.id = event.id
+        self.email = event.email
+        self.name = event.name
+        self.password_hash = event.password_hash
+
+    @apply
+    def on_activated(self, event: Activated) -> None:
+        pass
+
+
+class Email(BaseAggregate):
+    email = String()
+    sent_at = DateTime()
+
+    @apply
+    def on_sent(self, event: Sent) -> None:
+        self.email = event.email
+        self.sent_at = event.sent_at
 
 
 class UserEventHandler(BaseEventHandler):

--- a/tests/unit_of_work/test_nested_inline_event_processing.py
+++ b/tests/unit_of_work/test_nested_inline_event_processing.py
@@ -51,6 +51,7 @@ class Post(BaseAggregate):
 
     @apply
     def created(self, event: Created):
+        self.id = event.id
         self.topic = event.topic
         self.content = event.content
 

--- a/tests/unit_of_work/test_storing_events_on_commit.py
+++ b/tests/unit_of_work/test_storing_events_on_commit.py
@@ -2,7 +2,7 @@ from uuid import uuid4
 
 import pytest
 
-from protean.core.aggregate import BaseAggregate
+from protean.core.aggregate import BaseAggregate, apply
 from protean.core.command import BaseCommand
 from protean.core.command_handler import BaseCommandHandler
 from protean.core.event import BaseEvent
@@ -19,13 +19,20 @@ class Register(BaseCommand):
     password_hash = String()
 
 
+class Registered(BaseEvent):
+    id = Identifier()
+    email = String()
+    name = String()
+    password_hash = String()
+
+
 class User(BaseAggregate):
     email = String()
     name = String()
     password_hash = String()
 
     @classmethod
-    def register(cls, command: "Registered") -> "User":
+    def register(cls, command: Register) -> "User":
         user = cls(
             id=command.id,
             email=command.email,
@@ -45,12 +52,12 @@ class User(BaseAggregate):
 
         return user
 
-
-class Registered(BaseEvent):
-    id = Identifier()
-    email = String()
-    name = String()
-    password_hash = String()
+    @apply
+    def on_registered(self, event: Registered) -> None:
+        self.id = event.id
+        self.email = event.email
+        self.name = event.name
+        self.password_hash = event.password_hash
 
 
 class UserCommandHandler(BaseCommandHandler):


### PR DESCRIPTION
Previously, event-sourced aggregates had two divergent code paths for state mutation: business methods mutated state directly during live operations, while `@apply` handlers only ran during event replay (reconstitution from the event store). This meant the live path and replay path could silently produce different results — a class of bugs that is difficult to detect and diagnose.

Additionally, `from_events()` special-cased the first event by passing its payload to the aggregate constructor, coupling reconstitution to Pydantic validation and requiring event field names to match constructor parameter names exactly.

**Solution:**

**`raise_()` now invokes `@apply` handlers automatically** for event-sourced aggregates. After appending the enriched event to `_events`, `raise_()` calls `_apply_handler()` wrapped in `atomic_change()`, ensuring invariants are checked before and after the state change. Fact events are excluded since they are auto-generated snapshots without `@apply` handlers.

`_apply()` is split into two methods:

- `_apply_handler(event)` — Invokes the registered `@apply` projection function(s) without touching `_version`. Shared by both the live path (`raise_()`) and the replay path (`_apply()`). Raises `NotImplementedError` if no handler is registered, enforcing that every event has a corresponding handler.
- `_apply(event)` — The replay-specific method. Calls `_apply_handler()` then increments `_version` once per event (previously version was incremented once per projection function, which was incorrect for events with multiple handlers).

Three new construction methods replace the old `from_events()` approach:

- `_create_for_reconstitution()` — Creates a blank aggregate via `__new__`, bypassing Pydantic `__init__` entirely. Initializes all Pydantic internals, private attributes (`_version=-1`, `_events=[]`, etc.), model fields (all `None`), ValueObject shadow fields, Reference shadow fields, HasMany pseudo-methods (`add_*`, `remove_*`, `get_one_from_*`, `filter_*`), and discovers invariants. Invariant checks are suppressed during replay.
- `_create_new(**identity_kwargs)` — For factory methods. Builds on `_create_for_reconstitution()`, enables invariant checks, and sets identity (from kwargs or auto-generated). All remaining state is populated by the creation event's `@apply` handler via `raise_()`.
- `from_events(events)` — Simplified. Uses `_create_for_reconstitution()` then applies ALL events uniformly through `_apply()`. No special-casing of the first event. Re-enables invariant checks after all events are applied.

Association `__get__` fix for ES aggregates (`association.py`): When a `HasMany` field's cache is empty on an ES aggregate, the descriptor now returns an empty list instead of attempting a database fetch (which would fail since ES aggregates have no database tables). The check walks to the aggregate root and inspects `meta_.is_event_sourced`.

**Impact:**

- Business methods on ES aggregates should only call `raise_()` — never mutate state directly
- Every event raised by an ES aggregate must have a corresponding `@apply` handler
- Factory methods should use `_create_new()` instead of the regular constructor
- The `@apply` handler for the creation event must set ALL fields including identity
- Live path and replay path are now guaranteed to produce identical state