### PR TITLE
Add event store inspection CLI: read, stats, search, history

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -152,6 +152,7 @@ specific area.
 - [`protean test`](./guides/cli/test.md) -- Run tests with category and technology options.
 - [`protean snapshot`](./guides/cli/snapshot.md) -- Create snapshots for event-sourced aggregates.
 - [`protean projection`](./guides/cli/projection.md) -- Rebuild projections by replaying events from the event store.
+- [`protean events`](./guides/cli/events.md) -- Inspect the event store: read streams, view stats, search events, and trace aggregate history.
 - [Type Checking](./guides/type-checking.md) -- Static type checking with the Protean mypy plugin.
 
 ### Test Your Application

--- a/docs/guides/cli/events.md
+++ b/docs/guides/cli/events.md
@@ -1,0 +1,188 @@
+# `protean events`
+
+The `protean events` command group provides tools for inspecting the event
+store. These commands help you read events from streams, view statistics
+across aggregates, search for specific event types, and display the full
+event history of an aggregate instance -- all without writing custom scripts.
+
+All commands accept a `--domain` option to specify the domain module path
+(defaults to the current directory).
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `protean events read` | Read and display events from a stream |
+| `protean events stats` | Show stream statistics across the domain |
+| `protean events search` | Search for events by type across streams |
+| `protean events history` | Display the event timeline for an aggregate instance |
+
+## `protean events read`
+
+Reads events from a specific stream (entity stream or category stream) and
+displays them in a formatted table.
+
+```bash
+# Read from an entity stream
+protean events read "test::user-abc123" --domain=my_domain
+
+# Read from a category stream (all events for an aggregate type)
+protean events read "test::user" --domain=my_domain
+
+# Read from a specific position with a limit
+protean events read "test::user-abc123" --from 5 --limit 10 --domain=my_domain
+
+# Include full event data payloads
+protean events read "test::user-abc123" --data --domain=my_domain
+```
+
+**Options**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `STREAM` | Stream name (positional argument) | Required |
+| `--domain` | Domain module path | `.` (current directory) |
+| `--from` | Start reading from this position | `0` |
+| `--limit` | Maximum number of events to display | `20` |
+| `--data/--no-data` | Show full event data payloads | `--no-data` |
+
+**Output**
+
+```
+┏━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┓
+┃ Position ┃ Global Pos ┃ Type                    ┃ Time                ┃ Data Keys   ┃
+┡━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━┩
+│        0 │          1 │ App.UserRegistered.v1   │ 2026-02-22 10:30:00 │ name, email │
+│        1 │          5 │ App.UserEmailChanged.v1 │ 2026-02-22 10:31:00 │ email       │
+└──────────┴────────────┴─────────────────────────┴─────────────────────┴─────────────┘
+
+Showing 2 event(s) from position 0
+```
+
+## `protean events stats`
+
+Displays aggregate-level statistics: instance counts, event counts, and the
+most recent event per aggregate.
+
+```bash
+protean events stats --domain=my_domain
+```
+
+**Options**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--domain` | Domain module path | `.` (current directory) |
+
+**Output**
+
+```
+┏━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┓
+┃ Aggregate ┃ Stream Category ┃ ES? ┃ Instances ┃ Events ┃ Latest Type           ┃ Latest Time         ┃
+┡━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━┩
+│ User      │ app::user       │ Yes │        15 │     47 │ App.UserUpdated.v1    │ 2026-02-22 10:30:00 │
+│ Order     │ app::order      │ No  │         8 │     23 │ App.OrderPlaced.v1    │ 2026-02-22 09:15:00 │
+└───────────┴─────────────────┴─────┴───────────┴────────┴───────────────────────┴─────────────────────┘
+
+Total: 70 event(s) across 23 aggregate instance(s)
+```
+
+The **ES?** column indicates whether the aggregate is configured as
+event-sourced (`is_event_sourced=True`).
+
+## `protean events search`
+
+Searches for events matching a type name. Supports both exact and partial
+matching.
+
+```bash
+# Partial match (case-insensitive substring match)
+protean events search --type=UserRegistered --domain=my_domain
+
+# Exact match (when type contains dots)
+protean events search --type=App.UserRegistered.v1 --domain=my_domain
+
+# Restrict to a specific stream category
+protean events search --type=UserRegistered --category=app::user --domain=my_domain
+
+# Limit results and show data
+protean events search --type=UserRegistered --limit=5 --data --domain=my_domain
+```
+
+**Options**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--type` | Event type to search for | Required |
+| `--domain` | Domain module path | `.` (current directory) |
+| `--category` | Restrict search to a stream category | All streams (`$all`) |
+| `--limit` | Maximum number of results to display | `20` |
+| `--data/--no-data` | Show full event data payloads | `--no-data` |
+
+**Type matching rules:**
+
+- If the search term contains dots (e.g., `App.UserRegistered.v1`), an
+  **exact match** is performed against the event type.
+- Otherwise, a **case-insensitive substring match** is used, so `User`
+  matches `App.UserRegistered.v1`, `App.UserUpdated.v1`, etc.
+
+## `protean events history`
+
+Displays the full event timeline for a specific aggregate instance, including
+snapshot information when available.
+
+```bash
+# Show event timeline
+protean events history --aggregate=User --id=abc-123 --domain=my_domain
+
+# Include full event data
+protean events history --aggregate=User --id=abc-123 --data --domain=my_domain
+```
+
+**Options**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--aggregate` | Aggregate class name (e.g. `User`) | Required |
+| `--id` | Aggregate instance identifier | Required |
+| `--domain` | Domain module path | `.` (current directory) |
+| `--data/--no-data` | Show full event data payloads | `--no-data` |
+
+**Output**
+
+```
+         User (abc-123)
+┏━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┓
+┃ Version ┃ Type                    ┃ Time                ┃ Data Keys   ┃
+┡━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━┩
+│       0 │ App.UserRegistered.v1   │ 2026-02-22 10:30:00 │ name, email │
+│       1 │ App.UserEmailChanged.v1 │ 2026-02-22 10:31:00 │ email       │
+│       2 │ App.UserDeactivated.v1  │ 2026-02-22 10:32:00 │ reason      │
+└─────────┴─────────────────────────┴─────────────────────┴─────────────┘
+Snapshot exists at version 1
+
+User (abc-123): 3 event(s), current version: 2
+```
+
+## Error Handling
+
+| Condition | Behavior |
+|-----------|----------|
+| Invalid domain path | Aborts with "Error loading Protean domain" |
+| Aggregate not found in registry (`history`) | Aborts with "not found in domain" |
+| No events in stream (`read`) | Prints "No events found in stream" |
+| No matching events (`search`) | Prints "No events found matching type" |
+| No events for aggregate (`history`) | Prints "No events found for \<Aggregate\>" |
+| No aggregates in domain (`stats`) | Prints "No aggregates registered" |
+
+## Domain Discovery
+
+The `protean events` commands use the same domain discovery mechanism as
+other CLI commands. The `--domain` option accepts:
+
+- A Python module path: `my_package.domain`
+- A file path: `src/my_domain.py`
+- A module with instance name: `my_domain:custom_domain`
+- `.` (default): Searches the current directory
+
+See [Domain Discovery](discovery.md) for the full resolution logic.

--- a/docs/guides/cli/index.md
+++ b/docs/guides/cli/index.md
@@ -18,6 +18,10 @@ load the domain.
 | [`protean db setup-outbox`](database.md)| Create only outbox tables          |
 | [`protean snapshot create`](snapshot.md)| Create snapshots for ES aggregates |
 | [`protean projection rebuild`](projection.md) | Rebuild projections from events |
+| [`protean events read`](events.md)     | Read and display events from a stream |
+| [`protean events stats`](events.md)    | Show stream statistics across the domain |
+| [`protean events search`](events.md)   | Search for events by type |
+| [`protean events history`](events.md)  | Display aggregate event timeline |
 
 !!! note
 

--- a/docs/how-do-i.md
+++ b/docs/how-do-i.md
@@ -115,6 +115,8 @@ need by what you're trying to accomplish.
 | Manage database schemas                         | [`protean db`](./guides/cli/database.md) |
 | Create and manage snapshots                     | [`protean snapshot`](./guides/cli/snapshot.md) |
 | Rebuild projections from events                 | [`protean projection`](./guides/cli/projection.md) |
+| Inspect events in the event store               | [`protean events`](./guides/cli/events.md) |
+| View the event history of an aggregate          | [`protean events history`](./guides/cli/events.md) |
 
 ## Evolve and Maintain
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -208,6 +208,7 @@ nav:
         - guides/cli/test.md
         - guides/cli/snapshot.md
         - guides/cli/projection.md
+        - guides/cli/events.md
       - guides/type-checking.md
 
     - Test Your Application:

--- a/src/protean/cli/__init__.py
+++ b/src/protean/cli/__init__.py
@@ -23,6 +23,7 @@ from typing_extensions import Annotated
 
 from protean.cli.database import app as db_app
 from protean.cli.docs import app as docs_app
+from protean.cli.events import app as events_app
 from protean.cli.generate import app as generate_app
 from protean.cli.new import new
 from protean.cli.observatory import observatory
@@ -45,6 +46,7 @@ app.command()(new)
 app.command()(observatory)
 app.command()(shell)
 app.add_typer(db_app, name="db")
+app.add_typer(events_app, name="events")
 app.add_typer(generate_app, name="generate")
 app.add_typer(docs_app, name="docs")
 app.add_typer(projection_app, name="projection")

--- a/src/protean/cli/events.py
+++ b/src/protean/cli/events.py
@@ -1,0 +1,373 @@
+"""CLI commands for inspecting the event store.
+
+Provides commands for reading events, viewing stream statistics,
+searching for events by type, and viewing aggregate event histories.
+
+Usage::
+
+    # Read events from a stream
+    protean events read "test::user-abc123" --domain=my_domain
+
+    # View stream statistics
+    protean events stats --domain=my_domain
+
+    # Search for events by type
+    protean events search --type=UserRegistered --domain=my_domain
+
+    # View aggregate event history
+    protean events history --aggregate=User --id=abc123 --domain=my_domain
+"""
+
+import json
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+import typer
+from rich import print
+from rich.table import Table
+from typing_extensions import Annotated
+
+from protean.exceptions import NoDomainException
+from protean.utils import DomainObjects
+from protean.utils.domain_discovery import derive_domain
+from protean.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from protean.domain import Domain
+
+logger = get_logger(__name__)
+
+app = typer.Typer(no_args_is_help=True)
+
+
+@app.callback()
+def callback():
+    """Inspect and query the event store."""
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_domain(domain_path: str) -> "Domain":
+    """Load and initialize a domain, handling errors consistently."""
+    try:
+        derived_domain = derive_domain(domain_path)
+    except NoDomainException as exc:
+        msg = f"Error loading Protean domain: {exc.args[0]}"
+        print(msg)
+        logger.error(msg)
+        raise typer.Abort()
+
+    assert derived_domain is not None
+    derived_domain.init()
+    return derived_domain
+
+
+def _resolve_aggregate(domain: "Domain", aggregate_name: str):  # type: ignore[name-defined]
+    """Resolve an aggregate class by name from the domain registry."""
+    for _, record in domain.registry._elements[DomainObjects.AGGREGATE.value].items():
+        if record.cls.__name__ == aggregate_name:
+            return record.cls
+
+    print(f"Error: Aggregate '{aggregate_name}' not found in domain.")
+    return None
+
+
+def _format_time(raw_time: Any) -> str:
+    """Format a raw time value (datetime or ISO string) for display."""
+    if raw_time is None:
+        return "-"
+    if isinstance(raw_time, datetime):
+        return raw_time.strftime("%Y-%m-%d %H:%M:%S")
+    if isinstance(raw_time, str):
+        try:
+            return datetime.fromisoformat(raw_time).strftime("%Y-%m-%d %H:%M:%S")
+        except ValueError:
+            return raw_time
+    return str(raw_time)
+
+
+def _data_keys_summary(data: dict | None) -> str:
+    """Return a short summary of the data keys."""
+    if not data:
+        return "-"
+    keys = list(data.keys())
+    summary = ", ".join(keys[:5])
+    if len(keys) > 5:
+        summary += f" (+{len(keys) - 5} more)"
+    return summary
+
+
+def _build_events_table(
+    messages: list[dict[str, Any]],
+    *,
+    show_data: bool = False,
+    show_stream: bool = False,
+) -> Table:
+    """Build a Rich Table from a list of raw event dicts."""
+    table = Table()
+    table.add_column("Position", justify="right", style="cyan")
+    table.add_column("Global Pos", justify="right", style="dim")
+    table.add_column("Type", style="green")
+    if show_stream:
+        table.add_column("Stream")
+    table.add_column("Time")
+    if not show_data:
+        table.add_column("Data Keys", style="dim")
+
+    for msg in messages:
+        row = [
+            str(msg.get("position", "?")),
+            str(msg.get("global_position", "?")),
+            str(msg.get("type", "<unknown>")),
+        ]
+        if show_stream:
+            row.append(str(msg.get("stream_name", "")))
+        row.append(_format_time(msg.get("time")))
+        if not show_data:
+            row.append(_data_keys_summary(msg.get("data")))
+        table.add_row(*row)
+
+    return table
+
+
+def _print_event_data(messages: list[dict[str, Any]]) -> None:
+    """Print the full data payload for each message."""
+    for msg in messages:
+        event_type = msg.get("type", "<unknown>")
+        position = msg.get("position", "?")
+        data = msg.get("data", {})
+        print(f"\n[bold]Event {position}[/bold] ({event_type}):")
+        print(json.dumps(data, indent=2, default=str))
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+
+@app.command()
+def read(
+    stream: Annotated[
+        str,
+        typer.Argument(
+            help="Stream name (e.g. 'test::user-abc123') or category (e.g. 'test::user')"
+        ),
+    ],
+    domain: Annotated[str, typer.Option(help="Domain module path")] = ".",
+    position: Annotated[
+        int, typer.Option("--from", help="Start reading from this position")
+    ] = 0,
+    limit: Annotated[
+        int, typer.Option(help="Maximum number of events to display")
+    ] = 20,
+    show_data: Annotated[
+        bool, typer.Option("--data/--no-data", help="Show full event data")
+    ] = False,
+) -> None:
+    """Read and display events from a stream."""
+    derived_domain = _load_domain(domain)
+    with derived_domain.domain_context():
+        store = derived_domain.event_store.store
+        messages = store._read(stream, position=position, no_of_messages=limit)
+
+        if not messages:
+            print(f"No events found in stream '{stream}'")
+            return
+
+        table = _build_events_table(messages, show_data=show_data)
+        print(table)
+
+        if show_data:
+            _print_event_data(messages)
+
+        print(f"\nShowing {len(messages)} event(s) from position {position}")
+
+
+@app.command()
+def stats(
+    domain: Annotated[str, typer.Option(help="Domain module path")] = ".",
+) -> None:
+    """Show stream statistics across the domain."""
+    derived_domain = _load_domain(domain)
+    with derived_domain.domain_context():
+        store = derived_domain.event_store.store
+        aggregates = derived_domain.registry._elements.get(
+            DomainObjects.AGGREGATE.value, {}
+        )
+
+        if not aggregates:
+            print("No aggregates registered in domain.")
+            return
+
+        table = Table()
+        table.add_column("Aggregate", style="bold")
+        table.add_column("Stream Category")
+        table.add_column("ES?", justify="center")
+        table.add_column("Instances", justify="right")
+        table.add_column("Events", justify="right", style="cyan")
+        table.add_column("Latest Type", style="green")
+        table.add_column("Latest Time")
+
+        total_events = 0
+        total_instances = 0
+
+        for _, record in aggregates.items():
+            agg_cls = record.cls
+            stream_category = agg_cls.meta_.stream_category
+            is_es = "Yes" if agg_cls.meta_.is_event_sourced else "No"
+
+            # Count unique instances
+            try:
+                identifiers = store._stream_identifiers(stream_category)
+                instance_count = len(identifiers)
+            except Exception:
+                instance_count = 0
+
+            # Count total events and find latest
+            try:
+                all_events = store._read(stream_category, no_of_messages=1_000_000)
+                event_count = len(all_events)
+                latest = all_events[-1] if all_events else None
+            except Exception:
+                event_count = 0
+                latest = None
+
+            latest_type = str(latest.get("type", "")) if latest else "-"
+            latest_time = _format_time(latest.get("time")) if latest else "-"
+
+            table.add_row(
+                agg_cls.__name__,
+                stream_category,
+                is_es,
+                str(instance_count),
+                str(event_count),
+                latest_type,
+                latest_time,
+            )
+
+            total_events += event_count
+            total_instances += instance_count
+
+        print(table)
+        print(
+            f"\nTotal: {total_events} event(s) across "
+            f"{total_instances} aggregate instance(s)"
+        )
+
+
+@app.command()
+def search(
+    type_name: Annotated[
+        str,
+        typer.Option("--type", help="Event type to search for (e.g. 'UserRegistered')"),
+    ],
+    domain: Annotated[str, typer.Option(help="Domain module path")] = ".",
+    category: Annotated[
+        str, typer.Option(help="Restrict search to a stream category")
+    ] = "",
+    limit: Annotated[int, typer.Option(help="Maximum number of results")] = 20,
+    show_data: Annotated[
+        bool, typer.Option("--data/--no-data", help="Show full event data")
+    ] = False,
+) -> None:
+    """Search for events by type across streams."""
+    derived_domain = _load_domain(domain)
+    with derived_domain.domain_context():
+        store = derived_domain.event_store.store
+        stream = category if category else "$all"
+        all_messages = store._read(stream, no_of_messages=1_000_000)
+
+        # Filter by type: exact match if dots present, partial otherwise
+        if "." in type_name:
+            matched = [m for m in all_messages if m.get("type") == type_name]
+        else:
+            type_lower = type_name.lower()
+            matched = [
+                m for m in all_messages if type_lower in m.get("type", "").lower()
+            ]
+
+        if not matched:
+            print(f"No events found matching type '{type_name}'")
+            return
+
+        total_matched = len(matched)
+        display = matched[:limit]
+
+        table = _build_events_table(display, show_data=show_data, show_stream=True)
+        print(table)
+
+        if show_data:
+            _print_event_data(display)
+
+        msg = f"\nFound {total_matched} event(s) matching type '{type_name}'"
+        if total_matched > limit:
+            msg += f" (showing first {limit})"
+        print(msg)
+
+
+@app.command()
+def history(
+    aggregate: Annotated[str, typer.Option(help="Aggregate class name (e.g. 'User')")],
+    identifier: Annotated[
+        str, typer.Option("--id", help="Aggregate instance identifier")
+    ],
+    domain: Annotated[str, typer.Option(help="Domain module path")] = ".",
+    show_data: Annotated[
+        bool, typer.Option("--data/--no-data", help="Show full event data")
+    ] = False,
+) -> None:
+    """Display the event timeline for a specific aggregate instance."""
+    derived_domain = _load_domain(domain)
+    with derived_domain.domain_context():
+        aggregate_cls = _resolve_aggregate(derived_domain, aggregate)
+        if aggregate_cls is None:
+            raise typer.Abort()
+
+        store = derived_domain.event_store.store
+        stream_category = aggregate_cls.meta_.stream_category
+        stream_name = f"{stream_category}-{identifier}"
+
+        messages = store._read(stream_name)
+
+        if not messages:
+            print(f"No events found for {aggregate} with identifier '{identifier}'")
+            return
+
+        # Build timeline table
+        table = Table(title=f"{aggregate} ({identifier})")
+        table.add_column("Version", justify="right", style="cyan")
+        table.add_column("Type", style="green")
+        table.add_column("Time")
+        if not show_data:
+            table.add_column("Data Keys", style="dim")
+
+        for msg in messages:
+            row = [
+                str(msg.get("position", "?")),
+                str(msg.get("type", "<unknown>")),
+                _format_time(msg.get("time")),
+            ]
+            if not show_data:
+                row.append(_data_keys_summary(msg.get("data")))
+            table.add_row(*row)
+
+        print(table)
+
+        if show_data:
+            _print_event_data(messages)
+
+        # Check for snapshot
+        snapshot_stream = f"{stream_category}:snapshot-{identifier}"
+        snapshot = store._read_last_message(snapshot_stream)
+        if snapshot:
+            snap_version = snapshot.get("data", {}).get("_version", "?")
+            print(f"Snapshot exists at version {snap_version}")
+
+        last_position = messages[-1].get("position", "?")
+        print(
+            f"\n{aggregate} ({identifier}): "
+            f"{len(messages)} event(s), current version: {last_position}"
+        )

--- a/tests/cli/test_events.py
+++ b/tests/cli/test_events.py
@@ -1,0 +1,784 @@
+"""Tests for CLI events commands (protean events ...)."""
+
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from protean.cli import app
+from protean.cli.events import _data_keys_summary, _format_time
+from protean.exceptions import NoDomainException
+from tests.shared import change_working_directory_to
+
+runner = CliRunner()
+
+
+def _make_raw_event(
+    position: int = 0,
+    global_position: int = 0,
+    event_type: str = "Test.UserRegistered.v1",
+    stream_name: str = "test::user-abc123",
+    data: dict | None = None,
+) -> dict:
+    """Create a raw event dict matching the format returned by `_read()`."""
+    return {
+        "data": data or {"name": "John", "email": "john@example.com"},
+        "type": event_type,
+        "stream_name": stream_name,
+        "position": position,
+        "global_position": global_position,
+        "id": f"evt-{global_position}",
+        "time": "2026-02-22T10:00:00",
+    }
+
+
+def _mock_domain_with_store(
+    read_return: list | None = None,
+    read_last_return: dict | None = None,
+    identifiers_return: list | None = None,
+    aggregates: dict | None = None,
+) -> MagicMock:
+    """Create a MagicMock domain with an event store configured."""
+    mock_domain = MagicMock()
+    mock_store = MagicMock()
+    mock_domain.event_store.store = mock_store
+
+    mock_store._read.return_value = read_return or []
+    mock_store._read_last_message.return_value = read_last_return
+    mock_store._stream_identifiers.return_value = identifiers_return or []
+
+    if aggregates is not None:
+        mock_domain.registry._elements = {"AGGREGATE": aggregates}
+    else:
+        mock_domain.registry._elements = {"AGGREGATE": {}}
+
+    return mock_domain
+
+
+def _make_aggregate_record(
+    name: str, stream_category: str = "", is_event_sourced: bool = True
+) -> MagicMock:
+    """Create a mock aggregate registry record."""
+    record = MagicMock()
+    record.cls.__name__ = name
+    record.cls.meta_.stream_category = stream_category or f"test::{name.lower()}"
+    record.cls.meta_.is_event_sourced = is_event_sourced
+    return record
+
+
+# ---------------------------------------------------------------------------
+# protean events read
+# ---------------------------------------------------------------------------
+
+
+class TestEventsRead:
+    @pytest.fixture(autouse=True)
+    def reset_path(self):
+        original_path = sys.path[:]
+        cwd = Path.cwd()
+        yield
+        sys.path[:] = original_path
+        os.chdir(cwd)
+
+    def test_read_stream_with_events(self):
+        change_working_directory_to("test7")
+
+        events = [
+            _make_raw_event(0, 1),
+            _make_raw_event(1, 3, event_type="Test.UserEmailChanged.v1"),
+        ]
+        mock_domain = _mock_domain_with_store(read_return=events)
+
+        with patch("protean.cli.events.derive_domain", return_value=mock_domain):
+            result = runner.invoke(
+                app,
+                ["events", "read", "test::user-abc123", "--domain", "publishing7.py"],
+            )
+            assert result.exit_code == 0
+            # Rich may truncate long type names in the table, so check for
+            # the summary line and key data instead of full type strings.
+            assert "Showing 2 event(s) from position 0" in result.output
+            assert "name, email" in result.output
+
+    def test_read_empty_stream(self):
+        change_working_directory_to("test7")
+
+        mock_domain = _mock_domain_with_store(read_return=[])
+
+        with patch("protean.cli.events.derive_domain", return_value=mock_domain):
+            result = runner.invoke(
+                app,
+                ["events", "read", "test::user-abc123", "--domain", "publishing7.py"],
+            )
+            assert result.exit_code == 0
+            assert "No events found in stream 'test::user-abc123'" in result.output
+
+    def test_read_with_from_offset(self):
+        change_working_directory_to("test7")
+
+        events = [_make_raw_event(5, 10)]
+        mock_domain = _mock_domain_with_store(read_return=events)
+
+        with patch("protean.cli.events.derive_domain", return_value=mock_domain):
+            result = runner.invoke(
+                app,
+                [
+                    "events",
+                    "read",
+                    "test::user-abc123",
+                    "--domain",
+                    "publishing7.py",
+                    "--from",
+                    "5",
+                ],
+            )
+            assert result.exit_code == 0
+            mock_domain.event_store.store._read.assert_called_once_with(
+                "test::user-abc123", position=5, no_of_messages=20
+            )
+
+    def test_read_with_limit(self):
+        change_working_directory_to("test7")
+
+        mock_domain = _mock_domain_with_store(read_return=[_make_raw_event()])
+
+        with patch("protean.cli.events.derive_domain", return_value=mock_domain):
+            result = runner.invoke(
+                app,
+                [
+                    "events",
+                    "read",
+                    "test::user-abc123",
+                    "--domain",
+                    "publishing7.py",
+                    "--limit",
+                    "5",
+                ],
+            )
+            assert result.exit_code == 0
+            mock_domain.event_store.store._read.assert_called_once_with(
+                "test::user-abc123", position=0, no_of_messages=5
+            )
+
+    def test_read_with_data_flag(self):
+        change_working_directory_to("test7")
+
+        events = [_make_raw_event(data={"email": "test@example.com"})]
+        mock_domain = _mock_domain_with_store(read_return=events)
+
+        with patch("protean.cli.events.derive_domain", return_value=mock_domain):
+            result = runner.invoke(
+                app,
+                [
+                    "events",
+                    "read",
+                    "test::user-abc123",
+                    "--domain",
+                    "publishing7.py",
+                    "--data",
+                ],
+            )
+            assert result.exit_code == 0
+            assert "test@example.com" in result.output
+
+    def test_read_invalid_domain(self):
+        with patch(
+            "protean.cli.events.derive_domain",
+            side_effect=NoDomainException("Not found"),
+        ):
+            result = runner.invoke(
+                app, ["events", "read", "some-stream", "--domain", "invalid.py"]
+            )
+            assert result.exit_code != 0
+            assert "Error loading Protean domain" in result.output
+
+
+# ---------------------------------------------------------------------------
+# protean events stats
+# ---------------------------------------------------------------------------
+
+
+class TestEventsStats:
+    @pytest.fixture(autouse=True)
+    def reset_path(self):
+        original_path = sys.path[:]
+        cwd = Path.cwd()
+        yield
+        sys.path[:] = original_path
+        os.chdir(cwd)
+
+    def test_stats_with_aggregates(self):
+        change_working_directory_to("test7")
+
+        user_record = _make_aggregate_record("User", "test::user")
+        order_record = _make_aggregate_record(
+            "Order", "test::order", is_event_sourced=False
+        )
+
+        aggregates = {
+            "test.User": user_record,
+            "test.Order": order_record,
+        }
+
+        events_user = [
+            _make_raw_event(0, 1, stream_name="test::user-id1"),
+            _make_raw_event(1, 2, stream_name="test::user-id1"),
+            _make_raw_event(0, 3, stream_name="test::user-id2"),
+        ]
+
+        mock_domain = _mock_domain_with_store(aggregates=aggregates)
+        store = mock_domain.event_store.store
+
+        def side_effect_read(stream, **kwargs):
+            if stream == "test::user":
+                return events_user
+            return []
+
+        store._read.side_effect = side_effect_read
+
+        def side_effect_identifiers(stream_category):
+            if stream_category == "test::user":
+                return ["id1", "id2"]
+            return []
+
+        store._stream_identifiers.side_effect = side_effect_identifiers
+
+        with patch("protean.cli.events.derive_domain", return_value=mock_domain):
+            result = runner.invoke(
+                app,
+                ["events", "stats", "--domain", "publishing7.py"],
+            )
+            assert result.exit_code == 0
+            assert "User" in result.output
+            assert "Order" in result.output
+            assert "Yes" in result.output  # User is ES
+            assert "No" in result.output  # Order is not ES
+            assert "Total:" in result.output
+
+    def test_stats_no_aggregates(self):
+        change_working_directory_to("test7")
+
+        mock_domain = _mock_domain_with_store(aggregates={})
+
+        with patch("protean.cli.events.derive_domain", return_value=mock_domain):
+            result = runner.invoke(
+                app,
+                ["events", "stats", "--domain", "publishing7.py"],
+            )
+            assert result.exit_code == 0
+            assert "No aggregates registered in domain" in result.output
+
+    def test_stats_empty_event_store(self):
+        change_working_directory_to("test7")
+
+        user_record = _make_aggregate_record("User", "test::user")
+        aggregates = {"test.User": user_record}
+
+        mock_domain = _mock_domain_with_store(
+            read_return=[],
+            identifiers_return=[],
+            aggregates=aggregates,
+        )
+
+        with patch("protean.cli.events.derive_domain", return_value=mock_domain):
+            result = runner.invoke(
+                app,
+                ["events", "stats", "--domain", "publishing7.py"],
+            )
+            assert result.exit_code == 0
+            assert "User" in result.output
+            assert "Total: 0 event(s) across 0 aggregate instance(s)" in result.output
+
+    def test_stats_invalid_domain(self):
+        with patch(
+            "protean.cli.events.derive_domain",
+            side_effect=NoDomainException("Not found"),
+        ):
+            result = runner.invoke(app, ["events", "stats", "--domain", "invalid.py"])
+            assert result.exit_code != 0
+            assert "Error loading Protean domain" in result.output
+
+
+# ---------------------------------------------------------------------------
+# protean events search
+# ---------------------------------------------------------------------------
+
+
+class TestEventsSearch:
+    @pytest.fixture(autouse=True)
+    def reset_path(self):
+        original_path = sys.path[:]
+        cwd = Path.cwd()
+        yield
+        sys.path[:] = original_path
+        os.chdir(cwd)
+
+    def test_search_by_exact_type(self):
+        change_working_directory_to("test7")
+
+        events = [
+            _make_raw_event(0, 1, event_type="Test.UserRegistered.v1"),
+            _make_raw_event(1, 2, event_type="Test.OrderPlaced.v1"),
+            _make_raw_event(2, 3, event_type="Test.UserRegistered.v1"),
+        ]
+        mock_domain = _mock_domain_with_store(read_return=events)
+
+        with patch("protean.cli.events.derive_domain", return_value=mock_domain):
+            result = runner.invoke(
+                app,
+                [
+                    "events",
+                    "search",
+                    "--type",
+                    "Test.UserRegistered.v1",
+                    "--domain",
+                    "publishing7.py",
+                ],
+            )
+            assert result.exit_code == 0
+            assert (
+                "Found 2 event(s) matching type 'Test.UserRegistered.v1'"
+                in result.output
+            )
+
+    def test_search_by_partial_type(self):
+        change_working_directory_to("test7")
+
+        events = [
+            _make_raw_event(0, 1, event_type="Test.UserRegistered.v1"),
+            _make_raw_event(1, 2, event_type="Test.OrderPlaced.v1"),
+            _make_raw_event(2, 3, event_type="Test.UserEmailChanged.v1"),
+        ]
+        mock_domain = _mock_domain_with_store(read_return=events)
+
+        with patch("protean.cli.events.derive_domain", return_value=mock_domain):
+            result = runner.invoke(
+                app,
+                [
+                    "events",
+                    "search",
+                    "--type",
+                    "User",
+                    "--domain",
+                    "publishing7.py",
+                ],
+            )
+            assert result.exit_code == 0
+            # Should match both User events (partial, case-insensitive)
+            assert "Found 2 event(s) matching type 'User'" in result.output
+
+    def test_search_with_category_filter(self):
+        change_working_directory_to("test7")
+
+        events = [_make_raw_event(0, 1)]
+        mock_domain = _mock_domain_with_store(read_return=events)
+
+        with patch("protean.cli.events.derive_domain", return_value=mock_domain):
+            result = runner.invoke(
+                app,
+                [
+                    "events",
+                    "search",
+                    "--type",
+                    "UserRegistered",
+                    "--domain",
+                    "publishing7.py",
+                    "--category",
+                    "test::user",
+                ],
+            )
+            assert result.exit_code == 0
+            mock_domain.event_store.store._read.assert_called_once_with(
+                "test::user", no_of_messages=1_000_000
+            )
+
+    def test_search_no_results(self):
+        change_working_directory_to("test7")
+
+        events = [_make_raw_event(0, 1, event_type="Test.OrderPlaced.v1")]
+        mock_domain = _mock_domain_with_store(read_return=events)
+
+        with patch("protean.cli.events.derive_domain", return_value=mock_domain):
+            result = runner.invoke(
+                app,
+                [
+                    "events",
+                    "search",
+                    "--type",
+                    "UserRegistered",
+                    "--domain",
+                    "publishing7.py",
+                ],
+            )
+            assert result.exit_code == 0
+            assert "No events found matching type 'UserRegistered'" in result.output
+
+    def test_search_with_limit(self):
+        change_working_directory_to("test7")
+
+        events = [
+            _make_raw_event(i, i, event_type="Test.UserRegistered.v1")
+            for i in range(10)
+        ]
+        mock_domain = _mock_domain_with_store(read_return=events)
+
+        with patch("protean.cli.events.derive_domain", return_value=mock_domain):
+            result = runner.invoke(
+                app,
+                [
+                    "events",
+                    "search",
+                    "--type",
+                    "UserRegistered",
+                    "--domain",
+                    "publishing7.py",
+                    "--limit",
+                    "3",
+                ],
+            )
+            assert result.exit_code == 0
+            assert "Found 10 event(s)" in result.output
+            assert "showing first 3" in result.output
+
+    def test_search_invalid_domain(self):
+        with patch(
+            "protean.cli.events.derive_domain",
+            side_effect=NoDomainException("Not found"),
+        ):
+            result = runner.invoke(
+                app,
+                ["events", "search", "--type", "Foo", "--domain", "invalid.py"],
+            )
+            assert result.exit_code != 0
+            assert "Error loading Protean domain" in result.output
+
+
+# ---------------------------------------------------------------------------
+# protean events history
+# ---------------------------------------------------------------------------
+
+
+class TestEventsHistory:
+    @pytest.fixture(autouse=True)
+    def reset_path(self):
+        original_path = sys.path[:]
+        cwd = Path.cwd()
+        yield
+        sys.path[:] = original_path
+        os.chdir(cwd)
+
+    def test_history_with_events(self):
+        change_working_directory_to("test7")
+
+        user_record = _make_aggregate_record("User", "test::user")
+        aggregates = {"test.User": user_record}
+        events = [
+            _make_raw_event(0, 1, event_type="Test.UserRegistered.v1"),
+            _make_raw_event(1, 3, event_type="Test.UserEmailChanged.v1"),
+        ]
+
+        mock_domain = _mock_domain_with_store(
+            read_return=events,
+            aggregates=aggregates,
+        )
+        # _read_last_message for snapshot check returns None
+        mock_domain.event_store.store._read_last_message.return_value = None
+
+        with patch("protean.cli.events.derive_domain", return_value=mock_domain):
+            result = runner.invoke(
+                app,
+                [
+                    "events",
+                    "history",
+                    "--aggregate",
+                    "User",
+                    "--id",
+                    "abc123",
+                    "--domain",
+                    "publishing7.py",
+                ],
+            )
+            assert result.exit_code == 0
+            assert "UserRegistered" in result.output
+            assert "UserEmailChanged" in result.output
+            assert "2 event(s), current version: 1" in result.output
+
+    def test_history_no_events(self):
+        change_working_directory_to("test7")
+
+        user_record = _make_aggregate_record("User", "test::user")
+        aggregates = {"test.User": user_record}
+
+        mock_domain = _mock_domain_with_store(
+            read_return=[],
+            aggregates=aggregates,
+        )
+
+        with patch("protean.cli.events.derive_domain", return_value=mock_domain):
+            result = runner.invoke(
+                app,
+                [
+                    "events",
+                    "history",
+                    "--aggregate",
+                    "User",
+                    "--id",
+                    "nonexistent",
+                    "--domain",
+                    "publishing7.py",
+                ],
+            )
+            assert result.exit_code == 0
+            assert (
+                "No events found for User with identifier 'nonexistent'"
+                in result.output
+            )
+
+    def test_history_with_snapshot(self):
+        change_working_directory_to("test7")
+
+        user_record = _make_aggregate_record("User", "test::user")
+        aggregates = {"test.User": user_record}
+        events = [
+            _make_raw_event(0, 1, event_type="Test.UserRegistered.v1"),
+            _make_raw_event(1, 3, event_type="Test.UserEmailChanged.v1"),
+        ]
+        snapshot = {"data": {"_version": 1, "name": "John"}, "type": "SNAPSHOT"}
+
+        mock_domain = _mock_domain_with_store(
+            read_return=events,
+            read_last_return=snapshot,
+            aggregates=aggregates,
+        )
+
+        with patch("protean.cli.events.derive_domain", return_value=mock_domain):
+            result = runner.invoke(
+                app,
+                [
+                    "events",
+                    "history",
+                    "--aggregate",
+                    "User",
+                    "--id",
+                    "abc123",
+                    "--domain",
+                    "publishing7.py",
+                ],
+            )
+            assert result.exit_code == 0
+            assert "Snapshot exists at version 1" in result.output
+
+    def test_history_aggregate_not_found(self):
+        change_working_directory_to("test7")
+
+        mock_domain = _mock_domain_with_store(aggregates={})
+
+        with patch("protean.cli.events.derive_domain", return_value=mock_domain):
+            result = runner.invoke(
+                app,
+                [
+                    "events",
+                    "history",
+                    "--aggregate",
+                    "NonExistent",
+                    "--id",
+                    "abc123",
+                    "--domain",
+                    "publishing7.py",
+                ],
+            )
+            assert result.exit_code != 0
+            assert "Aggregate 'NonExistent' not found" in result.output
+
+    def test_history_with_data_flag(self):
+        change_working_directory_to("test7")
+
+        user_record = _make_aggregate_record("User", "test::user")
+        aggregates = {"test.User": user_record}
+        events = [
+            _make_raw_event(
+                0,
+                1,
+                data={"email": "john@example.com", "name": "John"},
+            )
+        ]
+
+        mock_domain = _mock_domain_with_store(
+            read_return=events,
+            aggregates=aggregates,
+        )
+        mock_domain.event_store.store._read_last_message.return_value = None
+
+        with patch("protean.cli.events.derive_domain", return_value=mock_domain):
+            result = runner.invoke(
+                app,
+                [
+                    "events",
+                    "history",
+                    "--aggregate",
+                    "User",
+                    "--id",
+                    "abc123",
+                    "--domain",
+                    "publishing7.py",
+                    "--data",
+                ],
+            )
+            assert result.exit_code == 0
+            assert "john@example.com" in result.output
+
+    def test_history_invalid_domain(self):
+        with patch(
+            "protean.cli.events.derive_domain",
+            side_effect=NoDomainException("Not found"),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "events",
+                    "history",
+                    "--aggregate",
+                    "User",
+                    "--id",
+                    "abc123",
+                    "--domain",
+                    "invalid.py",
+                ],
+            )
+            assert result.exit_code != 0
+            assert "Error loading Protean domain" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Helper function unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatTime:
+    def test_none_returns_dash(self):
+        assert _format_time(None) == "-"
+
+    def test_datetime_object(self):
+        dt = datetime(2026, 2, 22, 10, 30, 0, tzinfo=timezone.utc)
+        assert _format_time(dt) == "2026-02-22 10:30:00"
+
+    def test_iso_string(self):
+        assert _format_time("2026-02-22T10:30:00") == "2026-02-22 10:30:00"
+
+    def test_invalid_string_returned_as_is(self):
+        assert _format_time("not-a-date") == "not-a-date"
+
+    def test_other_type_returns_str(self):
+        assert _format_time(12345) == "12345"
+
+
+class TestDataKeysSummary:
+    def test_none_returns_dash(self):
+        assert _data_keys_summary(None) == "-"
+
+    def test_empty_dict_returns_dash(self):
+        assert _data_keys_summary({}) == "-"
+
+    def test_few_keys(self):
+        assert _data_keys_summary({"a": 1, "b": 2}) == "a, b"
+
+    def test_more_than_five_keys(self):
+        data = {f"key{i}": i for i in range(8)}
+        result = _data_keys_summary(data)
+        assert "(+3 more)" in result
+
+
+# ---------------------------------------------------------------------------
+# Stats exception handling
+# ---------------------------------------------------------------------------
+
+
+class TestEventsStatsExceptions:
+    @pytest.fixture(autouse=True)
+    def reset_path(self):
+        original_path = sys.path[:]
+        cwd = Path.cwd()
+        yield
+        sys.path[:] = original_path
+        os.chdir(cwd)
+
+    def test_stats_handles_stream_identifiers_exception(self):
+        change_working_directory_to("test7")
+
+        user_record = _make_aggregate_record("User", "test::user")
+        aggregates = {"test.User": user_record}
+
+        mock_domain = _mock_domain_with_store(aggregates=aggregates)
+        store = mock_domain.event_store.store
+        store._stream_identifiers.side_effect = Exception("Connection error")
+        store._read.return_value = [_make_raw_event(0, 1)]
+
+        with patch("protean.cli.events.derive_domain", return_value=mock_domain):
+            result = runner.invoke(
+                app,
+                ["events", "stats", "--domain", "publishing7.py"],
+            )
+            assert result.exit_code == 0
+            assert "User" in result.output
+
+    def test_stats_handles_read_exception(self):
+        change_working_directory_to("test7")
+
+        user_record = _make_aggregate_record("User", "test::user")
+        aggregates = {"test.User": user_record}
+
+        mock_domain = _mock_domain_with_store(aggregates=aggregates)
+        store = mock_domain.event_store.store
+        store._stream_identifiers.return_value = ["id1"]
+        store._read.side_effect = Exception("Connection error")
+
+        with patch("protean.cli.events.derive_domain", return_value=mock_domain):
+            result = runner.invoke(
+                app,
+                ["events", "stats", "--domain", "publishing7.py"],
+            )
+            assert result.exit_code == 0
+            assert "User" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Search with --data flag
+# ---------------------------------------------------------------------------
+
+
+class TestEventsSearchData:
+    @pytest.fixture(autouse=True)
+    def reset_path(self):
+        original_path = sys.path[:]
+        cwd = Path.cwd()
+        yield
+        sys.path[:] = original_path
+        os.chdir(cwd)
+
+    def test_search_with_data_flag(self):
+        change_working_directory_to("test7")
+
+        events = [
+            _make_raw_event(0, 1, data={"email": "test@example.com"}),
+        ]
+        mock_domain = _mock_domain_with_store(read_return=events)
+
+        with patch("protean.cli.events.derive_domain", return_value=mock_domain):
+            result = runner.invoke(
+                app,
+                [
+                    "events",
+                    "search",
+                    "--type",
+                    "UserRegistered",
+                    "--domain",
+                    "publishing7.py",
+                    "--data",
+                ],
+            )
+            assert result.exit_code == 0
+            assert "test@example.com" in result.output


### PR DESCRIPTION
Add `protean events` command group with four subcommands for inspecting the event store without writing custom scripts:

- `protean events read <stream>` — display events from a stream with --from, --limit, and --data options
- `protean events stats` — show per-aggregate statistics including instance counts, event totals, and latest activity
- `protean events search --type <name>` — find events by type with partial (case-insensitive) or exact matching, filterable by category
- `protean events history --aggregate <Name> --id <id>` — display the full event timeline for a specific aggregate instance with snapshot info

All commands work on raw message dicts from the event store, making them resilient even when event types have been renamed or removed. No new abstract methods were added to BaseEventStore — the commands compose existing _read(), _read_last_message(), and _stream_identifiers() APIs.