### PR TITLE
Enhance event-sourced test DSL

### DIFF
--- a/tests/testing/test_event_log.py
+++ b/tests/testing/test_event_log.py
@@ -246,3 +246,48 @@ class TestEventAttributeAccess:
         log = EventLog([event])
 
         assert log[0].customer == "Charlie"
+
+
+# ---------------------------------------------------------------------------
+# Tests: Truthiness (__bool__)
+# ---------------------------------------------------------------------------
+class TestEventLogBool:
+    def test_empty_log_is_falsy(self, empty_log):
+        assert not empty_log
+        assert bool(empty_log) is False
+
+    def test_non_empty_log_is_truthy(self, single_log):
+        assert single_log
+        assert bool(single_log) is True
+
+    def test_multi_log_is_truthy(self, multi_log):
+        assert multi_log
+        assert bool(multi_log) is True
+
+
+# ---------------------------------------------------------------------------
+# Tests: .first and .last properties
+# ---------------------------------------------------------------------------
+class TestEventLogFirstLast:
+    def test_first_on_empty_log(self, empty_log):
+        assert empty_log.first is None
+
+    def test_last_on_empty_log(self, empty_log):
+        assert empty_log.last is None
+
+    def test_first_on_single_log(self, single_log, placed_event):
+        assert single_log.first is placed_event
+
+    def test_last_on_single_log(self, single_log, placed_event):
+        assert single_log.last is placed_event
+
+    def test_first_on_multi_log(self, multi_log, placed_event):
+        assert multi_log.first is placed_event
+
+    def test_last_on_multi_log(self, multi_log, payment_event):
+        assert multi_log.last is payment_event
+
+    def test_first_and_last_differ(self, multi_log, placed_event, payment_event):
+        assert multi_log.first is placed_event
+        assert multi_log.last is payment_event
+        assert multi_log.first is not multi_log.last


### PR DESCRIPTION
Enhance event-sourced test DSL with multi-command chaining, EventLog improvements, and rejection ergonomics

Add multi-command chaining support to `given().process()`, allowing `.process()` to be called repeatedly to build up aggregate state through the real pipeline — eliminating the need to hand-craft event fixtures for setup steps:

    order = (
        given(Order)
        .process(CreateOrder(order_id=oid, customer="Alice", amount=99.99))
        .process(ConfirmOrder(order_id=oid))
        .process(InitiatePayment(order_id=oid, payment_id="pay-001"))
    )

New AggregateResult features:
- `.process()` can be called multiple times; `.events` reflects the last command, `.all_events` accumulates across all calls, `.accepted`/ `.rejected` reflects the last command
- `.rejection_messages` returns a flat list of error strings, flattening ValidationError.messages dict values for cleaner assertions

New EventLog features:
- `__bool__`: `assert result.events` / `assert not result.events`
- `.first` / `.last`: safe access returning None on empty logs

Also removes an unreachable dead code branch in the rejection handler (the `elif self._given_events` path could never execute because `_seed_events` always sets `_aggregate_id` before command processing).