### PR TITLE
Add message enrichment hooks for events and commands

### DIFF
--- a/docs/guides/domain-behavior/index.md
+++ b/docs/guides/domain-behavior/index.md
@@ -47,6 +47,17 @@ Domain events record significant state changes and enable communication between 
 
 [Learn more about raising events →](raising-events.md)
 
+### Message Tracing & Enrichment
+
+Protean automatically tracks causal chains across commands and events, and
+lets you attach custom metadata to every message:
+
+- **Correlation & causation IDs** - Automatically propagated through command → event chains
+- **Message enrichment hooks** - Register callables that add custom metadata (user context, tenant ID, audit data) to every event and command
+- **Extensions metadata** - A user-space `metadata.extensions` dict persisted in the event store
+
+[Learn more about message tracing →](message-tracing.md) &nbsp;|&nbsp; [Learn more about message enrichment →](message-enrichment.md)
+
 ### Domain Services
 
 Domain services encapsulate business logic that doesn't naturally fit within any single aggregate:

--- a/docs/guides/domain-behavior/message-enrichment.md
+++ b/docs/guides/domain-behavior/message-enrichment.md
@@ -1,0 +1,180 @@
+# Message Enrichment
+
+!!! abstract "Applies to: CQRS · Event Sourcing"
+
+
+In event-driven systems, every event and command often needs cross-cutting
+metadata that has nothing to do with the event's business payload -- who
+performed the action, which tenant it belongs to, the originating IP address,
+or custom audit context. Without a central mechanism, developers must sprinkle
+this logic into every `raise_()` call, which is repetitive and easy to forget.
+
+**Message enrichment hooks** solve this by letting you register callables on
+the domain that automatically add custom metadata to every event and command.
+The enriched data is stored in `metadata.extensions` -- a user-space dict that
+is persisted alongside all other metadata in the event store and survives
+serialization round-trips.
+
+## Event Enrichers
+
+An **event enricher** is a callable that receives the event being raised and
+the aggregate instance, and returns a `dict[str, Any]` of key-value pairs
+to merge into `metadata.extensions`.
+
+### Registration
+
+Register enrichers with `domain.register_event_enricher()` or the
+`@domain.event_enricher` decorator:
+
+```python
+# Functional registration
+def add_user_context(event, aggregate):
+    """Enrich every event with the current user."""
+    user = get_current_user()
+    return {
+        "user_id": user.id if user else "system",
+        "tenant_id": get_current_tenant_id(),
+    }
+
+domain.register_event_enricher(add_user_context)
+```
+
+```python
+# Decorator registration
+@domain.event_enricher
+def add_audit_context(event, aggregate):
+    return {"ip_address": get_client_ip()}
+```
+
+### How It Works
+
+Enrichers run inside `aggregate.raise_()`, **after** the event's full metadata
+(headers, envelope, domain meta) is constructed but **before** the event is
+appended to `aggregate._events`. This means:
+
+- Enrichers have access to the **event payload** (e.g., `event.email`)
+- Enrichers have access to the **aggregate** (e.g., `aggregate.tenant_id`, `aggregate.id`)
+- The event's core metadata (correlation ID, stream, sequence) is already set
+- Extensions are included when the event is stored in the event store
+
+### Enricher Signature
+
+```python
+def enricher(event: BaseEvent, aggregate: BaseAggregate) -> dict[str, Any]:
+    """Return key-value pairs to merge into metadata.extensions."""
+```
+
+| Parameter   | Description |
+|-------------|-------------|
+| `event`     | The domain event being raised, with its payload fields accessible |
+| `aggregate` | The aggregate instance raising the event |
+| **Returns** | A `dict[str, Any]` merged into `metadata.extensions` |
+
+### Multiple Enrichers
+
+You can register any number of enrichers. They execute in registration order
+(FIFO), and their results are merged. If two enrichers set the same key, the
+later one wins:
+
+```python
+@domain.event_enricher
+def add_user(event, aggregate):
+    return {"source": "user-enricher", "user_id": "u-123"}
+
+@domain.event_enricher
+def add_tenant(event, aggregate):
+    return {"source": "tenant-enricher", "tenant_id": "t-456"}
+
+# Result: {"source": "tenant-enricher", "user_id": "u-123", "tenant_id": "t-456"}
+```
+
+## Command Enrichers
+
+A **command enricher** works the same way but for commands processed via
+`domain.process()`. Since commands haven't reached a handler yet, enrichers
+receive only the command (no aggregate):
+
+```python
+@domain.command_enricher
+def add_request_context(command):
+    return {
+        "request_id": get_request_id(),
+        "ip_address": get_client_ip(),
+    }
+```
+
+### Enricher Signature
+
+```python
+def enricher(command: BaseCommand) -> dict[str, Any]:
+    """Return key-value pairs to merge into metadata.extensions."""
+```
+
+## Accessing Extensions
+
+After raising an event, extensions are available on the metadata:
+
+```python
+user.register()
+event = user._events[0]
+print(event._metadata.extensions)
+# {"user_id": "u-123", "tenant_id": "acme-corp"}
+```
+
+Extensions are included in the serialized form and survive round-trips
+through the event store:
+
+```python
+message = Message.from_domain_object(event)
+msg_dict = message.to_dict()
+print(msg_dict["metadata"]["extensions"])
+# {"user_id": "u-123", "tenant_id": "acme-corp"}
+
+# Deserialize back
+restored = Message.deserialize(msg_dict)
+print(restored.metadata.extensions)
+# {"user_id": "u-123", "tenant_id": "acme-corp"}
+```
+
+## Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| Enricher returns `None` | Treated as no-op, extensions unchanged |
+| Enricher returns `{}` | Treated as no-op, extensions unchanged |
+| Enricher raises an exception | Exception propagates; event is not appended / command is not processed |
+| No enrichers registered | `extensions` defaults to `{}` |
+| Legacy messages (pre-enrichment) | Deserialize with `extensions: {}` |
+
+## Fact Events
+
+Event enrichers also run on [fact events](../domain-definition/events.md#fact-events).
+Since fact events pass through `raise_()` like any other event, they
+are enriched automatically.
+
+## Best Practices
+
+1. **Keep enrichers fast** -- they run synchronously inside `raise_()` for
+   every event. Avoid I/O calls; prefer reading from thread-local context
+   (like Flask's `g` or Protean's `g`).
+
+2. **Use enrichers for cross-cutting concerns only** -- user context, tenant
+   ID, request tracing, audit metadata. Don't use them for business logic
+   that belongs in the aggregate or event itself.
+
+3. **Use `metadata.extensions` for querying** -- the Outbox and event store
+   persist extensions, making them available for filtering and correlation
+   in downstream processing.
+
+4. **Combine with [message tracing](message-tracing.md)** -- enrichers
+   complement correlation and causation IDs. Use correlation_id for causal
+   chains and extensions for contextual metadata (who, where, why).
+
+---
+
+!!! tip "See also"
+    **Related guides:**
+
+    - [Message Tracing](message-tracing.md) -- Correlation and causation IDs for distributed tracing
+    - [Raising Events](raising-events.md) -- How aggregates raise domain events
+    - [Commands](../../guides/change-state/commands.md) -- Command processing via `domain.process()`

--- a/docs/guides/domain-behavior/message-tracing.md
+++ b/docs/guides/domain-behavior/message-tracing.md
@@ -188,6 +188,8 @@ This is useful for operational dashboards and debugging delivery issues.
 ---
 
 !!! tip "See also"
+    **Related guide:** [Message Enrichment](message-enrichment.md) -- Automatically add custom metadata (user context, tenant ID, audit data) to every event and command via enricher hooks.
+
     **Pattern:** [Message Tracing in Event-Driven Systems](../../patterns/message-tracing.md) -- Design considerations, when to use external vs generated IDs, and multi-service tracing strategies.
 
     **Reference:** [`protean events trace`](../../reference/cli/data/events.md) -- CLI command for following causal chains.

--- a/docs/guides/domain-behavior/raising-events.md
+++ b/docs/guides/domain-behavior/raising-events.md
@@ -162,6 +162,11 @@ and the output stream is `user-fact-e97cef08-f11d-43eb-8a69-251a0828bbff`
 !!! tip "See also"
     **Concept overview:** [Events](../../concepts/building-blocks/events.md) — Domain events and their role in system communication.
 
+    **Related guides:**
+
+    - [Message Enrichment](message-enrichment.md) — Automatically add custom metadata (user context, tenant ID, audit data) to every event.
+    - [Message Tracing](message-tracing.md) — Follow causal chains with correlation and causation IDs.
+
     **Patterns:**
 
     - [Design Events for Consumers](../../patterns/design-events-for-consumers.md) — Structuring events so consumers can process them reliably.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -174,6 +174,7 @@ nav:
       - guides/domain-behavior/aggregate-mutation.md
       - guides/domain-behavior/raising-events.md
       - guides/domain-behavior/message-tracing.md
+      - guides/domain-behavior/message-enrichment.md
       - guides/domain-behavior/domain-services.md
     - Change State:
       - guides/change-state/index.md

--- a/src/protean/core/aggregate.py
+++ b/src/protean/core/aggregate.py
@@ -205,6 +205,22 @@ class BaseAggregate(BaseEntity):
             domain=domain_meta,
         )
 
+        # Run event enrichers
+        if current_domain._event_enrichers:
+            extensions = dict(metadata.extensions)
+            for enricher in current_domain._event_enrichers:
+                result = enricher(event, self)
+                if result:
+                    extensions.update(result)
+            if extensions:
+                metadata = Metadata(
+                    headers=metadata.headers,
+                    envelope=metadata.envelope,
+                    domain=metadata.domain,
+                    event_store=metadata.event_store,
+                    extensions=extensions,
+                )
+
         event_with_metadata = event.__class__(
             event.payload,
             _expected_version=self._event_position,

--- a/src/protean/core/command.py
+++ b/src/protean/core/command.py
@@ -203,6 +203,9 @@ class BaseCommand(BaseMessageType):
         metadata_kwargs = {"headers": headers, "domain": domain_meta}
         if existing_envelope is not None:
             metadata_kwargs["envelope"] = existing_envelope
+        # Preserve extensions from incoming metadata (set by command enrichers)
+        if incoming and hasattr(incoming, "extensions") and incoming.extensions:
+            metadata_kwargs["extensions"] = incoming.extensions
         self._metadata = Metadata(**metadata_kwargs)
 
 

--- a/src/protean/core/event.py
+++ b/src/protean/core/event.py
@@ -209,6 +209,9 @@ class BaseEvent(BaseMessageType):
         metadata_kwargs = {"headers": headers, "domain": domain_meta}
         if existing_envelope is not None:
             metadata_kwargs["envelope"] = existing_envelope
+        # Preserve extensions from incoming metadata (set by event enrichers)
+        if incoming and hasattr(incoming, "extensions") and incoming.extensions:
+            metadata_kwargs["extensions"] = incoming.extensions
         self._metadata = Metadata(**metadata_kwargs)
 
 

--- a/src/protean/domain/__init__.py
+++ b/src/protean/domain/__init__.py
@@ -252,6 +252,13 @@ class Domain:
         self._upcasters: list[type] = []
         self._upcaster_chain: UpcasterChain = UpcasterChain()
 
+        # Message enricher hooks — callables that add custom metadata to events/commands.
+        # Event enrichers receive (event, aggregate) and return dict[str, Any].
+        # Command enrichers receive (command,) and return dict[str, Any].
+        # Results are merged into metadata.extensions.
+        self._event_enrichers: List[Callable] = []
+        self._command_enrichers: List[Callable] = []
+
         #: A list of functions that are called when the domain context
         #: is destroyed.  This is the place to store code that cleans up and
         #: disconnects from databases, for example.
@@ -1612,6 +1619,93 @@ class Domain:
             return wrap
         return wrap(_cls)
 
+    ########################
+    # Message Enrichment  #
+    ########################
+    def register_event_enricher(self, fn: Callable) -> None:
+        """Register a callable that enriches every event's metadata.
+
+        The enricher is called during :meth:`~protean.core.aggregate.raise_`
+        with ``(event, aggregate)`` and must return a ``dict[str, Any]``
+        whose entries are merged into ``metadata.extensions``.
+
+        Enrichers execute in registration order (FIFO).  Later enrichers
+        can overwrite keys set by earlier ones.  If an enricher raises an
+        exception it propagates and the event is not appended.
+
+        Args:
+            fn: A callable with signature ``(event, aggregate) -> dict[str, Any]``.
+
+        Example::
+
+            def add_user_context(event, aggregate):
+                return {"user_id": get_current_user_id()}
+
+            domain.register_event_enricher(add_user_context)
+        """
+        if not callable(fn):
+            raise IncorrectUsageError("Event enricher must be callable")
+        self._event_enrichers.append(fn)
+
+    @property
+    def event_enricher(self) -> Callable:
+        """Decorator form of :meth:`register_event_enricher`.
+
+        Example::
+
+            @domain.event_enricher
+            def add_tenant(event, aggregate):
+                return {"tenant_id": get_current_tenant_id()}
+        """
+
+        def decorator(fn: Callable) -> Callable:
+            self.register_event_enricher(fn)
+            return fn
+
+        return decorator
+
+    def register_command_enricher(self, fn: Callable) -> None:
+        """Register a callable that enriches every command's metadata.
+
+        The enricher is called during :meth:`process` with ``(command,)``
+        and must return a ``dict[str, Any]`` whose entries are merged into
+        ``metadata.extensions``.
+
+        Enrichers execute in registration order (FIFO).  Later enrichers
+        can overwrite keys set by earlier ones.  If an enricher raises an
+        exception it propagates and the command is not processed.
+
+        Args:
+            fn: A callable with signature ``(command,) -> dict[str, Any]``.
+
+        Example::
+
+            def add_request_context(command):
+                return {"request_id": get_request_id()}
+
+            domain.register_command_enricher(add_request_context)
+        """
+        if not callable(fn):
+            raise IncorrectUsageError("Command enricher must be callable")
+        self._command_enrichers.append(fn)
+
+    @property
+    def command_enricher(self) -> Callable:
+        """Decorator form of :meth:`register_command_enricher`.
+
+        Example::
+
+            @domain.command_enricher
+            def add_request_id(command):
+                return {"request_id": get_request_id()}
+        """
+
+        def decorator(fn: Callable) -> Callable:
+            self.register_command_enricher(fn)
+            return fn
+
+        return decorator
+
     #####################
     # Handling Commands #
     #####################
@@ -1691,6 +1785,22 @@ class Domain:
             envelope=envelope,
             domain=domain_meta,
         )
+
+        # Run command enrichers
+        if self._command_enrichers:
+            extensions = dict(metadata.extensions)
+            for enricher in self._command_enrichers:
+                result = enricher(command)
+                if result:
+                    extensions.update(result)
+            if extensions:
+                metadata = Metadata(
+                    headers=metadata.headers,
+                    envelope=metadata.envelope,
+                    domain=metadata.domain,
+                    event_store=metadata.event_store,
+                    extensions=extensions,
+                )
 
         command_with_metadata = command.__class__(
             command.to_dict(),

--- a/src/protean/utils/eventing.py
+++ b/src/protean/utils/eventing.py
@@ -191,10 +191,24 @@ class EventStoreMeta(BaseValueObject):
 
 
 class Metadata(BaseValueObject):
+    """Complete metadata for a domain message (event or command).
+
+    Attributes:
+        headers: Transport-level metadata (id, type, stream, time, traceparent).
+        envelope: Integrity and versioning (specversion, checksum).
+        domain: Domain-level metadata (fqn, kind, correlation/causation IDs, etc.).
+        event_store: Store-level metadata (positions), set after persistence.
+        extensions: User-provided metadata populated by message enrichment hooks.
+            Registered via ``domain.register_event_enricher()`` or
+            ``domain.register_command_enricher()``.  Persisted alongside all
+            other metadata and survives serialization round-trips.
+    """
+
     headers: MessageHeaders
     envelope: MessageEnvelope | None = PydanticField(default_factory=MessageEnvelope)
     domain: DomainMeta | None = None
     event_store: EventStoreMeta | None = None
+    extensions: dict[str, Any] = PydanticField(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/command/test_command_enrichment.py
+++ b/tests/command/test_command_enrichment.py
@@ -1,0 +1,272 @@
+"""Tests for command enrichment hooks.
+
+Command enrichers are callables registered on the domain that automatically
+add custom metadata (``metadata.extensions``) to every command processed
+via ``domain.process()`` or ``domain._enrich_command()``.
+"""
+
+from uuid import uuid4
+
+import pytest
+
+from protean.core.aggregate import BaseAggregate
+from protean.core.command import BaseCommand
+from protean.core.command_handler import BaseCommandHandler
+from protean.core.event import BaseEvent
+from protean.exceptions import IncorrectUsageError
+from protean.fields import Identifier, String
+from protean.utils.eventing import Message
+from protean.utils.mixins import handle
+
+
+# ---------------------------------------------------------------------------
+# Test domain elements
+# ---------------------------------------------------------------------------
+class User(BaseAggregate):
+    id: Identifier(identifier=True)
+    email: String()
+    name: String()
+
+
+class Register(BaseCommand):
+    user_id: Identifier(identifier=True)
+    email: String()
+
+
+class Activate(BaseCommand):
+    user_id: Identifier(identifier=True)
+
+
+class UserRegistered(BaseEvent):
+    user_id: Identifier(identifier=True)
+
+
+class RegisterHandler(BaseCommandHandler):
+    @handle(Register)
+    def handle_register(self, command: Register):
+        User(id=command.user_id, email=command.email, name="Test")
+
+
+@pytest.fixture(autouse=True)
+def register_elements(test_domain):
+    test_domain.register(User)
+    test_domain.register(Register, part_of=User)
+    test_domain.register(Activate, part_of=User)
+    test_domain.register(UserRegistered, part_of=User)
+    test_domain.register(RegisterHandler, part_of=User)
+    test_domain.init(traverse=False)
+
+
+# ---------------------------------------------------------------------------
+# Basic enrichment
+# ---------------------------------------------------------------------------
+class TestBasicCommandEnrichment:
+    def test_single_enricher(self, test_domain):
+        """A registered enricher populates metadata.extensions on the command."""
+
+        def add_request_id(command):
+            return {"request_id": "req-123"}
+
+        test_domain.register_command_enricher(add_request_id)
+
+        command = Register(user_id=str(uuid4()), email="a@b.com")
+        enriched = test_domain._enrich_command(command, asynchronous=True)
+
+        assert enriched._metadata.extensions == {"request_id": "req-123"}
+
+    def test_multiple_enrichers_merge(self, test_domain):
+        """Multiple enrichers contribute to extensions (merge semantics)."""
+
+        def add_user(command):
+            return {"user_id": "u-123"}
+
+        def add_tenant(command):
+            return {"tenant_id": "t-456"}
+
+        test_domain.register_command_enricher(add_user)
+        test_domain.register_command_enricher(add_tenant)
+
+        command = Register(user_id=str(uuid4()), email="a@b.com")
+        enriched = test_domain._enrich_command(command, asynchronous=True)
+
+        assert enriched._metadata.extensions == {
+            "user_id": "u-123",
+            "tenant_id": "t-456",
+        }
+
+    def test_later_enricher_overrides_earlier(self, test_domain):
+        """When two enrichers set the same key, the last one wins."""
+
+        def first(command):
+            return {"source": "first"}
+
+        def second(command):
+            return {"source": "second"}
+
+        test_domain.register_command_enricher(first)
+        test_domain.register_command_enricher(second)
+
+        command = Register(user_id=str(uuid4()), email="a@b.com")
+        enriched = test_domain._enrich_command(command, asynchronous=True)
+
+        assert enriched._metadata.extensions["source"] == "second"
+
+
+# ---------------------------------------------------------------------------
+# Enricher access to command fields
+# ---------------------------------------------------------------------------
+class TestEnricherAccess:
+    def test_enricher_can_read_command_fields(self, test_domain):
+        """Enricher receives the command and can read its payload fields."""
+
+        def mirror_email(command):
+            return {"command_email": command.email}
+
+        test_domain.register_command_enricher(mirror_email)
+
+        command = Register(user_id=str(uuid4()), email="test@example.com")
+        enriched = test_domain._enrich_command(command, asynchronous=True)
+
+        assert enriched._metadata.extensions["command_email"] == "test@example.com"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+class TestCommandEnricherEdgeCases:
+    def test_no_enrichers_gives_empty_extensions(self, test_domain):
+        """Without enrichers, extensions defaults to empty dict."""
+        command = Register(user_id=str(uuid4()), email="a@b.com")
+        enriched = test_domain._enrich_command(command, asynchronous=True)
+
+        assert enriched._metadata.extensions == {}
+
+    def test_enricher_returning_none(self, test_domain):
+        """An enricher returning None is treated as a no-op."""
+
+        def noop(command):
+            return None
+
+        test_domain.register_command_enricher(noop)
+
+        command = Register(user_id=str(uuid4()), email="a@b.com")
+        enriched = test_domain._enrich_command(command, asynchronous=True)
+
+        assert enriched._metadata.extensions == {}
+
+    def test_enricher_returning_empty_dict(self, test_domain):
+        """An enricher returning {} is treated as a no-op."""
+
+        def noop(command):
+            return {}
+
+        test_domain.register_command_enricher(noop)
+
+        command = Register(user_id=str(uuid4()), email="a@b.com")
+        enriched = test_domain._enrich_command(command, asynchronous=True)
+
+        assert enriched._metadata.extensions == {}
+
+    def test_error_in_enricher_propagates(self, test_domain):
+        """If an enricher raises, the exception propagates."""
+
+        def bad_enricher(command):
+            raise ValueError("enricher failed")
+
+        test_domain.register_command_enricher(bad_enricher)
+
+        command = Register(user_id=str(uuid4()), email="a@b.com")
+        with pytest.raises(ValueError, match="enricher failed"):
+            test_domain._enrich_command(command, asynchronous=True)
+
+    def test_non_callable_raises_error(self, test_domain):
+        """Registering a non-callable raises IncorrectUsageError."""
+        with pytest.raises(IncorrectUsageError, match="callable"):
+            test_domain.register_command_enricher(42)
+
+
+# ---------------------------------------------------------------------------
+# Decorator registration
+# ---------------------------------------------------------------------------
+class TestDecoratorRegistration:
+    def test_command_enricher_decorator(self, test_domain):
+        """The @domain.command_enricher decorator registers and returns the fn."""
+
+        @test_domain.command_enricher
+        def add_source(command):
+            return {"source": "decorator"}
+
+        assert callable(add_source)
+        assert add_source.__name__ == "add_source"
+
+        command = Register(user_id=str(uuid4()), email="a@b.com")
+        enriched = test_domain._enrich_command(command, asynchronous=True)
+
+        assert enriched._metadata.extensions == {"source": "decorator"}
+
+
+# ---------------------------------------------------------------------------
+# Extensions survive through domain.process() and handler
+# ---------------------------------------------------------------------------
+class TestExtensionsThroughProcessing:
+    def test_extensions_reach_event_store(self, test_domain):
+        """Command extensions are persisted to the event store."""
+
+        def add_context(command):
+            return {"tenant_id": "acme"}
+
+        test_domain.register_command_enricher(add_context)
+
+        identifier = str(uuid4())
+        command = Register(user_id=identifier, email="a@b.com")
+        test_domain.process(command, asynchronous=False)
+
+        # Read command from event store
+        last_msg = test_domain.event_store.store.read_last_message(
+            f"test::user:command-{identifier}"
+        )
+        assert last_msg is not None
+        assert last_msg.metadata.extensions == {"tenant_id": "acme"}
+
+
+# ---------------------------------------------------------------------------
+# Serialization round-trip
+# ---------------------------------------------------------------------------
+class TestSerializationRoundTrip:
+    def test_extensions_survive_message_round_trip(self, test_domain):
+        """Extensions survive: command → Message → dict → deserialize → extensions."""
+
+        def add_context(command):
+            return {"request_id": "r-1", "ip": "127.0.0.1"}
+
+        test_domain.register_command_enricher(add_context)
+
+        command = Register(user_id=str(uuid4()), email="a@b.com")
+        enriched = test_domain._enrich_command(command, asynchronous=True)
+
+        message = Message.from_domain_object(enriched)
+        msg_dict = message.to_dict()
+
+        assert msg_dict["metadata"]["extensions"] == {
+            "request_id": "r-1",
+            "ip": "127.0.0.1",
+        }
+
+        restored = Message.deserialize(msg_dict)
+        assert restored.metadata.extensions == {
+            "request_id": "r-1",
+            "ip": "127.0.0.1",
+        }
+
+    def test_empty_extensions_in_serialization(self, test_domain):
+        """Empty extensions serialize as {} and deserialize back."""
+        command = Register(user_id=str(uuid4()), email="a@b.com")
+        enriched = test_domain._enrich_command(command, asynchronous=True)
+
+        message = Message.from_domain_object(enriched)
+        msg_dict = message.to_dict()
+
+        assert msg_dict["metadata"]["extensions"] == {}
+
+        restored = Message.deserialize(msg_dict)
+        assert restored.metadata.extensions == {}

--- a/tests/command/test_command_metadata.py
+++ b/tests/command/test_command_metadata.py
@@ -145,6 +145,7 @@ def test_command_metadata(test_domain):
                     "idempotency_key": None,
                 },
                 "event_store": None,
+                "extensions": {},
             },
             "user_id": command.user_id,
         }

--- a/tests/event/test_event_enrichment.py
+++ b/tests/event/test_event_enrichment.py
@@ -1,0 +1,450 @@
+"""Tests for event enrichment hooks.
+
+Event enrichers are callables registered on the domain that automatically
+add custom metadata (``metadata.extensions``) to every event raised via
+``aggregate.raise_()``.
+"""
+
+from uuid import uuid4
+
+import pytest
+
+from protean import apply
+from protean.core.aggregate import BaseAggregate
+from protean.core.event import BaseEvent
+from protean.exceptions import IncorrectUsageError
+from protean.fields import String
+from protean.fields.basic import Identifier
+from protean.utils.eventing import Message
+
+
+# ---------------------------------------------------------------------------
+# Test domain elements
+# ---------------------------------------------------------------------------
+class UserRegistered(BaseEvent):
+    user_id: Identifier(identifier=True)
+    email: String()
+
+
+class UserActivated(BaseEvent):
+    user_id: Identifier(identifier=True)
+
+
+class User(BaseAggregate):
+    id: Identifier(identifier=True)
+    email: String()
+    name: String()
+    tenant_id: String(default="default")
+
+    def register(self):
+        self.raise_(UserRegistered(user_id=self.id, email=self.email))
+
+    def activate(self):
+        self.raise_(UserActivated(user_id=self.id))
+
+    @apply
+    def on_registered(self, event: UserRegistered) -> None:
+        pass
+
+    @apply
+    def on_activated(self, event: UserActivated) -> None:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def register_elements(test_domain):
+    test_domain.register(User, is_event_sourced=True)
+    test_domain.register(UserRegistered, part_of=User)
+    test_domain.register(UserActivated, part_of=User)
+    test_domain.init(traverse=False)
+
+
+# ---------------------------------------------------------------------------
+# Basic enrichment
+# ---------------------------------------------------------------------------
+class TestBasicEventEnrichment:
+    def test_single_enricher(self, test_domain):
+        """A registered enricher populates metadata.extensions."""
+
+        def add_audit(event, aggregate):
+            return {"auditor": "system"}
+
+        test_domain.register_event_enricher(add_audit)
+
+        user = User(id=str(uuid4()), email="a@b.com", name="A")
+        user.register()
+
+        event = user._events[0]
+        assert event._metadata.extensions == {"auditor": "system"}
+
+    def test_multiple_enrichers_merge(self, test_domain):
+        """Multiple enrichers contribute to extensions (merge semantics)."""
+
+        def add_user(event, aggregate):
+            return {"user_id": "u-123"}
+
+        def add_tenant(event, aggregate):
+            return {"tenant_id": "t-456"}
+
+        test_domain.register_event_enricher(add_user)
+        test_domain.register_event_enricher(add_tenant)
+
+        user = User(id=str(uuid4()), email="a@b.com", name="A")
+        user.register()
+
+        event = user._events[0]
+        assert event._metadata.extensions == {
+            "user_id": "u-123",
+            "tenant_id": "t-456",
+        }
+
+    def test_later_enricher_overrides_earlier(self, test_domain):
+        """When two enrichers set the same key, the last one wins."""
+
+        def first(event, aggregate):
+            return {"source": "first"}
+
+        def second(event, aggregate):
+            return {"source": "second"}
+
+        test_domain.register_event_enricher(first)
+        test_domain.register_event_enricher(second)
+
+        user = User(id=str(uuid4()), email="a@b.com", name="A")
+        user.register()
+
+        event = user._events[0]
+        assert event._metadata.extensions["source"] == "second"
+
+
+# ---------------------------------------------------------------------------
+# Enricher access to event and aggregate
+# ---------------------------------------------------------------------------
+class TestEnricherAccess:
+    def test_enricher_can_read_aggregate_fields(self, test_domain):
+        """Enricher receives the aggregate and can read its fields."""
+
+        def add_tenant(event, aggregate):
+            return {"tenant_id": aggregate.tenant_id}
+
+        test_domain.register_event_enricher(add_tenant)
+
+        user = User(id=str(uuid4()), email="a@b.com", name="A", tenant_id="acme-corp")
+        user.register()
+
+        event = user._events[0]
+        assert event._metadata.extensions["tenant_id"] == "acme-corp"
+
+    def test_enricher_can_read_event_payload(self, test_domain):
+        """Enricher receives the event and can read its payload fields."""
+
+        def mirror_email(event, aggregate):
+            return {"event_email": event.email}
+
+        test_domain.register_event_enricher(mirror_email)
+
+        user = User(id=str(uuid4()), email="test@example.com", name="A")
+        user.register()
+
+        event = user._events[0]
+        assert event._metadata.extensions["event_email"] == "test@example.com"
+
+    def test_enricher_can_read_aggregate_identity(self, test_domain):
+        """Enricher can access the aggregate's identity."""
+
+        def add_agg_id(event, aggregate):
+            return {"aggregate_id": aggregate.id}
+
+        test_domain.register_event_enricher(add_agg_id)
+
+        user_id = str(uuid4())
+        user = User(id=user_id, email="a@b.com", name="A")
+        user.register()
+
+        event = user._events[0]
+        assert event._metadata.extensions["aggregate_id"] == user_id
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+class TestEnricherEdgeCases:
+    def test_no_enrichers_gives_empty_extensions(self, test_domain):
+        """Without enrichers, extensions defaults to empty dict."""
+        user = User(id=str(uuid4()), email="a@b.com", name="A")
+        user.register()
+
+        event = user._events[0]
+        assert event._metadata.extensions == {}
+
+    def test_enricher_returning_none(self, test_domain):
+        """An enricher returning None is treated as a no-op."""
+
+        def noop(event, aggregate):
+            return None
+
+        test_domain.register_event_enricher(noop)
+
+        user = User(id=str(uuid4()), email="a@b.com", name="A")
+        user.register()
+
+        event = user._events[0]
+        assert event._metadata.extensions == {}
+
+    def test_enricher_returning_empty_dict(self, test_domain):
+        """An enricher returning {} is treated as a no-op."""
+
+        def noop(event, aggregate):
+            return {}
+
+        test_domain.register_event_enricher(noop)
+
+        user = User(id=str(uuid4()), email="a@b.com", name="A")
+        user.register()
+
+        event = user._events[0]
+        assert event._metadata.extensions == {}
+
+    def test_error_in_enricher_propagates(self, test_domain):
+        """If an enricher raises, the exception propagates from raise_()."""
+
+        def bad_enricher(event, aggregate):
+            raise ValueError("enricher failed")
+
+        test_domain.register_event_enricher(bad_enricher)
+
+        user = User(id=str(uuid4()), email="a@b.com", name="A")
+        with pytest.raises(ValueError, match="enricher failed"):
+            user.register()
+
+        # Event was not appended
+        assert len(user._events) == 0
+
+    def test_non_callable_raises_error(self, test_domain):
+        """Registering a non-callable raises IncorrectUsageError."""
+        with pytest.raises(IncorrectUsageError, match="callable"):
+            test_domain.register_event_enricher("not a function")
+
+    def test_enrichers_run_for_all_events(self, test_domain):
+        """Enrichers run for every event, not just the first."""
+        call_count = 0
+
+        def counting_enricher(event, aggregate):
+            nonlocal call_count
+            call_count += 1
+            return {"call": call_count}
+
+        test_domain.register_event_enricher(counting_enricher)
+
+        user = User(id=str(uuid4()), email="a@b.com", name="A")
+        user.register()
+        user.activate()
+
+        assert len(user._events) == 2
+        assert user._events[0]._metadata.extensions == {"call": 1}
+        assert user._events[1]._metadata.extensions == {"call": 2}
+
+
+# ---------------------------------------------------------------------------
+# Decorator registration
+# ---------------------------------------------------------------------------
+class TestDecoratorRegistration:
+    def test_event_enricher_decorator(self, test_domain):
+        """The @domain.event_enricher decorator registers and returns the fn."""
+
+        @test_domain.event_enricher
+        def add_source(event, aggregate):
+            return {"source": "decorator"}
+
+        # Function is still callable
+        assert callable(add_source)
+        assert add_source.__name__ == "add_source"
+
+        user = User(id=str(uuid4()), email="a@b.com", name="A")
+        user.register()
+
+        event = user._events[0]
+        assert event._metadata.extensions == {"source": "decorator"}
+
+
+# ---------------------------------------------------------------------------
+# Serialization round-trip
+# ---------------------------------------------------------------------------
+class TestSerializationRoundTrip:
+    def test_extensions_survive_message_round_trip(self, test_domain):
+        """Extensions survive: event → Message → dict → deserialize → extensions."""
+
+        def add_context(event, aggregate):
+            return {"user_id": "u-1", "tenant_id": "t-2"}
+
+        test_domain.register_event_enricher(add_context)
+
+        user = User(id=str(uuid4()), email="a@b.com", name="A")
+        user.register()
+
+        event = user._events[0]
+
+        # Serialize to Message
+        message = Message.from_domain_object(event)
+        msg_dict = message.to_dict()
+
+        # Verify extensions in serialized form
+        assert msg_dict["metadata"]["extensions"] == {
+            "user_id": "u-1",
+            "tenant_id": "t-2",
+        }
+
+        # Deserialize back
+        restored = Message.deserialize(msg_dict)
+        assert restored.metadata.extensions == {"user_id": "u-1", "tenant_id": "t-2"}
+
+    def test_empty_extensions_in_serialization(self, test_domain):
+        """Empty extensions serialize as {} and deserialize back."""
+        user = User(id=str(uuid4()), email="a@b.com", name="A")
+        user.register()
+
+        event = user._events[0]
+        message = Message.from_domain_object(event)
+        msg_dict = message.to_dict()
+
+        assert msg_dict["metadata"]["extensions"] == {}
+
+        restored = Message.deserialize(msg_dict)
+        assert restored.metadata.extensions == {}
+
+    def test_extensions_absent_in_legacy_messages(self, test_domain):
+        """Messages stored before this feature (no extensions key) deserialize with default {}."""
+        user = User(id=str(uuid4()), email="a@b.com", name="A")
+        user.register()
+
+        event = user._events[0]
+        message = Message.from_domain_object(event)
+        msg_dict = message.to_dict()
+
+        # Simulate legacy message without extensions
+        del msg_dict["metadata"]["extensions"]
+
+        restored = Message.deserialize(msg_dict)
+        assert restored.metadata.extensions == {}
+
+
+# ---------------------------------------------------------------------------
+# Fact events
+# ---------------------------------------------------------------------------
+class TestFactEventEnrichment:
+    """Enrichers also run for auto-generated fact events."""
+
+    @pytest.fixture(autouse=True)
+    def setup_fact_events(self, test_domain):
+        """Re-register User with fact_events=True."""
+        # Elements already registered by module-level fixture;
+        # we need a fresh domain with fact_events enabled.
+        pass
+
+    def test_enrichers_run_on_fact_events(self, test_domain):
+        """Fact events raised during repository.add() also get enriched."""
+
+        # Register a new aggregate with fact_events
+        class Order(BaseAggregate):
+            id: Identifier(identifier=True)
+            amount: String()
+
+        class OrderPlaced(BaseEvent):
+            order_id: Identifier(identifier=True)
+
+        test_domain.register(Order, fact_events=True)
+        test_domain.register(OrderPlaced, part_of=Order)
+        test_domain.init(traverse=False)
+
+        def add_tag(event, aggregate):
+            return {"enriched": True}
+
+        test_domain.register_event_enricher(add_tag)
+
+        order = Order(id=str(uuid4()), amount="100")
+        order.raise_(OrderPlaced(order_id=order.id))
+
+        # The manually raised event should be enriched
+        assert order._events[0]._metadata.extensions == {"enriched": True}
+
+
+# ---------------------------------------------------------------------------
+# Event-sourced aggregate enrichment
+# ---------------------------------------------------------------------------
+class TestEventSourcedAggregateEnrichment:
+    def test_enrichers_work_with_es_aggregates(self, test_domain):
+        """Event enrichers work correctly with event-sourced aggregates."""
+
+        def add_version_tag(event, aggregate):
+            return {"agg_version": aggregate._version}
+
+        test_domain.register_event_enricher(add_version_tag)
+
+        user = User(id=str(uuid4()), email="a@b.com", name="A")
+        user.register()
+
+        event = user._events[0]
+        # After raise_, version was incremented to 0 (from -1)
+        assert "agg_version" in event._metadata.extensions
+
+    def test_multiple_events_on_es_aggregate(self, test_domain):
+        """Each event on an ES aggregate is independently enriched."""
+
+        call_count = 0
+
+        def add_seq(event, aggregate):
+            nonlocal call_count
+            call_count += 1
+            return {"seq": call_count}
+
+        test_domain.register_event_enricher(add_seq)
+
+        user = User(id=str(uuid4()), email="a@b.com", name="A")
+        user.register()
+        user.activate()
+
+        assert user._events[0]._metadata.extensions["seq"] == 1
+        assert user._events[1]._metadata.extensions["seq"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Complex extension values
+# ---------------------------------------------------------------------------
+class TestComplexExtensionValues:
+    def test_nested_dict_in_extensions(self, test_domain):
+        """Extensions can contain nested dicts."""
+
+        def add_nested(event, aggregate):
+            return {"context": {"user": "admin", "roles": ["read", "write"]}}
+
+        test_domain.register_event_enricher(add_nested)
+
+        user = User(id=str(uuid4()), email="a@b.com", name="A")
+        user.register()
+
+        event = user._events[0]
+        assert event._metadata.extensions["context"] == {
+            "user": "admin",
+            "roles": ["read", "write"],
+        }
+
+    def test_nested_dict_survives_round_trip(self, test_domain):
+        """Nested extension values survive serialization round-trip."""
+
+        def add_nested(event, aggregate):
+            return {"context": {"user": "admin", "roles": ["read", "write"]}}
+
+        test_domain.register_event_enricher(add_nested)
+
+        user = User(id=str(uuid4()), email="a@b.com", name="A")
+        user.register()
+
+        event = user._events[0]
+        message = Message.from_domain_object(event)
+        msg_dict = message.to_dict()
+
+        restored = Message.deserialize(msg_dict)
+        assert restored.metadata.extensions["context"] == {
+            "user": "admin",
+            "roles": ["read", "write"],
+        }

--- a/tests/event/test_event_metadata.py
+++ b/tests/event/test_event_metadata.py
@@ -205,6 +205,7 @@ def test_event_metadata():
                 "idempotency_key": None,
             },
             "event_store": None,
+            "extensions": {},
         },
         "user_id": event.user_id,
     }

--- a/tests/event/test_event_payload.py
+++ b/tests/event/test_event_payload.py
@@ -73,6 +73,7 @@ def test_event_payload():
                 "causation_id": None,
             },
             "event_store": None,
+            "extensions": {},
         },
         "user_id": event.user_id,
     }

--- a/tests/event/tests.py
+++ b/tests/event/tests.py
@@ -94,6 +94,7 @@ class TestDomainEventDefinition:
                         "causation_id": None,
                     },
                     "event_store": None,
+                    "extensions": {},
                 },
                 "email": {
                     "address": "john.doe@gmail.com",
@@ -134,6 +135,7 @@ class TestDomainEventDefinition:
                     "causation_id": None,
                 },
                 "event_store": None,
+                "extensions": {},
             },
             "email": {
                 "address": "john.doe@gmail.com",


### PR DESCRIPTION
Introduce a mechanism for automatically attaching cross-cutting metadata (user context, tenant ID, audit data, request tracing) to every domain event and command without requiring manual intervention at each raise_() or process() call site.

## Problem

In event-driven systems, events and commands frequently need metadata that has nothing to do with their business payload — who performed the action, which tenant it belongs to, the originating IP address, or custom audit context. Without a central mechanism, developers must sprinkle this logic into every raise_() call, which is repetitive, error-prone, and violates DRY.

## Solution

### Metadata.extensions field

Add `extensions: dict[str, Any]` to the `Metadata` class — a user-space dict persisted alongside all other metadata in the event store and surviving serialization round-trips. This follows the CloudEvents extensions concept and keeps user data cleanly separated from Protean's internal metadata fields.

### Event enrichers

Callables registered on the domain that run inside `aggregate.raise_()` after metadata construction but before event appending:

    @domain.event_enricher
    def add_user_context(event, aggregate):
        return {"user_id": get_current_user_id(),
                "tenant_id": aggregate.tenant_id}

    # Or functional registration:
    domain.register_event_enricher(add_user_context)

Enrichers receive the event and the aggregate instance, and return a dict merged into metadata.extensions. They run for all events including fact events and event-sourced aggregate events.

### Command enrichers

Same pattern but for commands processed via `domain.process()`:

    @domain.command_enricher
    def add_request_context(command):
        return {"request_id": get_request_id()}

    domain.register_command_enricher(add_request_context)

### Execution semantics

- Enrichers execute in registration order (FIFO)
- Results are merged; later enrichers can overwrite earlier keys
- Exceptions propagate (enrichment is part of message integrity)
- Returning None or {} is a no-op
- Non-callable registration raises IncorrectUsageError
- Zero overhead when no enrichers are registered

### Backward compatibility

- Old messages without `extensions` deserialize with default `{}`
- No changes to existing APIs or behavior