### PR TITLE
Add causation chain API for traversing command/event causal relationships

### DIFF
--- a/docs/api/ports/event-store.md
+++ b/docs/api/ports/event-store.md
@@ -9,3 +9,14 @@ concrete adapter configuration.
 ::: protean.port.event_store.BaseEventStore
     options:
       show_root_heading: false
+
+---
+
+## CausationNode
+
+Tree node used by `build_causation_tree()` to represent the causation
+hierarchy of messages sharing a `correlation_id`.
+
+::: protean.port.event_store.CausationNode
+    options:
+      show_root_heading: false

--- a/docs/concepts/internals/event-sourcing.md
+++ b/docs/concepts/internals/event-sourcing.md
@@ -255,6 +255,60 @@ historical accuracy.
 See [Temporal Queries](../../guides/change-state/temporal-queries.md) for the
 practical guide with examples.
 
+## Causation chain traversal
+
+Every message in the event store carries a `correlation_id` (shared across the
+full causal chain) and a `causation_id` (the `headers.id` of the immediate
+parent message). `BaseEventStore` provides three methods that use these links
+to traverse the causation graph.
+
+All three methods scan `$all` (the global ordered stream) and filter by
+`correlation_id` to build a working set. This is intentional: causation
+traversal is a **debugging/inspection tool**, not a hot-path operation, so a
+single full scan trades simplicity for generality.
+
+### `trace_causation(message_id)`
+
+Walks **up** from a target message to the root command by following
+`causation_id` links. Returns a `list[Message]` ordered root-first,
+target-last.
+
+**Algorithm:** Build a `{headers.id: raw_msg}` index from the correlation
+group. Starting from the target, follow `causation_id` pointers until reaching
+a message with `causation_id=None` (the root). A `visited` set guards against
+cycles. The chain is reversed at the end so the root is first.
+
+### `trace_effects(message_id, *, recursive=True)`
+
+Walks **down** from a message to find everything it caused. Returns effects in
+chronological order (by `global_position`). The target message is **not**
+included.
+
+**Algorithm:** Build a reverse index `{causation_id: [children]}`. BFS from
+the target message's `headers.id`, collecting children at each level. When
+`recursive=False`, only direct children (one level) are returned.
+
+### `build_causation_tree(correlation_id)`
+
+Builds a `CausationNode` tree for an entire correlation group. Returns the
+root node with `.children` recursively populated, or `None` if no messages
+exist.
+
+**Algorithm:** Build `{causation_id: [children]}` from the raw messages.
+Identify root(s) as messages with `causation_id=None`. Recursively construct
+`CausationNode` objects using `_build_node()`, with a `visited` set to
+prevent infinite recursion when message IDs overlap between parent and child
+(can happen with the MessageDB adapter in sync mode).
+
+`CausationNode` is a dataclass with: `message_id`, `message_type`, `kind`
+(`"EVENT"` or `"COMMAND"`), `stream`, `time`, `global_position`, and
+`children`.
+
+See [Message Tracing](../../guides/domain-behavior/message-tracing.md) for the
+practical guide with code examples, and
+[`protean events trace`](../../reference/cli/data/events.md#protean-events-trace)
+for the CLI command.
+
 ## Projection rebuilding
 
 Projections are read-optimized views maintained by projectors in response to

--- a/docs/concepts/internals/index.md
+++ b/docs/concepts/internals/index.md
@@ -22,7 +22,8 @@ shaped it.
   evaluation, and entity state tracking.
 - [Event sourcing](./event-sourcing.md) -- How `raise_()` invokes `@apply`
   handlers, aggregate reconstitution via `_create_for_reconstitution()` and
-  `from_events()`, version tracking, and invariant checking during replay.
+  `from_events()`, version tracking, invariant checking during replay, and
+  causation chain traversal algorithms.
 - [Event upcasting](./event-upcasting.md) -- How old event payloads are
   transparently transformed to the current schema during deserialization,
   chain building algorithm, validation, and integration with

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -91,7 +91,7 @@ specific area.
 - [Invariants](./guides/domain-behavior/invariants.md) -- Business rules that must always hold true within an aggregate.
 - [Mutating Aggregates](./guides/domain-behavior/aggregate-mutation.md) -- Modify state through named methods reflecting actions and events.
 - [Raising Events](./guides/domain-behavior/raising-events.md) -- Notify other parts of the system through domain events.
-- [Message Tracing](./guides/domain-behavior/message-tracing.md) -- Track the full causal chain of commands and events with correlation and causation IDs.
+- [Message Tracing](./guides/domain-behavior/message-tracing.md) -- Track the full causal chain of commands and events with correlation and causation IDs, and traverse causation chains programmatically.
 - [Domain Services](./guides/domain-behavior/domain-services.md) -- Complex domain logic that spans multiple aggregates.
 
 ### Change State
@@ -143,7 +143,7 @@ specific area.
 - [`protean test`](./community/contributing/testing.md) -- Run Protean's framework test suite (development only).
 - [`protean snapshot`](./reference/cli/data/snapshot.md) -- Create snapshots for event-sourced aggregates.
 - [`protean projection`](./reference/cli/data/projection.md) -- Rebuild projections by replaying events from the event store.
-- [`protean events`](./reference/cli/data/events.md) -- Inspect the event store: read streams, view stats, search events, and trace aggregate history.
+- [`protean events`](./reference/cli/data/events.md) -- Inspect the event store: read streams, view stats, search events, trace aggregate history, and follow causal chains as a tree or flat table.
 - [Type Checking](./reference/type-checking/index.md) -- Static type checking with the Protean mypy plugin.
 
 ### Test Your Application
@@ -306,6 +306,8 @@ Design reasoning and internal architecture for contributors and advanced users.
 - [Field System](./concepts/internals/field-system.md) -- How FieldSpec translates domain vocabulary to Pydantic, and why three definition styles are supported.
 - [Shadow Fields](./concepts/internals/shadow-fields.md) -- How ValueObject and Reference fields are flattened into database columns via shadow fields.
 - [Query System](./concepts/internals/query-system.md) -- How the Repository → DAO → QuerySet → Provider chain works, Q object expression trees, lookup resolution, and lazy evaluation.
+- [Event Sourcing](./concepts/internals/event-sourcing.md) -- How `raise_()` invokes `@apply` handlers, aggregate reconstitution, version tracking, causation chain traversal algorithms, and projection rebuilding.
+- [Event Upcasting](./concepts/internals/event-upcasting.md) -- How old event payloads are transparently transformed to the current schema during deserialization.
 
 ---
 

--- a/docs/guides/consume-state/process-managers.md
+++ b/docs/guides/consume-state/process-managers.md
@@ -211,3 +211,5 @@ PM's state when loading.
     **Patterns:**
 
     - [Coordinating Long-Running Processes](../../patterns/coordinating-long-running-processes.md) — Patterns for orchestrating multi-step workflows.
+
+    **Related guide:** [Message Tracing](../domain-behavior/message-tracing.md) — Correlation and causation IDs that thread through process manager workflows, plus the programmatic causation chain API.

--- a/docs/guides/domain-behavior/index.md
+++ b/docs/guides/domain-behavior/index.md
@@ -53,6 +53,7 @@ Protean automatically tracks causal chains across commands and events, and
 lets you attach custom metadata to every message:
 
 - **Correlation & causation IDs** - Automatically propagated through command → event chains
+- **Causation chain API** - Walk up to the root command, down to all effects, or build a full causation tree programmatically
 - **Message enrichment hooks** - Register callables that add custom metadata (user context, tenant ID, audit data) to every event and command
 - **Extensions metadata** - A user-space `metadata.extensions` dict persisted in the event store
 

--- a/docs/guides/domain-behavior/message-enrichment.md
+++ b/docs/guides/domain-behavior/message-enrichment.md
@@ -175,6 +175,6 @@ are enriched automatically.
 !!! tip "See also"
     **Related guides:**
 
-    - [Message Tracing](message-tracing.md) -- Correlation and causation IDs for distributed tracing
+    - [Message Tracing](message-tracing.md) -- Correlation and causation IDs for distributed tracing, plus the programmatic causation chain API
     - [Raising Events](raising-events.md) -- How aggregates raise domain events
     - [Commands](../../guides/change-state/commands.md) -- Command processing via `domain.process()`

--- a/docs/guides/domain-behavior/message-tracing.md
+++ b/docs/guides/domain-behavior/message-tracing.md
@@ -144,6 +144,79 @@ result.process(
 )
 ```
 
+## Traversing the Causation Chain Programmatically
+
+The event store provides three methods for traversing causation chains in code.
+These are inspection/debugging utilities that operate on the event store
+directly.
+
+### Walking up: `trace_causation()`
+
+Given a message, walk **up** the causation chain to the root command:
+
+```python
+store = domain.event_store.store
+
+# From a message ID string
+chain = store.trace_causation("myapp::order-abc123-0.1")
+
+# From a Message object
+chain = store.trace_causation(some_message)
+
+# chain = [root_command, ..., target_message]
+for msg in chain:
+    print(f"{msg.metadata.headers.type} (caused by {msg.metadata.domain.causation_id})")
+```
+
+The result is a list of `Message` objects ordered root-first, target-last. The
+root command (with `causation_id=None`) is always the first element, and the
+target message is always the last.
+
+### Walking down: `trace_effects()`
+
+Given a message, walk **down** to find everything it caused:
+
+```python
+# All downstream effects (recursive)
+effects = store.trace_effects("myapp::order:command-abc123-0")
+
+# Only direct children (one level)
+direct = store.trace_effects("myapp::order:command-abc123-0", recursive=False)
+```
+
+Effects are returned in chronological order (by `global_position`). The target
+message itself is **not** included in the result.
+
+### Building the full tree: `build_causation_tree()`
+
+For a complete picture of a business operation, build the full causation tree
+from a `correlation_id`:
+
+```python
+from protean.port.event_store import CausationNode
+
+root = store.build_causation_tree("a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6")
+
+if root:
+    print(f"{root.kind} {root.message_type}")  # e.g., "COMMAND App.PlaceOrder.v1"
+    for child in root.children:
+        print(f"  {child.kind} {child.message_type}")
+```
+
+`CausationNode` is a dataclass with these attributes:
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `message_id` | `str` | The message's `headers.id` |
+| `message_type` | `str` | The fully-qualified message type |
+| `kind` | `str` | `"EVENT"` or `"COMMAND"` |
+| `stream` | `str` | The stream name |
+| `time` | `str \| None` | Write timestamp |
+| `global_position` | `int \| None` | Global position in the event store |
+| `children` | `list[CausationNode]` | Child messages caused by this message |
+
+Returns `None` if no messages exist for the given `correlation_id`.
+
 ## Inspecting Traces via CLI
 
 The `protean events` CLI commands support a `--trace` flag to display
@@ -160,11 +233,27 @@ protean events search --type=OrderPlaced --trace --domain=myapp
 To follow an entire causal chain by correlation ID:
 
 ```bash
+# Tree view (default) — shows parent-child causation structure
 protean events trace "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6" --domain=myapp
+
+# Flat table view — chronological list with trace columns
+protean events trace "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6" --flat --domain=myapp
 ```
 
-This scans all events matching the given `correlation_id` and displays them in
-chronological order, showing the full causation tree.
+The default tree view reconstructs the parent-child causation relationships and
+displays them as an indented tree:
+
+```
+CMD App.PlaceOrder.v1 (myapp::order:command-abc123-0) @ 2026-02-22 10:30:00
+├── EVT App.OrderPlaced.v1 (myapp::order-abc123-0) @ 2026-02-22 10:30:00
+│   └── CMD App.ReserveInventory.v1 (myapp::inventory:command-inv456-0) @ 2026-02-22 10:30:01
+│       └── EVT App.InventoryReserved.v1 (myapp::inventory-inv456-0) @ 2026-02-22 10:30:02
+
+Causation tree: 4 message(s) for correlation ID 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6'
+```
+
+Use `--flat` for a chronological table view when you need exact positions and
+timestamps.
 
 See [`protean events`](../../reference/cli/data/events.md) for the complete CLI
 reference.
@@ -193,5 +282,9 @@ This is useful for operational dashboards and debugging delivery issues.
     **Pattern:** [Message Tracing in Event-Driven Systems](../../patterns/message-tracing.md) -- Design considerations, when to use external vs generated IDs, and multi-service tracing strategies.
 
     **Reference:** [`protean events trace`](../../reference/cli/data/events.md) -- CLI command for following causal chains.
+
+    **Internals:** [Causation Chain Traversal](../../concepts/internals/event-sourcing.md#causation-chain-traversal) -- Algorithm details for the traversal methods.
+
+    **API:** [BaseEventStore](../../api/ports/event-store.md) -- Auto-generated API reference for `trace_causation`, `trace_effects`, `build_causation_tree`, and `CausationNode`.
 
     **Concept:** [Observability](../../reference/server/observability.md) -- Real-time tracing and monitoring with the Protean Observatory.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -88,6 +88,7 @@ A quick reference for common tasks. See the
 | Handle a request (synchronous)        | [Application Services](./change-state/application-services.md)        |
 | Handle a request (via commands)       | [Commands](./change-state/commands.md) + [Handlers](./change-state/command-handlers.md) |
 | Save or load an aggregate             | [Persist](./change-state/persist-aggregates.md) · [Retrieve](./change-state/retrieve-aggregates.md) |
+| Trace a causal chain of messages      | [Message Tracing](./domain-behavior/message-tracing.md)               |
 | React to a domain event               | [Event Handlers](./consume-state/event-handlers.md)                   |
 | Build a read-optimized view           | [Projections](./consume-state/projections.md)                         |
 | Choose between CQRS and ES            | [Architecture Decision](../concepts/architecture/architecture-decision.md)    |

--- a/docs/how-do-i.md
+++ b/docs/how-do-i.md
@@ -67,6 +67,7 @@ need by what you're trying to accomplish.
 | Rebuild a projection from historical events     | [`protean projection rebuild`](./reference/cli/data/projection.md) |
 | Listen to messages from an external broker      | [Subscribers](./guides/consume-state/subscribers.md) |
 | Follow the causal chain of a business operation | [Message Tracing](./guides/domain-behavior/message-tracing.md) |
+| Traverse causation chains programmatically      | [Message Tracing](./guides/domain-behavior/message-tracing.md#traversing-the-causation-chain-programmatically) |
 
 ## Set Up and Configure
 
@@ -190,3 +191,4 @@ need by what you're trying to accomplish.
 | Understand how the field system works           | [Field System](./concepts/internals/field-system.md) |
 | Learn why three field definition styles exist   | [Field System](./concepts/internals/field-system.md) |
 | Understand how the query system works internally | [Query System](./concepts/internals/query-system.md) |
+| Understand causation chain traversal internals  | [Event Sourcing Internals](./concepts/internals/event-sourcing.md#causation-chain-traversal) |

--- a/docs/patterns/coordinating-long-running-processes.md
+++ b/docs/patterns/coordinating-long-running-processes.md
@@ -248,3 +248,4 @@ map different field names: `correlate={"order_id": "payment_order_id"}`.
     **Guides:**
 
     - [Process Managers](../guides/consume-state/process-managers.md) — Defining process managers, correlation, lifecycle, and configuration.
+    - [Message Tracing](../guides/domain-behavior/message-tracing.md) — Correlation and causation IDs for end-to-end traceability, with programmatic causation chain traversal.

--- a/docs/patterns/message-tracing.md
+++ b/docs/patterns/message-tracing.md
@@ -135,16 +135,54 @@ outbox_repo.find_by_correlation_id("a1b2c3d4...")
 outbox_repo.find_by_causation_id("myapp::order-abc123-0.1")
 ```
 
+### Causation Chain API
+
+The event store provides methods to traverse causation chains programmatically:
+
+```python
+store = domain.event_store.store
+
+# Walk UP from a message to the root command
+chain = store.trace_causation(event_message)
+# Returns [root_command, ..., target_message]
+
+# Walk DOWN from a command to find all its effects
+effects = store.trace_effects(command_message)
+# Returns downstream events/commands in chronological order
+
+# Build the full tree for a correlation ID
+root = store.build_causation_tree("a1b2c3d4...")
+# Returns a CausationNode with .children recursively populated
+```
+
+These methods answer the three debugging questions directly:
+
+1. **"Which user request caused this?"** — `trace_causation()` walks up to the root
+2. **"What was the immediate trigger?"** — check `causation_id` on the message
+3. **"What other effects did that request produce?"** — `trace_effects()` walks down
+
 ### CLI Inspection
 
-The `protean events` CLI supports tracing:
+The `protean events` CLI supports tracing with both tree and flat views:
 
 ```bash
 # Show trace IDs alongside events
 protean events read "myapp::order-abc123" --trace
 
-# Follow a full causal chain
+# Follow a full causal chain (tree view, default)
 protean events trace "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"
+
+# Flat table view for chronological listing
+protean events trace "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6" --flat
+```
+
+The tree view reconstructs parent-child relationships from `causation_id` links:
+
+```
+CMD App.PlaceOrder.v1 (myapp::order:command-abc123-0) @ 2026-02-22 10:30:00
+├── EVT App.OrderPlaced.v1 (myapp::order-abc123-0) @ 2026-02-22 10:30:00
+│   └── CMD App.ReserveInventory.v1 (myapp::inventory:command-inv456-0) @ 2026-02-22 10:30:01
+│       └── EVT App.InventoryReserved.v1 (myapp::inventory-inv456-0) @ 2026-02-22 10:30:02
 ```
 
 ## When to Use External Correlation IDs
@@ -220,6 +258,8 @@ assert result2.events[0]._metadata.domain.correlation_id == corr_id
 - **`causation_id`** links each message to its direct parent, forming a tree.
 - Protean handles propagation automatically -- you only need to supply an
   external `correlation_id` at the entry point if you have one.
+- Use `trace_causation()`, `trace_effects()`, and `build_causation_tree()` to
+  traverse chains programmatically.
 - Use `protean events trace` to follow a full chain in the event store.
 - Prefer external (caller-provided) correlation IDs for end-to-end
   traceability across services.
@@ -230,6 +270,8 @@ assert result2.events[0]._metadata.domain.correlation_id == corr_id
     **Guide:** [Message Tracing](../guides/domain-behavior/message-tracing.md) -- How-to guide with code examples for setting up tracing.
 
     **Reference:** [`protean events trace`](../reference/cli/data/events.md) -- CLI command for following causal chains.
+
+    **Internals:** [Causation Chain Traversal](../concepts/internals/event-sourcing.md#causation-chain-traversal) -- Algorithm details for `trace_causation`, `trace_effects`, and `build_causation_tree`.
 
     **Related patterns:**
 

--- a/docs/reference/cli/data/events.md
+++ b/docs/reference/cli/data/events.md
@@ -179,16 +179,18 @@ User (abc-123): 3 event(s), current version: 2
 
 ## `protean events trace`
 
-Follows the full causal chain for a given `correlation_id`. Scans all events
-in the event store that share the same correlation ID and displays them in
-chronological order, revealing the complete causation tree of a business
-operation.
+Follows the full causal chain for a given `correlation_id`. Scans all messages
+in the event store that share the same correlation ID and displays them as a
+**causation tree** (default) or a **flat table**.
 
 ```bash
-# Follow a causal chain
+# Tree view (default) — shows parent-child causation structure
 protean events trace "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6" --domain=my_domain
 
-# Include full event data payloads
+# Flat table view — chronological list with trace columns
+protean events trace "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6" --flat --domain=my_domain
+
+# Include full event data payloads (works with both views)
 protean events trace "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6" --data --domain=my_domain
 ```
 
@@ -199,29 +201,48 @@ protean events trace "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6" --data --domain=my_domai
 | `CORRELATION_ID` | Correlation ID to trace (positional argument) | Required |
 | `--domain` | Domain module path | `.` (current directory) |
 | `--data/--no-data` | Show full event data payloads | `--no-data` |
+| `--flat/--tree` | Show flat table instead of causation tree | `--tree` |
 
-**Output**
+**Tree output** (default)
 
-The output shows the stream, type, time, correlation ID, and causation ID for
-each message in the chain. When `--data` is enabled, event payloads are
-displayed inline.
+The tree view uses `build_causation_tree()` to reconstruct the parent-child
+relationships between commands and events. Each node shows a `CMD` or `EVT`
+badge, the message type, a truncated message ID, and a timestamp:
 
 ```
-Trace: a1b2c3d4... (3 messages)
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ Stream                    ┃ Type                    ┃ Time                ┃ Causation ID              ┃
-┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-│ app::order:command-abc123 │ App.PlaceOrder.v1       │ 2026-02-22 10:30:00 │                           │
-│ app::order-abc123         │ App.OrderPlaced.v1      │ 2026-02-22 10:30:01 │ app::order:command-abc123 │
-│ app::inventory-inv456     │ App.InventoryReserved.v1│ 2026-02-22 10:30:02 │ app::order-abc123-0.1     │
-└───────────────────────────┴─────────────────────────┴─────────────────────┴───────────────────────────┘
+CMD App.PlaceOrder.v1 (app::order:command-abc123-0) @ 2026-02-22 10:30:00
+├── EVT App.OrderPlaced.v1 (app::order-abc123-0) @ 2026-02-22 10:30:00
+│   └── CMD App.ReserveInventory.v1 (app::inventory:command-inv456-0) @ 2026-02-22 10:30:01
+│       └── EVT App.InventoryReserved.v1 (app::inventory-inv456-0) @ 2026-02-22 10:30:02
+└── EVT App.OrderConfirmed.v1 (app::order-abc123-1) @ 2026-02-22 10:30:01
+
+Causation tree: 5 message(s) for correlation ID 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6'
 ```
 
-This is useful for debugging multi-step workflows and verifying that trace
-context propagates correctly across handlers.
+**Flat output** (`--flat`)
+
+The flat view shows all matching messages in a chronological table with stream,
+type, time, correlation ID, and causation ID columns:
+
+```
+┏━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Position ┃ Global Pos ┃ Type                      ┃ Stream                    ┃ Time                ┃ Correlation ID  ┃ Causation ID              ┃
+┡━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│        0 │          1 │ App.PlaceOrder.v1         │ app::order:command-abc123 │ 2026-02-22 10:30:00 │ a1b2c3d4...     │                           │
+│        0 │          2 │ App.OrderPlaced.v1        │ app::order-abc123         │ 2026-02-22 10:30:01 │ a1b2c3d4...     │ app::order:command-abc123 │
+│        1 │          3 │ App.InventoryReserved.v1  │ app::inventory-inv456     │ 2026-02-22 10:30:02 │ a1b2c3d4...     │ app::order-abc123-0.1     │
+└──────────┴────────────┴───────────────────────────┴───────────────────────────┴─────────────────────┴─────────────────┴───────────────────────────┘
+
+Found 3 event(s) for correlation ID 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6'
+```
+
+The tree view is most useful for debugging because it shows causal relationships
+at a glance. The flat view is useful when you need to see exact positions and
+timestamps for every message.
 
 See [Message Tracing](../../../guides/domain-behavior/message-tracing.md) for
-details on how correlation and causation IDs work.
+details on how correlation and causation IDs work, including the programmatic
+causation chain API.
 
 ## Error Handling
 

--- a/src/protean/cli/events.py
+++ b/src/protean/cli/events.py
@@ -1,7 +1,8 @@
 """CLI commands for inspecting the event store.
 
 Provides commands for reading events, viewing stream statistics,
-searching for events by type, and viewing aggregate event histories.
+searching for events by type, viewing aggregate event histories,
+and tracing causation chains.
 
 Usage::
 
@@ -16,6 +17,12 @@ Usage::
 
     # View aggregate event history
     protean events history --aggregate=User --id=abc123 --domain=my_domain
+
+    # Trace causation chain (tree view)
+    protean events trace <correlation_id> --domain=my_domain
+
+    # Trace causation chain (flat table)
+    protean events trace <correlation_id> --flat --domain=my_domain
 """
 
 import json
@@ -25,6 +32,7 @@ from typing import TYPE_CHECKING, Any
 import typer
 from rich import print
 from rich.table import Table
+from rich.tree import Tree as RichTree
 from typing_extensions import Annotated
 
 from protean.exceptions import NoDomainException
@@ -34,6 +42,7 @@ from protean.utils.logging import get_logger
 
 if TYPE_CHECKING:
     from protean.domain import Domain
+    from protean.port.event_store import CausationNode
 
 logger = get_logger(__name__)
 
@@ -169,6 +178,26 @@ def _print_event_data(messages: list[dict[str, Any]]) -> None:
         data = msg.get("data", {})
         print(f"\n[bold]Event {position}[/bold] ({event_type}):")
         print(json.dumps(data, indent=2, default=str))
+
+
+def _build_rich_tree(node: "CausationNode") -> RichTree:
+    """Build a Rich Tree from a CausationNode for CLI display."""
+    kind_badge = "[bold cyan]CMD[/]" if node.kind == "COMMAND" else "[bold green]EVT[/]"
+    time_str = f" @ {_format_time(node.time)}" if node.time else ""
+    label = (
+        f"{kind_badge} {node.message_type} "
+        f"[dim]({_truncate_id(node.message_id, 40)}){time_str}[/]"
+    )
+
+    tree = RichTree(label)
+    for child in node.children:
+        tree.add(_build_rich_tree(child))
+    return tree
+
+
+def _count_nodes(node: "CausationNode") -> int:
+    """Count all nodes in a CausationNode tree."""
+    return 1 + sum(_count_nodes(c) for c in node.children)
 
 
 # ---------------------------------------------------------------------------
@@ -431,27 +460,51 @@ def trace(
     show_data: Annotated[
         bool, typer.Option("--data/--no-data", help="Show full event data")
     ] = False,
+    flat: Annotated[
+        bool,
+        typer.Option("--flat/--tree", help="Show flat table instead of causation tree"),
+    ] = False,
 ) -> None:
     """Follow the full causal chain for a correlation ID across all streams."""
     derived_domain = _load_domain(domain)
     with derived_domain.domain_context():
         store = derived_domain.event_store.store
-        all_messages = store._read("$all", no_of_messages=1_000_000)
 
-        matched = [
-            m for m in all_messages if _extract_trace_ids(m)[0] == correlation_id
-        ]
+        if flat:
+            # Flat table display (original behavior)
+            all_messages = store._read("$all", no_of_messages=1_000_000)
 
-        if not matched:
-            print(f"No events found for correlation ID '{correlation_id}'")
-            return
+            matched = [
+                m for m in all_messages if _extract_trace_ids(m)[0] == correlation_id
+            ]
 
-        table = _build_events_table(
-            matched, show_data=show_data, show_stream=True, show_trace=True
-        )
-        print(table)
+            if not matched:
+                print(f"No events found for correlation ID '{correlation_id}'")
+                return
 
-        if show_data:
-            _print_event_data(matched)
+            table = _build_events_table(
+                matched, show_data=show_data, show_stream=True, show_trace=True
+            )
+            print(table)
 
-        print(f"\nFound {len(matched)} event(s) for correlation ID '{correlation_id}'")
+            if show_data:
+                _print_event_data(matched)
+
+            print(
+                f"\nFound {len(matched)} event(s) for correlation ID '{correlation_id}'"
+            )
+        else:
+            # Tree display (default)
+            root_node = store.build_causation_tree(correlation_id)
+            if root_node is None:
+                print(f"No events found for correlation ID '{correlation_id}'")
+                return
+
+            tree = _build_rich_tree(root_node)
+            print(tree)
+
+            total = _count_nodes(root_node)
+            print(
+                f"\nCausation tree: {total} message(s) for correlation ID "
+                f"'{correlation_id}'"
+            )

--- a/src/protean/port/event_store.py
+++ b/src/protean/port/event_store.py
@@ -1,5 +1,6 @@
 from abc import ABCMeta, abstractmethod
-from collections import deque
+from collections import defaultdict, deque
+from dataclasses import dataclass, field as dc_field
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Type, Union
 
@@ -8,6 +9,19 @@ from protean.core.command import BaseCommand
 from protean.core.event import BaseEvent
 from protean.exceptions import IncorrectUsageError, ObjectNotFoundError
 from protean.utils.eventing import Message
+
+
+@dataclass
+class CausationNode:
+    """A node in the causation tree, representing a single message and its effects."""
+
+    message_id: str
+    message_type: str
+    kind: str  # "EVENT" or "COMMAND"
+    stream: str
+    time: str | None
+    global_position: int | None
+    children: list["CausationNode"] = dc_field(default_factory=list)
 
 
 class BaseEventStore(metaclass=ABCMeta):
@@ -451,6 +465,283 @@ class BaseEventStore(metaclass=ABCMeta):
             count += 1
 
         return count
+
+    # ------------------------------------------------------------------
+    # Causation chain traversal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _extract_message_id(msg: dict[str, Any]) -> str | None:
+        """Extract the Protean message ID (headers.id) from a raw message dict."""
+        metadata = msg.get("metadata")
+        if not metadata or not isinstance(metadata, dict):
+            return None
+        headers = metadata.get("headers")
+        if not headers or not isinstance(headers, dict):
+            return None
+        return headers.get("id")
+
+    @staticmethod
+    def _extract_causation_id(msg: dict[str, Any]) -> str | None:
+        """Extract causation_id from a raw message dict."""
+        metadata = msg.get("metadata")
+        if not metadata or not isinstance(metadata, dict):
+            return None
+        domain = metadata.get("domain")
+        if not domain or not isinstance(domain, dict):
+            return None
+        return domain.get("causation_id")
+
+    @staticmethod
+    def _extract_correlation_id(msg: dict[str, Any]) -> str | None:
+        """Extract correlation_id from a raw message dict."""
+        metadata = msg.get("metadata")
+        if not metadata or not isinstance(metadata, dict):
+            return None
+        domain = metadata.get("domain")
+        if not domain or not isinstance(domain, dict):
+            return None
+        return domain.get("correlation_id")
+
+    def _load_correlation_group(self, correlation_id: str) -> list[dict[str, Any]]:
+        """Load all raw messages sharing a correlation_id from the event store.
+
+        Reads ``$all`` and filters by ``correlation_id``.
+        This is a debugging/inspection utility — not optimized for high-throughput.
+        """
+        all_messages = self._read("$all", no_of_messages=1_000_000)
+        return [
+            m for m in all_messages if self._extract_correlation_id(m) == correlation_id
+        ]
+
+    def _resolve_and_load_group(
+        self, message_id: str | Message
+    ) -> tuple[str, list[dict[str, Any]]]:
+        """Resolve a message identifier and load its full correlation group.
+
+        When ``message_id`` is a :class:`Message`, the correlation ID is read
+        directly from metadata (no scan required).  When it is a ``str``, a
+        single pass over ``$all`` finds the message and its correlation group.
+
+        Returns:
+            Tuple of ``(resolved_message_id, correlation_group)``.
+
+        Raises:
+            ValueError: If the message cannot be found in the event store.
+        """
+        if isinstance(message_id, Message):
+            mid = (
+                message_id.metadata.headers.id
+                if message_id.metadata and message_id.metadata.headers
+                else None
+            )
+            cid = (
+                message_id.metadata.domain.correlation_id
+                if message_id.metadata and message_id.metadata.domain
+                else None
+            )
+            if mid is None:
+                raise ValueError("Message has no headers.id")
+            if cid is None:
+                return mid, []
+            group = self._load_correlation_group(cid)
+            return mid, group
+
+        # String ID — single pass to find the target and its group
+        all_messages = self._read("$all", no_of_messages=1_000_000)
+        target_correlation_id: str | None = None
+        for m in all_messages:
+            if self._extract_message_id(m) == message_id:
+                target_correlation_id = self._extract_correlation_id(m)
+                break
+
+        if target_correlation_id is None:
+            raise ValueError(f"Message with ID '{message_id}' not found in event store")
+
+        group = [
+            m
+            for m in all_messages
+            if self._extract_correlation_id(m) == target_correlation_id
+        ]
+        return message_id, group
+
+    # ------------------------------------------------------------------
+    # Public causation chain API
+    # ------------------------------------------------------------------
+
+    def trace_causation(self, message_id: str | Message) -> list[Message]:
+        """Walk UP the causation chain from a message to the root.
+
+        Returns an ordered list of Messages from the root command (first)
+        to the given message (last).  The given message itself is included.
+
+        Args:
+            message_id: A Protean message ID string (``headers.id``) or
+                a :class:`Message` object.
+
+        Returns:
+            List of :class:`Message` objects in causal order (root first,
+            target last).
+
+        Raises:
+            ValueError: If the message cannot be found in the event store.
+        """
+        mid, group = self._resolve_and_load_group(message_id)
+
+        # Build lookup: headers.id -> raw_message
+        by_id: dict[str, dict[str, Any]] = {}
+        for m in group:
+            hid = self._extract_message_id(m)
+            if hid:
+                by_id[hid] = m
+
+        # Walk up from target to root
+        chain: list[dict[str, Any]] = []
+        current_id: str | None = mid
+        visited: set[str] = set()
+
+        while current_id and current_id not in visited:
+            visited.add(current_id)
+            raw_msg = by_id.get(current_id)
+            if raw_msg is None:
+                break
+            chain.append(raw_msg)
+            current_id = self._extract_causation_id(raw_msg)
+
+        # Reverse so root is first
+        chain.reverse()
+
+        return [Message.deserialize(m) for m in chain]
+
+    def trace_effects(
+        self, message_id: str | Message, *, recursive: bool = True
+    ) -> list[Message]:
+        """Walk DOWN the causation chain to find all effects of a message.
+
+        Returns messages that were caused by the given message, ordered by
+        ``global_position`` (chronological order).
+
+        Args:
+            message_id: A Protean message ID string (``headers.id``) or
+                a :class:`Message` object.
+            recursive: If ``True`` (default), return the full subtree of
+                effects.  If ``False``, return only direct children.
+
+        Returns:
+            List of :class:`Message` objects caused by the given message,
+            in chronological order.  The given message itself is NOT included.
+
+        Raises:
+            ValueError: If the message cannot be found in the event store.
+        """
+        mid, group = self._resolve_and_load_group(message_id)
+
+        # Build children lookup: causation_id -> [raw_messages]
+        children: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        for m in group:
+            cid = self._extract_causation_id(m)
+            if cid:
+                children[cid].append(m)
+
+        if not recursive:
+            direct = children.get(mid, [])
+            direct.sort(key=lambda m: m.get("global_position", 0))
+            return [Message.deserialize(m) for m in direct]
+
+        # BFS for full subtree
+        result: list[dict[str, Any]] = []
+        queue: deque[str] = deque([mid])
+        visited: set[str] = {mid}
+
+        while queue:
+            current = queue.popleft()
+            for child in children.get(current, []):
+                child_id = self._extract_message_id(child)
+                if child_id and child_id not in visited:
+                    visited.add(child_id)
+                    result.append(child)
+                    queue.append(child_id)
+
+        result.sort(key=lambda m: m.get("global_position", 0))
+        return [Message.deserialize(m) for m in result]
+
+    def build_causation_tree(self, correlation_id: str) -> CausationNode | None:
+        """Build a full causation tree for a correlation ID.
+
+        Returns the root node of the tree with children recursively populated.
+
+        Args:
+            correlation_id: The correlation ID to trace.
+
+        Returns:
+            Root :class:`CausationNode` with children, or ``None`` if no
+            messages found.
+        """
+        group = self._load_correlation_group(correlation_id)
+        if not group:
+            return None
+
+        # Build index and children map
+        by_id: dict[str, dict[str, Any]] = {}
+        children_map: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        roots: list[dict[str, Any]] = []
+
+        for m in group:
+            hid = self._extract_message_id(m)
+            if hid:
+                by_id[hid] = m
+            cid = self._extract_causation_id(m)
+            if cid:
+                children_map[cid].append(m)
+            else:
+                roots.append(m)
+
+        # Sort children by global_position for deterministic ordering
+        for cid in children_map:
+            children_map[cid].sort(key=lambda m: m.get("global_position", 0))
+
+        visited: set[str] = set()
+
+        def _build_node(raw_msg: dict[str, Any]) -> CausationNode:
+            hid = self._extract_message_id(raw_msg) or "?"
+            visited.add(hid)
+
+            metadata = raw_msg.get("metadata", {})
+            if not isinstance(metadata, dict):
+                metadata = {}
+            headers = metadata.get("headers", {})
+            if not isinstance(headers, dict):
+                headers = {}
+            domain_meta = metadata.get("domain", {})
+            if not isinstance(domain_meta, dict):
+                domain_meta = {}
+
+            node = CausationNode(
+                message_id=hid,
+                message_type=raw_msg.get("type", headers.get("type", "?")),
+                kind=domain_meta.get("kind", "?"),
+                stream=raw_msg.get("stream_name", headers.get("stream", "?")),
+                time=str(raw_msg.get("time", "")) if raw_msg.get("time") else None,
+                global_position=raw_msg.get("global_position"),
+            )
+
+            for child_msg in children_map.get(hid, []):
+                child_id = self._extract_message_id(child_msg)
+                if child_id and child_id not in visited:
+                    node.children.append(_build_node(child_msg))
+
+            return node
+
+        if not roots:
+            # All messages have causation_id set — pick the one whose
+            # causation_id points outside the group
+            root_candidates = [
+                m for m in group if self._extract_causation_id(m) not in by_id
+            ]
+            roots = root_candidates if root_candidates else [group[0]]
+
+        roots.sort(key=lambda m: m.get("global_position", 0))
+        return _build_node(roots[0])
 
     @abstractmethod
     def _data_reset(self) -> None:

--- a/tests/cli/test_events.py
+++ b/tests/cli/test_events.py
@@ -1114,7 +1114,9 @@ class TestEventsHistoryTrace:
 # ---------------------------------------------------------------------------
 
 
-class TestEventsTrace:
+class TestEventsTraceFlat:
+    """Tests for ``protean events trace --flat`` (flat table output)."""
+
     @pytest.fixture(autouse=True)
     def reset_path(self):
         original_path = sys.path[:]
@@ -1123,7 +1125,7 @@ class TestEventsTrace:
         sys.path[:] = original_path
         os.chdir(cwd)
 
-    def test_trace_finds_matching_events(self):
+    def test_trace_flat_finds_matching_events(self):
         change_working_directory_to("test7")
 
         events = [
@@ -1163,6 +1165,7 @@ class TestEventsTrace:
                     "trace-corr-abc",
                     "--domain",
                     "publishing7.py",
+                    "--flat",
                 ],
             )
             assert result.exit_code == 0
@@ -1170,7 +1173,7 @@ class TestEventsTrace:
                 "Found 2 event(s) for correlation ID 'trace-corr-abc'" in result.output
             )
 
-    def test_trace_no_matching_events(self):
+    def test_trace_flat_no_matching_events(self):
         change_working_directory_to("test7")
 
         events = [
@@ -1189,6 +1192,7 @@ class TestEventsTrace:
                     "nonexistent-corr-id",
                     "--domain",
                     "publishing7.py",
+                    "--flat",
                 ],
             )
             assert result.exit_code == 0
@@ -1197,7 +1201,7 @@ class TestEventsTrace:
                 in result.output
             )
 
-    def test_trace_with_data_flag(self):
+    def test_trace_flat_with_data_flag(self):
         change_working_directory_to("test7")
 
         events = [
@@ -1220,6 +1224,7 @@ class TestEventsTrace:
                     "trace-data-corr",
                     "--domain",
                     "publishing7.py",
+                    "--flat",
                     "--data",
                 ],
             )
@@ -1227,7 +1232,7 @@ class TestEventsTrace:
             assert "Alice" in result.output
             assert "100.0" in result.output
 
-    def test_trace_with_empty_event_store(self):
+    def test_trace_flat_with_empty_event_store(self):
         change_working_directory_to("test7")
 
         mock_domain = _mock_domain_with_store(read_return=[])
@@ -1241,6 +1246,7 @@ class TestEventsTrace:
                     "any-corr-id",
                     "--domain",
                     "publishing7.py",
+                    "--flat",
                 ],
             )
             assert result.exit_code == 0
@@ -1257,3 +1263,150 @@ class TestEventsTrace:
             )
             assert result.exit_code != 0
             assert "Error loading Protean domain" in result.output
+
+
+# ---------------------------------------------------------------------------
+# protean events trace (tree view — default)
+# ---------------------------------------------------------------------------
+
+
+class TestEventsTraceTree:
+    """Tests for ``protean events trace`` (tree output, default mode)."""
+
+    @pytest.fixture(autouse=True)
+    def reset_path(self):
+        original_path = sys.path[:]
+        cwd = Path.cwd()
+        yield
+        sys.path[:] = original_path
+        os.chdir(cwd)
+
+    def test_trace_tree_shows_causation_tree(self):
+        change_working_directory_to("test7")
+
+        from protean.port.event_store import CausationNode
+
+        root_node = CausationNode(
+            message_id="test::order:command-abc123-0",
+            message_type="Test.PlaceOrder.v1",
+            kind="COMMAND",
+            stream="test::order:command-abc123",
+            time="2026-02-22T10:00:00",
+            global_position=1,
+            children=[
+                CausationNode(
+                    message_id="test::order-abc123-0",
+                    message_type="Test.OrderPlaced.v1",
+                    kind="EVENT",
+                    stream="test::order-abc123",
+                    time="2026-02-22T10:00:01",
+                    global_position=2,
+                ),
+            ],
+        )
+
+        mock_domain = _mock_domain_with_store()
+        mock_domain.event_store.store.build_causation_tree.return_value = root_node
+
+        with patch("protean.cli.events.derive_domain", return_value=mock_domain):
+            result = runner.invoke(
+                app,
+                [
+                    "events",
+                    "trace",
+                    "test-corr-id",
+                    "--domain",
+                    "publishing7.py",
+                ],
+            )
+            assert result.exit_code == 0
+            assert "CMD" in result.output
+            assert "EVT" in result.output
+            assert "PlaceOrder" in result.output
+            assert "OrderPlaced" in result.output
+            assert "Causation tree: 2 message(s)" in result.output
+
+    def test_trace_tree_empty_store(self):
+        change_working_directory_to("test7")
+
+        mock_domain = _mock_domain_with_store()
+        mock_domain.event_store.store.build_causation_tree.return_value = None
+
+        with patch("protean.cli.events.derive_domain", return_value=mock_domain):
+            result = runner.invoke(
+                app,
+                [
+                    "events",
+                    "trace",
+                    "nonexistent-corr",
+                    "--domain",
+                    "publishing7.py",
+                ],
+            )
+            assert result.exit_code == 0
+            assert "No events found for correlation ID" in result.output
+
+    def test_trace_tree_multi_level_chain(self):
+        change_working_directory_to("test7")
+
+        from protean.port.event_store import CausationNode
+
+        root_node = CausationNode(
+            message_id="cmd-0",
+            message_type="Test.PlaceOrder.v1",
+            kind="COMMAND",
+            stream="test::order:command-abc123",
+            time="2026-02-22T10:00:00",
+            global_position=1,
+            children=[
+                CausationNode(
+                    message_id="evt-0",
+                    message_type="Test.OrderPlaced.v1",
+                    kind="EVENT",
+                    stream="test::order-abc123",
+                    time="2026-02-22T10:00:01",
+                    global_position=2,
+                    children=[
+                        CausationNode(
+                            message_id="cmd-1",
+                            message_type="Test.ConfirmOrder.v1",
+                            kind="COMMAND",
+                            stream="test::order:command-abc123",
+                            time="2026-02-22T10:00:02",
+                            global_position=3,
+                            children=[
+                                CausationNode(
+                                    message_id="evt-1",
+                                    message_type="Test.OrderConfirmed.v1",
+                                    kind="EVENT",
+                                    stream="test::order-abc123",
+                                    time="2026-02-22T10:00:03",
+                                    global_position=4,
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+        mock_domain = _mock_domain_with_store()
+        mock_domain.event_store.store.build_causation_tree.return_value = root_node
+
+        with patch("protean.cli.events.derive_domain", return_value=mock_domain):
+            result = runner.invoke(
+                app,
+                [
+                    "events",
+                    "trace",
+                    "chain-corr-id",
+                    "--domain",
+                    "publishing7.py",
+                ],
+            )
+            assert result.exit_code == 0
+            assert "Causation tree: 4 message(s)" in result.output
+            assert "PlaceOrder" in result.output
+            assert "OrderPlaced" in result.output
+            assert "ConfirmOrder" in result.output
+            assert "OrderConfirmed" in result.output

--- a/tests/tracing/test_causation_chain_api.py
+++ b/tests/tracing/test_causation_chain_api.py
@@ -1,0 +1,770 @@
+"""Tests for the causation chain traversal API on BaseEventStore.
+
+Verifies:
+1. ``trace_causation()`` walks UP the chain from a message to the root.
+2. ``trace_effects()`` walks DOWN the chain from a message to find effects.
+3. ``build_causation_tree()`` builds a full tree for a correlation ID.
+4. Static helper extractors handle valid and malformed metadata.
+5. Edge cases: malformed Messages, broken causation links, malformed raw data.
+"""
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from protean.port.event_store import BaseEventStore, CausationNode
+from protean.utils.eventing import Message
+
+from tests.tracing.elements import (
+    ConfirmOrder,
+    Order,
+    OrderCommandHandler,
+    OrderConfirmed,
+    OrderPlaced,
+    OrderPlacedAutoConfirmHandler,
+    PlaceOrder,
+    ShipOrder,
+    OrderShipped,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def register_elements(test_domain):
+    test_domain.register(Order, is_event_sourced=True)
+    test_domain.register(OrderPlaced, part_of=Order)
+    test_domain.register(OrderConfirmed, part_of=Order)
+    test_domain.register(OrderShipped, part_of=Order)
+    test_domain.register(PlaceOrder, part_of=Order)
+    test_domain.register(ConfirmOrder, part_of=Order)
+    test_domain.register(ShipOrder, part_of=Order)
+    test_domain.register(OrderCommandHandler, part_of=Order)
+    test_domain.init(traverse=False)
+
+
+@pytest.fixture
+def order_id() -> str:
+    return str(uuid4())
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_events(test_domain, order_id: str) -> list[Message]:
+    """Read all messages from the order's event stream."""
+    stream = f"{Order.meta_.stream_category}-{order_id}"
+    return test_domain.event_store.store.read(stream)
+
+
+def _read_commands(test_domain, order_id: str) -> list[Message]:
+    """Read all messages from the order's command stream."""
+    stream = f"{Order.meta_.stream_category}:command-{order_id}"
+    return test_domain.event_store.store.read(stream)
+
+
+# ---------------------------------------------------------------------------
+# Tests: trace_causation
+# ---------------------------------------------------------------------------
+
+
+class TestTraceCausation:
+    """Tests for ``event_store.trace_causation()`` — walking UP the chain."""
+
+    @pytest.mark.eventstore
+    def test_root_command_returns_single_message(self, test_domain, order_id):
+        """trace_causation on the root command returns just that command."""
+        test_domain.process(
+            PlaceOrder(order_id=order_id, customer="Alice", amount=100.0),
+            asynchronous=False,
+        )
+
+        commands = _read_commands(test_domain, order_id)
+        root_cmd = commands[0]
+
+        store = test_domain.event_store.store
+        chain = store.trace_causation(root_cmd.metadata.headers.id)
+
+        assert len(chain) == 1
+        assert chain[0].metadata.headers.id == root_cmd.metadata.headers.id
+
+    @pytest.mark.eventstore
+    def test_event_returns_chain_to_root_command(self, test_domain, order_id):
+        """trace_causation on OrderPlaced returns [PlaceOrder, OrderPlaced]."""
+        test_domain.process(
+            PlaceOrder(order_id=order_id, customer="Alice", amount=100.0),
+            asynchronous=False,
+        )
+
+        events = _read_events(test_domain, order_id)
+        commands = _read_commands(test_domain, order_id)
+
+        store = test_domain.event_store.store
+        chain = store.trace_causation(events[0].metadata.headers.id)
+
+        # Chain should be: PlaceOrder -> OrderPlaced
+        assert len(chain) == 2
+        assert chain[0].metadata.headers.id == commands[0].metadata.headers.id
+        assert chain[1].metadata.headers.id == events[0].metadata.headers.id
+
+    @pytest.mark.eventstore
+    def test_returns_messages_in_root_to_target_order(self, test_domain, order_id):
+        """Chain is ordered root-first, target-last."""
+        test_domain.process(
+            PlaceOrder(order_id=order_id, customer="Alice", amount=100.0),
+            asynchronous=False,
+        )
+
+        events = _read_events(test_domain, order_id)
+        store = test_domain.event_store.store
+        chain = store.trace_causation(events[0].metadata.headers.id)
+
+        # First message should be the root (no causation_id)
+        assert chain[0].metadata.domain.causation_id is None
+        # Last message should be the target
+        assert chain[-1].metadata.headers.id == events[0].metadata.headers.id
+
+    @pytest.mark.eventstore
+    def test_accepts_message_object(self, test_domain, order_id):
+        """trace_causation accepts a Message object (not just a string)."""
+        test_domain.process(
+            PlaceOrder(order_id=order_id, customer="Alice", amount=100.0),
+            asynchronous=False,
+        )
+
+        events = _read_events(test_domain, order_id)
+        store = test_domain.event_store.store
+
+        # Pass Message object instead of string
+        chain = store.trace_causation(events[0])
+        assert len(chain) == 2
+
+    @pytest.mark.eventstore
+    def test_unknown_message_id_raises_value_error(self, test_domain):
+        """Nonexistent message ID raises ValueError."""
+        store = test_domain.event_store.store
+        with pytest.raises(ValueError, match="not found in event store"):
+            store.trace_causation("nonexistent-message-id")
+
+
+# ---------------------------------------------------------------------------
+# Tests: trace_effects
+# ---------------------------------------------------------------------------
+
+
+class TestTraceEffects:
+    """Tests for ``event_store.trace_effects()`` — walking DOWN the chain."""
+
+    @pytest.mark.eventstore
+    def test_root_command_returns_downstream_events(self, test_domain, order_id):
+        """trace_effects on PlaceOrder returns at least OrderPlaced."""
+        test_domain.process(
+            PlaceOrder(order_id=order_id, customer="Alice", amount=100.0),
+            asynchronous=False,
+        )
+
+        commands = _read_commands(test_domain, order_id)
+        store = test_domain.event_store.store
+        effects = store.trace_effects(commands[0].metadata.headers.id)
+
+        # At minimum, OrderPlaced should be an effect of PlaceOrder
+        assert len(effects) >= 1
+        effect_types = [m.metadata.headers.type for m in effects]
+        assert OrderPlaced.__type__ in effect_types
+
+    @pytest.mark.eventstore
+    def test_terminal_event_returns_empty(self, test_domain, order_id):
+        """An event with no downstream handlers returns empty effects."""
+        test_domain.process(
+            PlaceOrder(order_id=order_id, customer="Alice", amount=100.0),
+            asynchronous=False,
+        )
+
+        events = _read_events(test_domain, order_id)
+        # OrderPlaced has no event handler registered (no auto-confirm here)
+        # so it should have no effects
+        store = test_domain.event_store.store
+        effects = store.trace_effects(events[0].metadata.headers.id)
+
+        assert effects == []
+
+    @pytest.mark.eventstore
+    def test_recursive_false_returns_one_level(self, test_domain, order_id):
+        """recursive=False returns only direct children."""
+        test_domain.process(
+            PlaceOrder(order_id=order_id, customer="Alice", amount=100.0),
+            asynchronous=False,
+        )
+
+        commands = _read_commands(test_domain, order_id)
+        store = test_domain.event_store.store
+        direct = store.trace_effects(commands[0].metadata.headers.id, recursive=False)
+
+        # Direct children of PlaceOrder command = the events it raised
+        assert len(direct) >= 1
+        for msg in direct:
+            assert msg.metadata.domain.causation_id == commands[0].metadata.headers.id
+
+    @pytest.mark.eventstore
+    def test_effects_ordered_by_global_position(self, test_domain, order_id):
+        """Effects are returned in chronological (global_position) order."""
+        # Place and then confirm order for multiple events
+        test_domain.process(
+            PlaceOrder(order_id=order_id, customer="Alice", amount=100.0),
+            asynchronous=False,
+        )
+        test_domain.process(
+            ConfirmOrder(order_id=order_id),
+            asynchronous=False,
+        )
+
+        # Get all commands and check effects of the first one
+        commands = _read_commands(test_domain, order_id)
+        store = test_domain.event_store.store
+        effects = store.trace_effects(commands[0].metadata.headers.id)
+
+        # Verify ordering by checking global_positions are non-decreasing
+        positions = [
+            m.metadata.event_store.global_position
+            for m in effects
+            if m.metadata.event_store
+            and m.metadata.event_store.global_position is not None
+        ]
+        assert positions == sorted(positions)
+
+    @pytest.mark.eventstore
+    def test_accepts_message_object(self, test_domain, order_id):
+        """trace_effects accepts a Message object."""
+        test_domain.process(
+            PlaceOrder(order_id=order_id, customer="Alice", amount=100.0),
+            asynchronous=False,
+        )
+
+        commands = _read_commands(test_domain, order_id)
+        store = test_domain.event_store.store
+
+        # Pass Message object
+        effects = store.trace_effects(commands[0])
+        assert len(effects) >= 1
+
+    @pytest.mark.eventstore
+    def test_unknown_message_id_raises_value_error(self, test_domain):
+        """Nonexistent message ID raises ValueError."""
+        store = test_domain.event_store.store
+        with pytest.raises(ValueError, match="not found in event store"):
+            store.trace_effects("nonexistent-message-id")
+
+
+# ---------------------------------------------------------------------------
+# Tests: trace_effects with chained event handler
+# ---------------------------------------------------------------------------
+
+
+class TestTraceEffectsWithChain:
+    """Tests for trace_effects when an event handler dispatches a new command.
+
+    In sync mode, g.message_in_context stays as the root command during
+    UoW.commit() event handler dispatch. This means chained commands have
+    causation_id = root_command.headers.id, making them appear as siblings
+    of the events (direct children of the root command).
+    """
+
+    @pytest.fixture(autouse=True)
+    def register_event_handler(self, test_domain):
+        test_domain.register(OrderPlacedAutoConfirmHandler, part_of=Order)
+        test_domain.init(traverse=False)
+
+    @pytest.mark.eventstore
+    def test_root_command_effects_include_chained_events(self, test_domain, order_id):
+        """Effects of root command include events from the chained command."""
+        test_domain.process(
+            PlaceOrder(order_id=order_id, customer="Alice", amount=100.0),
+            asynchronous=False,
+        )
+
+        commands = _read_commands(test_domain, order_id)
+        store = test_domain.event_store.store
+        effects = store.trace_effects(commands[0].metadata.headers.id)
+
+        effect_types = [m.metadata.headers.type for m in effects]
+        assert OrderPlaced.__type__ in effect_types
+        assert OrderConfirmed.__type__ in effect_types
+
+
+# ---------------------------------------------------------------------------
+# Tests: build_causation_tree
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCausationTree:
+    """Tests for ``event_store.build_causation_tree()``."""
+
+    @pytest.mark.eventstore
+    def test_single_command_event_chain(self, test_domain, order_id):
+        """Tree for a simple PlaceOrder -> OrderPlaced chain."""
+        correlation_id = "test-tree-corr-123"
+        test_domain.process(
+            PlaceOrder(order_id=order_id, customer="Alice", amount=100.0),
+            asynchronous=False,
+            correlation_id=correlation_id,
+        )
+
+        store = test_domain.event_store.store
+        root = store.build_causation_tree(correlation_id)
+
+        assert root is not None
+        assert isinstance(root, CausationNode)
+        # Root should be the PlaceOrder command
+        assert root.kind == "COMMAND"
+        # Should have at least one child (OrderPlaced event)
+        assert len(root.children) >= 1
+        assert root.children[0].kind == "EVENT"
+
+    @pytest.mark.eventstore
+    def test_tree_has_correct_node_attributes(self, test_domain, order_id):
+        """CausationNode attributes are populated correctly."""
+        correlation_id = "test-attrs-corr"
+        test_domain.process(
+            PlaceOrder(order_id=order_id, customer="Alice", amount=100.0),
+            asynchronous=False,
+            correlation_id=correlation_id,
+        )
+
+        store = test_domain.event_store.store
+        root = store.build_causation_tree(correlation_id)
+
+        assert root is not None
+        assert root.message_id != "?"
+        assert root.message_type != "?"
+        assert root.kind in ("EVENT", "COMMAND")
+        assert root.stream != "?"
+
+    @pytest.mark.eventstore
+    def test_returns_none_for_unknown_correlation_id(self, test_domain):
+        """build_causation_tree returns None for nonexistent correlation ID."""
+        store = test_domain.event_store.store
+        result = store.build_causation_tree("nonexistent-correlation-id")
+        assert result is None
+
+    @pytest.mark.eventstore
+    def test_multiple_events_from_single_command(self, test_domain, order_id):
+        """Tree correctly shows multiple events as children of one command."""
+        correlation_id = "test-multi-corr"
+        test_domain.process(
+            PlaceOrder(order_id=order_id, customer="Alice", amount=100.0),
+            asynchronous=False,
+            correlation_id=correlation_id,
+        )
+        test_domain.process(
+            ConfirmOrder(order_id=order_id),
+            asynchronous=False,
+            correlation_id=correlation_id,
+        )
+
+        store = test_domain.event_store.store
+        root = store.build_causation_tree(correlation_id)
+
+        assert root is not None
+        # Root is PlaceOrder, should have OrderPlaced as child
+        # Second command (ConfirmOrder) is a separate root since it has no causation_id
+        # But they share the same correlation_id
+
+    @pytest.mark.eventstore
+    def test_chained_tree_structure(self, test_domain, order_id):
+        """Tree reflects the sync causation chain correctly.
+
+        In sync mode, the chained command (ConfirmOrder dispatched by the
+        OrderPlacedAutoConfirmHandler) has causation_id pointing to the root
+        command. So OrderPlaced and OrderConfirmed are siblings under PlaceOrder.
+        """
+        test_domain.register(OrderPlacedAutoConfirmHandler, part_of=Order)
+        test_domain.init(traverse=False)
+
+        correlation_id = "test-chain-corr"
+        test_domain.process(
+            PlaceOrder(order_id=order_id, customer="Alice", amount=100.0),
+            asynchronous=False,
+            correlation_id=correlation_id,
+        )
+
+        store = test_domain.event_store.store
+        root = store.build_causation_tree(correlation_id)
+
+        assert root is not None
+        # Root is PlaceOrder command
+        assert root.kind == "COMMAND"
+        # In sync mode, all events (OrderPlaced + OrderConfirmed) and the
+        # chained ConfirmOrder command are direct children of root
+        assert len(root.children) >= 2
+
+
+# ---------------------------------------------------------------------------
+# Tests: Static helper extractors
+# ---------------------------------------------------------------------------
+
+
+class TestHelperExtractors:
+    """Tests for the static metadata extraction helpers on BaseEventStore."""
+
+    def test_extract_message_id_valid(self, test_domain):
+        """Extracts headers.id from a well-formed raw message."""
+
+        msg = {"metadata": {"headers": {"id": "test-msg-123"}}}
+        assert BaseEventStore._extract_message_id(msg) == "test-msg-123"
+
+    def test_extract_message_id_missing_metadata(self, test_domain):
+        assert BaseEventStore._extract_message_id({}) is None
+        assert BaseEventStore._extract_message_id({"metadata": None}) is None
+
+    def test_extract_message_id_missing_headers(self, test_domain):
+        assert BaseEventStore._extract_message_id({"metadata": {}}) is None
+        assert (
+            BaseEventStore._extract_message_id({"metadata": {"headers": None}}) is None
+        )
+
+    def test_extract_causation_id_valid(self, test_domain):
+        msg = {"metadata": {"domain": {"causation_id": "parent-123"}}}
+        assert BaseEventStore._extract_causation_id(msg) == "parent-123"
+
+    def test_extract_causation_id_none_value(self, test_domain):
+        msg = {"metadata": {"domain": {"causation_id": None}}}
+        assert BaseEventStore._extract_causation_id(msg) is None
+
+    def test_extract_correlation_id_valid(self, test_domain):
+        msg = {"metadata": {"domain": {"correlation_id": "corr-abc"}}}
+        assert BaseEventStore._extract_correlation_id(msg) == "corr-abc"
+
+    def test_extract_from_malformed_metadata(self, test_domain):
+        # metadata is not a dict
+        msg = {"metadata": "not-a-dict"}
+        assert BaseEventStore._extract_message_id(msg) is None
+        assert BaseEventStore._extract_causation_id(msg) is None
+        assert BaseEventStore._extract_correlation_id(msg) is None
+
+        # domain is not a dict
+        msg2 = {"metadata": {"domain": "not-a-dict"}}
+        assert BaseEventStore._extract_causation_id(msg2) is None
+        assert BaseEventStore._extract_correlation_id(msg2) is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: Edge cases for _resolve_and_load_group
+# ---------------------------------------------------------------------------
+
+
+class TestResolveAndLoadGroupEdgeCases:
+    """Tests for edge cases in _resolve_and_load_group (lines 544, 546)."""
+
+    @pytest.mark.eventstore
+    def test_message_with_no_headers_raises(self, test_domain):
+        """A Message with no metadata raises ValueError (line 544)."""
+        store = test_domain.event_store.store
+        msg = MagicMock(spec=Message)
+        msg.metadata = None
+
+        with pytest.raises(ValueError, match="Message has no headers.id"):
+            store._resolve_and_load_group(msg)
+
+    @pytest.mark.eventstore
+    def test_message_with_no_correlation_id_returns_empty_group(self, test_domain):
+        """A Message with headers but no domain returns empty group (line 546)."""
+        store = test_domain.event_store.store
+        msg = MagicMock(spec=Message)
+        msg.metadata = MagicMock()
+        msg.metadata.headers = MagicMock()
+        msg.metadata.headers.id = "some-msg-id"
+        msg.metadata.domain = None
+
+        mid, group = store._resolve_and_load_group(msg)
+        assert mid == "some-msg-id"
+        assert group == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: trace_causation edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestTraceCausationEdgeCases:
+    """Tests for edge cases in trace_causation (lines 595, 607)."""
+
+    @pytest.fixture(autouse=True)
+    def register_elements(self, test_domain):
+        test_domain.register(Order, is_event_sourced=True)
+        test_domain.register(OrderPlaced, part_of=Order)
+        test_domain.register(OrderConfirmed, part_of=Order)
+        test_domain.register(PlaceOrder, part_of=Order)
+        test_domain.register(ConfirmOrder, part_of=Order)
+        test_domain.register(OrderCommandHandler, part_of=Order)
+        test_domain.init(traverse=False)
+
+    @pytest.mark.eventstore
+    def test_causation_id_pointing_outside_group(self, test_domain):
+        """When causation_id points to a message outside the group, chain stops (line 607).
+
+        Root commands have causation_id=None so they stop naturally.
+        This test verifies that trace_causation handles the root correctly
+        by stopping when by_id lookup returns None for a causation_id.
+        """
+        order_id = str(uuid4())
+        test_domain.process(
+            PlaceOrder(order_id=order_id, customer="Alice", amount=100.0),
+            asynchronous=False,
+        )
+
+        events = _read_events(test_domain, order_id)
+        store = test_domain.event_store.store
+
+        # The event's causation_id points to the command.
+        # The command's causation_id is None, which exits the while loop
+        # (current_id becomes None). This confirms the break path
+        # for when by_id.get(current_id) returns None is also safe.
+        chain = store.trace_causation(events[0].metadata.headers.id)
+        assert len(chain) == 2
+        # Root (command) has no causation_id
+        assert chain[0].metadata.domain.causation_id is None
+
+    @pytest.mark.eventstore
+    def test_message_with_no_correlation_returns_only_self(self, test_domain):
+        """A Message object with no domain metadata returns empty group,
+        leading to an empty chain (exercises line 546 via trace_causation)."""
+        store = test_domain.event_store.store
+        msg = MagicMock(spec=Message)
+        msg.metadata = MagicMock()
+        msg.metadata.headers = MagicMock()
+        msg.metadata.headers.id = "orphan-msg-id"
+        msg.metadata.domain = None
+
+        # Empty group means by_id is empty, so chain is empty
+        chain = store.trace_causation(msg)
+        assert chain == []
+
+    @pytest.mark.eventstore
+    def test_group_member_with_no_headers_id_skipped_in_lookup(self, test_domain):
+        """A group member with no headers.id is skipped in by_id (line 595->593)."""
+        store = test_domain.event_store.store
+
+        original = store._resolve_and_load_group
+
+        def _patched(message_id):
+            return "target-msg", [
+                # A valid root message
+                {
+                    "type": "RootCmd",
+                    "metadata": {
+                        "headers": {"id": "target-msg"},
+                        "domain": {"correlation_id": "corr-1", "causation_id": None},
+                    },
+                    "data": {},
+                },
+                # A malformed group member with no headers.id
+                {
+                    "type": "BadMsg",
+                    "metadata": {"headers": {}, "domain": {"correlation_id": "corr-1"}},
+                    "data": {},
+                },
+            ]
+
+        store._resolve_and_load_group = _patched
+        try:
+            chain = store.trace_causation("target-msg")
+            # Should find the root message but skip the malformed one
+            assert len(chain) == 1
+        finally:
+            store._resolve_and_load_group = original
+
+
+# ---------------------------------------------------------------------------
+# Tests: trace_effects edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestTraceEffectsEdgeCases:
+    """Tests for edge cases in trace_effects (line 660->658)."""
+
+    @pytest.fixture(autouse=True)
+    def register_elements(self, test_domain):
+        test_domain.register(Order, is_event_sourced=True)
+        test_domain.register(OrderPlaced, part_of=Order)
+        test_domain.register(PlaceOrder, part_of=Order)
+        test_domain.register(OrderCommandHandler, part_of=Order)
+        test_domain.init(traverse=False)
+
+    @pytest.mark.eventstore
+    def test_child_with_no_headers_id_skipped_in_bfs(self, test_domain):
+        """A child with no headers.id is skipped during BFS (line 660->658)."""
+        store = test_domain.event_store.store
+
+        original = store._resolve_and_load_group
+
+        def _patched(message_id):
+            return "root-cmd", [
+                {
+                    "type": "RootCmd",
+                    "metadata": {
+                        "headers": {"id": "root-cmd"},
+                        "domain": {"correlation_id": "corr-2", "causation_id": None},
+                    },
+                    "global_position": 1,
+                    "data": {},
+                },
+                {
+                    # Child with no headers.id — should be skipped in BFS
+                    "type": "BadChild",
+                    "metadata": {
+                        "headers": {},
+                        "domain": {
+                            "correlation_id": "corr-2",
+                            "causation_id": "root-cmd",
+                        },
+                    },
+                    "global_position": 2,
+                    "data": {},
+                },
+            ]
+
+        store._resolve_and_load_group = _patched
+        try:
+            effects = store.trace_effects("root-cmd")
+            # The child has no headers.id so it's skipped
+            assert effects == []
+        finally:
+            store._resolve_and_load_group = original
+
+
+# ---------------------------------------------------------------------------
+# Tests: build_causation_tree edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCausationTreeEdgeCases:
+    """Tests for edge cases in build_causation_tree (lines 691, 711, 714, 717)."""
+
+    @pytest.fixture(autouse=True)
+    def register_elements(self, test_domain):
+        test_domain.register(Order, is_event_sourced=True)
+        test_domain.register(OrderPlaced, part_of=Order)
+        test_domain.register(PlaceOrder, part_of=Order)
+        test_domain.register(OrderCommandHandler, part_of=Order)
+        test_domain.init(traverse=False)
+
+    def test_build_node_with_malformed_metadata_string(self, test_domain):
+        """_build_node handles metadata that is a string, not a dict (line 711)."""
+        store = test_domain.event_store.store
+
+        # Monkey-patch _load_correlation_group to return malformed data
+        original = store._load_correlation_group
+        store._load_correlation_group = lambda cid: [
+            {
+                "type": "MalformedEvent",
+                "stream_name": "test-stream",
+                "global_position": 1,
+                "metadata": "not-a-dict",  # malformed metadata
+            }
+        ]
+
+        try:
+            root = store.build_causation_tree("malformed-corr")
+            assert root is not None
+            assert root.message_id == "?"
+            assert root.message_type == "MalformedEvent"
+            assert root.kind == "?"
+        finally:
+            store._load_correlation_group = original
+
+    def test_build_node_with_malformed_headers_string(self, test_domain):
+        """_build_node handles headers that is a string, not a dict (line 714)."""
+        store = test_domain.event_store.store
+
+        original = store._load_correlation_group
+        store._load_correlation_group = lambda cid: [
+            {
+                "type": "MalformedEvent",
+                "stream_name": "test-stream",
+                "global_position": 1,
+                "metadata": {"headers": "not-a-dict", "domain": {"kind": "EVENT"}},
+            }
+        ]
+
+        try:
+            root = store.build_causation_tree("malformed-headers-corr")
+            assert root is not None
+            assert root.message_id == "?"
+            assert root.kind == "EVENT"
+        finally:
+            store._load_correlation_group = original
+
+    def test_build_node_with_malformed_domain_string(self, test_domain):
+        """_build_node handles domain that is a string, not a dict (line 717)."""
+        store = test_domain.event_store.store
+
+        original = store._load_correlation_group
+        store._load_correlation_group = lambda cid: [
+            {
+                "type": "MalformedEvent",
+                "stream_name": "test-stream",
+                "global_position": 1,
+                "metadata": {
+                    "headers": {"id": "msg-123"},
+                    "domain": "not-a-dict",  # malformed domain
+                },
+            }
+        ]
+
+        try:
+            root = store.build_causation_tree("malformed-domain-corr")
+            assert root is not None
+            assert root.message_id == "msg-123"
+            assert root.kind == "?"  # Falls back to "?" since domain is malformed
+        finally:
+            store._load_correlation_group = original
+
+    def test_build_tree_with_message_missing_headers_id(self, test_domain):
+        """Message with no headers.id in group: not added to by_id, and skipped
+        as a child because _extract_message_id returns None (falsy) at line 729.
+        This exercises the branch at line 691 where hid is falsy."""
+        store = test_domain.event_store.store
+
+        original = store._load_correlation_group
+        store._load_correlation_group = lambda cid: [
+            {
+                "type": "GoodEvent",
+                "stream_name": "test-stream",
+                "global_position": 1,
+                "metadata": {
+                    "headers": {"id": "root-msg"},
+                    "domain": {"kind": "COMMAND", "correlation_id": cid},
+                },
+            },
+            {
+                # This message has no headers.id
+                "type": "OrphanEvent",
+                "stream_name": "test-stream",
+                "global_position": 2,
+                "metadata": {
+                    "headers": {},
+                    "domain": {
+                        "kind": "EVENT",
+                        "causation_id": "root-msg",
+                        "correlation_id": cid,
+                    },
+                },
+            },
+        ]
+
+        try:
+            root = store.build_causation_tree("missing-hid-corr")
+            assert root is not None
+            assert root.message_id == "root-msg"
+            # The orphan child has no headers.id so _extract_message_id returns
+            # None (falsy) — it's skipped by the `if child_id and ...` guard
+            # in _build_node (line 729-730). The root has no children.
+            assert len(root.children) == 0
+        finally:
+            store._load_correlation_group = original


### PR DESCRIPTION
Add three methods to BaseEventStore for programmatic traversal of causation chains, enhance the CLI trace command with tree visualization, and document the feature comprehensively across the doc ecosystem.

Core implementation (src/protean/port/event_store.py):
- Add CausationNode dataclass for tree representation
- Add trace_causation() to walk UP from a message to the root command
- Add trace_effects() to walk DOWN from a message to all its effects
- Add build_causation_tree() to build a full causation tree by correlation_id
- Add private helpers for metadata extraction and correlation group loading
- Include cycle-safety via visited sets in all traversal methods

CLI enhancement (src/protean/cli/events.py):
- Change default `protean events trace` output to tree view using rich.tree
- Add --flat flag to preserve the existing flat table behavior
- Add _build_rich_tree() and _count_nodes() helpers for tree rendering
- Tree labels show CMD/EVT badge, message type, message ID, and timestamp