### PR TITLE
Add dead letter queue management for failed messages

### DIFF
--- a/docs/concepts/async-processing/subscriptions.md
+++ b/docs/concepts/async-processing/subscriptions.md
@@ -228,6 +228,42 @@ For unrecoverable errors:
 - Graceful shutdown is initiated
 - Exit code indicates failure
 
+### Dead Letter Queue Management
+
+Messages that exhaust all retries in a `StreamSubscription` are moved to a
+**Dead Letter Queue (DLQ)** — a separate stream named `{stream_category}:dlq`.
+When [priority lanes](./priority-lanes.md) are enabled, backfill failures go to
+`{stream_category}:backfill:dlq`.
+
+DLQ messages retain the original payload along with metadata about why they
+failed, how many retries were attempted, and which consumer group was processing
+them. Protean provides two interfaces for inspecting and acting on DLQ
+messages:
+
+**CLI** — The [`protean dlq`](../../reference/cli/data/dlq.md) commands let you
+list, inspect, replay, and purge DLQ messages from the terminal:
+
+```bash
+# See all failed messages
+protean dlq list --domain=my_app
+
+# Inspect a specific failure
+protean dlq inspect <dlq_id> --domain=my_app
+
+# Replay a single message back to its original stream
+protean dlq replay <dlq_id> --domain=my_app
+
+# Replay all messages for a subscription
+protean dlq replay-all --subscription=order --domain=my_app
+
+# Clear a subscription's DLQ
+protean dlq purge --subscription=order --domain=my_app
+```
+
+**Observatory** — The [Observatory dashboard](../../reference/server/observability.md)
+includes a DLQ tab that provides the same capabilities through a web interface,
+plus REST API endpoints at `/api/dlq/*` for programmatic access.
+
 
 ## Next Steps
 

--- a/docs/reference/adapters/broker/inline.md
+++ b/docs/reference/adapters/broker/inline.md
@@ -51,6 +51,7 @@ The Inline broker supports the following capabilities:
 - ✅ **BASIC_PUBSUB** - Fire-and-forget message publishing
 - ✅ **SIMPLE_QUEUING** - Consumer groups for message distribution
 - ✅ **RELIABLE_MESSAGING** - Message acknowledgment and rejection
+- ✅ **DEAD_LETTER_QUEUE** - Failed messages routed to DLQ for inspection and replay
 - ❌ **ORDERED_MESSAGING** - Not supported
 - ❌ **ENTERPRISE_STREAMING** - Not supported
 
@@ -173,9 +174,11 @@ class OrderProcessor2:
     - No support for partitioned delivery
     - Cannot ensure strict message sequencing
 - **Limited Error Recovery**
-    - Basic retry support only
-    - No dead letter queue functionality
-    - Limited visibility into failed messages
+    - Basic retry support with configurable max retries
+    - Dead letter queue stores failed messages in memory (lost on restart)
+    - DLQ messages can be listed, inspected, replayed, and purged via
+      [`protean dlq`](../../cli/data/dlq.md) CLI or the
+      [Observatory dashboard](../../server/observability.md)
 
 ## Migration Path
 

--- a/docs/reference/adapters/broker/redis.md
+++ b/docs/reference/adapters/broker/redis.md
@@ -58,6 +58,7 @@ The Redis Stream broker provides the following capabilities:
 
 - ✅ **ORDERED_MESSAGING** - Reliable messaging with ordering guarantees within streams
 - ✅ **BLOCKING_READ** - Efficient blocking reads for new messages
+- ✅ **DEAD_LETTER_QUEUE** - Failed messages routed to DLQ streams for inspection and replay
 
 This includes:
 - **Publish/subscribe** messaging
@@ -65,11 +66,12 @@ This includes:
 - **Message acknowledgment** (ACK/NACK) for reliable delivery
 - **At-least-once delivery** guarantees
 - **Message ordering** preservation within streams
+- **Dead letter queue management** — list, inspect, replay, and purge failed messages via
+  [`protean dlq`](../../cli/data/dlq.md) CLI or the
+  [Observatory dashboard](../../server/observability.md)
 
 Not supported:
-- ❌ **Dead Letter Queue (DLQ)** - Not implemented
 - ❌ **Stream partitioning** - Not a native feature
-- ❌ **Message replay** - Not implemented
 
 ## Monitoring and Debugging
 

--- a/docs/reference/cli/data/dlq.md
+++ b/docs/reference/cli/data/dlq.md
@@ -1,0 +1,185 @@
+# `protean dlq`
+
+The `protean dlq` command group provides tools for managing dead letter
+queues (DLQs). When messages fail processing after exhausting retries,
+they are moved to DLQ streams. These commands let you list, inspect,
+replay, and purge those failed messages — both from the terminal and
+via the [Observatory dashboard](../runtime/observatory.md).
+
+All commands accept a `--domain` option to specify the domain module path
+(defaults to the current directory).
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `protean dlq list` | List failed messages across DLQ streams |
+| `protean dlq inspect` | Show full details of a DLQ message |
+| `protean dlq replay` | Replay a single message back to its original stream |
+| `protean dlq replay-all` | Replay all DLQ messages for a subscription |
+| `protean dlq purge` | Purge all DLQ messages for a subscription |
+
+## `protean dlq list`
+
+Lists failed messages across all DLQ streams, or filtered by subscription.
+
+```bash
+# List all DLQ messages
+protean dlq list --domain=my_domain
+
+# Filter by subscription (stream category)
+protean dlq list --subscription=order --domain=my_domain
+
+# Limit results
+protean dlq list --limit=50 --domain=my_domain
+```
+
+**Options**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--domain` | Domain module path | `.` (current directory) |
+| `--subscription` | Filter by stream category (e.g. `order`) | All subscriptions |
+| `--limit` | Maximum number of messages to show | `100` |
+
+**Output**
+
+```
+┏━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┓
+┃ DLQ ID             ┃ Subscription ┃ Consumer Group          ┃ Failure Reason        ┃ Failed At           ┃ Retries ┃
+┡━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━┩
+│ 1708768400000-0    │ order        │ app.handlers.OrderHa... │ max_retries_exceeded  │ 2026-02-23 10:00:00 │       3 │
+│ 1708768500000-0    │ payment      │ app.handlers.Payment... │ max_retries_exceeded  │ 2026-02-23 10:01:40 │       3 │
+└────────────────────┴──────────────┴─────────────────────────┴───────────────────────┴─────────────────────┴─────────┘
+
+2 DLQ message(s) found.
+```
+
+## `protean dlq inspect`
+
+Displays the full details of a specific DLQ message, including its
+complete payload.
+
+```bash
+protean dlq inspect "1708768400000-0" --domain=my_domain
+```
+
+**Options**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `DLQ_ID` | DLQ entry identifier (positional argument) | Required |
+| `--domain` | Domain module path | `.` (current directory) |
+| `--subscription` | Stream category to search in | All subscriptions |
+
+## `protean dlq replay`
+
+Replays a single DLQ message back to its original stream for
+reprocessing. The message is removed from the DLQ and published as a new
+message on the target stream.
+
+```bash
+protean dlq replay "1708768400000-0" --domain=my_domain
+```
+
+**Options**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `DLQ_ID` | DLQ entry identifier (positional argument) | Required |
+| `--domain` | Domain module path | `.` (current directory) |
+| `--subscription` | Stream category to search in | All subscriptions |
+
+## `protean dlq replay-all`
+
+Replays all DLQ messages for a given subscription back to the original
+stream. This is a bulk operation — use with caution.
+
+```bash
+# Interactive (prompts for confirmation)
+protean dlq replay-all --subscription=order --domain=my_domain
+
+# Skip confirmation
+protean dlq replay-all --subscription=order --yes --domain=my_domain
+```
+
+**Options**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--subscription` | Stream category (required) | Required |
+| `--domain` | Domain module path | `.` (current directory) |
+| `--yes` / `-y` | Skip confirmation prompt | `False` |
+
+## `protean dlq purge`
+
+Permanently removes all DLQ messages for a subscription. **This cannot
+be undone.**
+
+```bash
+# Interactive (prompts for confirmation)
+protean dlq purge --subscription=order --domain=my_domain
+
+# Skip confirmation
+protean dlq purge --subscription=order --yes --domain=my_domain
+```
+
+**Options**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--subscription` | Stream category (required) | Required |
+| `--domain` | Domain module path | `.` (current directory) |
+| `--yes` / `-y` | Skip confirmation prompt | `False` |
+
+## Observatory Dashboard
+
+In addition to the CLI, the [Observatory dashboard](../runtime/observatory.md)
+provides a **DLQ tab** for visual management:
+
+- **List** — View all DLQ messages with subscription filter
+- **Inspect** — Click any message to view its full payload
+- **Replay** — Replay individual messages or all messages for a subscription
+- **Purge** — Clear all DLQ messages for a subscription
+
+The DLQ tab auto-refreshes every 5 seconds alongside other dashboard panels.
+
+## Observatory REST API
+
+The Observatory exposes DLQ management endpoints for programmatic access:
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/dlq` | GET | List DLQ messages (`?subscription=...&limit=...`) |
+| `/api/dlq/{dlq_id}` | GET | Inspect a single DLQ message |
+| `/api/dlq/{dlq_id}/replay` | POST | Replay a single message |
+| `/api/dlq/replay-all` | POST | Replay all messages (`?subscription=...`) |
+| `/api/dlq` | DELETE | Purge all messages (`?subscription=...`) |
+
+## Error Handling
+
+| Condition | Behavior |
+|-----------|----------|
+| Invalid domain path | Aborts with "Error loading Protean domain" |
+| No default broker configured | Aborts with "No default broker configured" |
+| Broker doesn't support DLQ | Aborts with "does not support dead letter queues" |
+| Subscription not found | Aborts with "No subscription found for stream category" |
+| DLQ message not found (`inspect`, `replay`) | Aborts with "not found" |
+| No DLQ messages (`list`) | Prints "No DLQ messages found" |
+
+## How Messages Enter the DLQ
+
+Messages are moved to the DLQ when they fail processing after exhausting
+all retry attempts. The engine's
+[StreamSubscription](../../server/subscription-types.md) tracks retry counts
+per message and moves messages to `{stream_category}:dlq` streams after
+`max_retries` failures.
+
+See [Subscriptions](../../../concepts/async-processing/subscriptions.md) for
+details on subscription lifecycle and error handling.
+
+## Domain Discovery
+
+The `protean dlq` commands use the same domain discovery mechanism as
+other CLI commands. See [Domain Discovery](../project/discovery.md) for the
+full resolution logic.

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -22,6 +22,11 @@ load the domain.
 | [`protean events stats`](data/events.md)    | Show stream statistics across the domain |
 | [`protean events search`](data/events.md)   | Search for events by type |
 | [`protean events history`](data/events.md)  | Display aggregate event timeline |
+| [`protean dlq list`](data/dlq.md)           | List failed DLQ messages |
+| [`protean dlq inspect`](data/dlq.md)        | Inspect a specific DLQ message |
+| [`protean dlq replay`](data/dlq.md)         | Replay a DLQ message to its original stream |
+| [`protean dlq replay-all`](data/dlq.md)     | Replay all DLQ messages for a subscription |
+| [`protean dlq purge`](data/dlq.md)          | Purge DLQ messages for a subscription |
 
 !!! note
 

--- a/docs/reference/server/observability.md
+++ b/docs/reference/server/observability.md
@@ -155,6 +155,12 @@ app = create_observatory_app(domains=[identity, catalogue])
 An embedded HTML dashboard that connects to the SSE stream and displays
 real-time message flow. Open `http://localhost:9000` in your browser.
 
+The dashboard includes a **DLQ tab** alongside Messages, Events, and Errors.
+The DLQ tab provides a filterable list of failed messages with buttons to
+inspect, replay, or purge entries — the same operations available through the
+[`protean dlq`](../cli/data/dlq.md) CLI commands and the `/api/dlq/*` REST
+endpoints documented below.
+
 #### SSE stream -- `GET /stream`
 
 Server-Sent Events endpoint for real-time trace streaming. Supports
@@ -358,6 +364,90 @@ curl http://localhost:9000/api/subscriptions
     }
   }
 }
+```
+
+#### DLQ Messages -- `GET /api/dlq`
+
+List dead letter queue messages across all subscriptions. Returns messages
+sorted by failure time (newest first).
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `subscription` | Filter by stream category | all |
+| `limit` | Maximum messages to return | `100` |
+
+```bash
+# List all DLQ messages
+curl http://localhost:9000/api/dlq
+
+# Filter by subscription
+curl "http://localhost:9000/api/dlq?subscription=order&limit=50"
+```
+
+```json
+{
+  "entries": [
+    {
+      "dlq_id": "1705312200000-0",
+      "original_id": "abc-123",
+      "stream": "order",
+      "consumer_group": "tests.order_handler.OrderEventHandler",
+      "payload": {"type": "OrderPlaced", "data": {"order_id": "123"}},
+      "failure_reason": "ConnectionError: database unavailable",
+      "failed_at": "2025-01-15T10:30:00Z",
+      "retry_count": 3,
+      "dlq_stream": "order:dlq"
+    }
+  ],
+  "total": 1,
+  "subscriptions": ["order", "payment"]
+}
+```
+
+#### DLQ Inspect -- `GET /api/dlq/{dlq_id}`
+
+Inspect a single DLQ message with full payload details.
+
+```bash
+curl http://localhost:9000/api/dlq/1705312200000-0
+```
+
+#### DLQ Replay -- `POST /api/dlq/{dlq_id}/replay`
+
+Replay a single DLQ message back to its original stream for reprocessing.
+
+```bash
+curl -X POST http://localhost:9000/api/dlq/1705312200000-0/replay
+```
+
+```json
+{"status": "ok", "replayed": true, "dlq_id": "1705312200000-0"}
+```
+
+#### DLQ Replay All -- `POST /api/dlq/replay-all`
+
+Replay all DLQ messages for a subscription. The `subscription` query parameter
+is required.
+
+```bash
+curl -X POST "http://localhost:9000/api/dlq/replay-all?subscription=order"
+```
+
+```json
+{"status": "ok", "replayed_count": 5, "subscription": "order"}
+```
+
+#### DLQ Purge -- `DELETE /api/dlq`
+
+Purge all DLQ messages for a subscription. The `subscription` query parameter
+is required.
+
+```bash
+curl -X DELETE "http://localhost:9000/api/dlq?subscription=order"
+```
+
+```json
+{"status": "ok", "purged_count": 5, "subscription": "order"}
 ```
 
 #### Queue Depth -- `GET /api/queue-depth`

--- a/docs/reference/server/subscription-types.md
+++ b/docs/reference/server/subscription-types.md
@@ -111,6 +111,19 @@ DLQ messages include metadata for debugging:
 }
 ```
 
+##### Managing DLQ Messages
+
+Protean provides built-in tools to inspect and act on DLQ messages without
+writing custom scripts:
+
+- **CLI**: Use [`protean dlq`](../cli/data/dlq.md) to list, inspect, replay, or
+  purge DLQ messages from the terminal.
+- **Observatory**: The [DLQ tab](observability.md) in the Observatory dashboard
+  provides a web UI and REST API (`/api/dlq/*`) for the same operations.
+
+See [Dead Letter Queue Management](../../concepts/async-processing/subscriptions.md#dead-letter-queue-management)
+for usage examples.
+
 #### Automatic Retries
 
 Failed messages are automatically retried with configurable delays:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -237,6 +237,7 @@ nav:
       - Data:
         - reference/cli/data/index.md
         - reference/cli/data/database.md
+        - reference/cli/data/dlq.md
         - reference/cli/data/events.md
         - reference/cli/data/snapshot.md
         - reference/cli/data/projection.md

--- a/src/protean/adapters/broker/inline.py
+++ b/src/protean/adapters/broker/inline.py
@@ -2,9 +2,16 @@ import logging
 import time
 import uuid
 from collections import defaultdict
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Dict
 
-from protean.port.broker import BaseBroker, BrokerCapabilities, OperationState, registry
+from protean.port.broker import (
+    BaseBroker,
+    BrokerCapabilities,
+    DLQEntry,
+    OperationState,
+    registry,
+)
 
 if TYPE_CHECKING:
     from protean.domain import Domain
@@ -84,7 +91,9 @@ class InlineBroker(BaseBroker):
     @property
     def capabilities(self) -> BrokerCapabilities:
         """InlineBroker provides full manual broker capabilities for testing."""
-        return BrokerCapabilities.RELIABLE_MESSAGING
+        return (
+            BrokerCapabilities.RELIABLE_MESSAGING | BrokerCapabilities.DEAD_LETTER_QUEUE
+        )
 
     def _publish(self, stream: str, message: dict) -> str:
         """Publish a message dict to the stream"""
@@ -773,6 +782,119 @@ class InlineBroker(BaseBroker):
         except Exception as e:
             logger.error(f"Error reprocessing DLQ message '{identifier}': {e}")
             return False
+
+    # ------------------------------------------------------------------
+    # DLQ Management
+    # ------------------------------------------------------------------
+
+    def _dlq_list(self, dlq_streams: list[str], limit: int) -> list[DLQEntry]:
+        """List DLQ messages across specified DLQ streams."""
+        entries: list[DLQEntry] = []
+        for group_key, messages in self._dead_letter_queue.items():
+            if not messages:
+                continue
+            stream, consumer_group = group_key.split(CONSUMER_GROUP_SEPARATOR, 1)
+            dlq_stream_name = f"{stream}:dlq"
+            if dlq_stream_name not in dlq_streams:
+                continue
+            for identifier, message, failure_reason, timestamp in messages:
+                entries.append(
+                    DLQEntry(
+                        dlq_id=identifier,
+                        original_id=identifier,
+                        stream=stream,
+                        consumer_group=consumer_group,
+                        payload=message,
+                        failure_reason=failure_reason,
+                        failed_at=(
+                            datetime.fromtimestamp(
+                                timestamp, tz=timezone.utc
+                            ).isoformat()
+                            if timestamp
+                            else None
+                        ),
+                        retry_count=0,
+                        dlq_stream=dlq_stream_name,
+                    )
+                )
+        entries.sort(key=lambda e: e.failed_at or "", reverse=True)
+        return entries[:limit]
+
+    def _dlq_inspect(self, dlq_stream: str, dlq_id: str) -> DLQEntry | None:
+        """Inspect a specific DLQ message by ID."""
+        for group_key, messages in self._dead_letter_queue.items():
+            if not messages:
+                continue
+            stream, consumer_group = group_key.split(CONSUMER_GROUP_SEPARATOR, 1)
+            dlq_stream_name = f"{stream}:dlq"
+            if dlq_stream_name != dlq_stream:
+                continue
+            for identifier, message, failure_reason, timestamp in messages:
+                if identifier == dlq_id:
+                    return DLQEntry(
+                        dlq_id=identifier,
+                        original_id=identifier,
+                        stream=stream,
+                        consumer_group=consumer_group,
+                        payload=message,
+                        failure_reason=failure_reason,
+                        failed_at=(
+                            datetime.fromtimestamp(
+                                timestamp, tz=timezone.utc
+                            ).isoformat()
+                            if timestamp
+                            else None
+                        ),
+                        retry_count=0,
+                        dlq_stream=dlq_stream_name,
+                    )
+        return None
+
+    def _dlq_replay(self, dlq_stream: str, dlq_id: str, target_stream: str) -> bool:
+        """Replay a single DLQ message back to its original stream."""
+        for group_key, messages in self._dead_letter_queue.items():
+            stream, consumer_group = group_key.split(CONSUMER_GROUP_SEPARATOR, 1)
+            dlq_stream_name = f"{stream}:dlq"
+            if dlq_stream_name != dlq_stream:
+                continue
+            for i, (identifier, message, failure_reason, timestamp) in enumerate(
+                messages
+            ):
+                if identifier == dlq_id:
+                    del messages[i]
+                    self._publish(target_stream, message)
+                    logger.info(
+                        f"Replayed DLQ message '{identifier}' to stream '{target_stream}'"
+                    )
+                    return True
+        return False
+
+    def _dlq_replay_all(self, dlq_stream: str, target_stream: str) -> int:
+        """Replay all DLQ messages from a stream."""
+        replayed = 0
+        for group_key in list(self._dead_letter_queue.keys()):
+            messages = self._dead_letter_queue[group_key]
+            stream, _ = group_key.split(CONSUMER_GROUP_SEPARATOR, 1)
+            dlq_stream_name = f"{stream}:dlq"
+            if dlq_stream_name != dlq_stream:
+                continue
+            for identifier, message, failure_reason, timestamp in messages:
+                self._publish(target_stream, message)
+                replayed += 1
+            messages.clear()
+        return replayed
+
+    def _dlq_purge(self, dlq_stream: str) -> int:
+        """Purge all messages from a DLQ stream."""
+        purged = 0
+        for group_key in list(self._dead_letter_queue.keys()):
+            stream, _ = group_key.split(CONSUMER_GROUP_SEPARATOR, 1)
+            dlq_stream_name = f"{stream}:dlq"
+            if dlq_stream_name != dlq_stream:
+                continue
+            purged += len(self._dead_letter_queue[group_key])
+            self._dead_letter_queue[group_key].clear()
+        return purged
 
     def _ensure_group(self, group_name: str, stream: str) -> None:
         """Bootstrap/create consumer group."""

--- a/src/protean/adapters/broker/redis.py
+++ b/src/protean/adapters/broker/redis.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 import redis
 
-from protean.port.broker import BaseBroker, BrokerCapabilities, registry
+from protean.port.broker import BaseBroker, BrokerCapabilities, DLQEntry, registry
 
 if TYPE_CHECKING:
     from protean.domain import Domain
@@ -46,7 +46,11 @@ class RedisBroker(BaseBroker):
     @property
     def capabilities(self) -> BrokerCapabilities:
         """Redis Streams provide ordered messaging with native consumer groups and blocking reads."""
-        return BrokerCapabilities.ORDERED_MESSAGING | BrokerCapabilities.BLOCKING_READ
+        return (
+            BrokerCapabilities.ORDERED_MESSAGING
+            | BrokerCapabilities.BLOCKING_READ
+            | BrokerCapabilities.DEAD_LETTER_QUEUE
+        )
 
     @property
     def _created_groups(self):
@@ -357,6 +361,114 @@ class RedisBroker(BaseBroker):
             return False
 
         return True
+
+    # ------------------------------------------------------------------
+    # DLQ Management
+    # ------------------------------------------------------------------
+
+    def _dlq_list(self, dlq_streams: list[str], limit: int) -> list[DLQEntry]:
+        """List DLQ messages across specified DLQ streams."""
+        entries: list[DLQEntry] = []
+        for dlq_stream in dlq_streams:
+            try:
+                raw_messages = self.redis_instance.xrange(dlq_stream)
+            except redis.ResponseError:
+                # Stream doesn't exist
+                continue
+
+            for redis_id, fields in raw_messages:
+                entry = self._parse_dlq_entry(dlq_stream, redis_id, fields)
+                if entry:
+                    entries.append(entry)
+
+        # Sort by failed_at descending (newest first)
+        entries.sort(key=lambda e: e.failed_at or "", reverse=True)
+        return entries[:limit]
+
+    def _dlq_inspect(self, dlq_stream: str, dlq_id: str) -> DLQEntry | None:
+        """Inspect a specific DLQ message by ID."""
+        try:
+            raw_messages = self.redis_instance.xrange(
+                dlq_stream, min=dlq_id, max=dlq_id, count=1
+            )
+        except redis.ResponseError:
+            return None
+
+        if not raw_messages:
+            return None
+
+        redis_id, fields = raw_messages[0]
+        return self._parse_dlq_entry(dlq_stream, redis_id, fields)
+
+    def _dlq_replay(self, dlq_stream: str, dlq_id: str, target_stream: str) -> bool:
+        """Replay a single DLQ message back to its original stream."""
+        try:
+            raw_messages = self.redis_instance.xrange(
+                dlq_stream, min=dlq_id, max=dlq_id, count=1
+            )
+        except redis.ResponseError:
+            return False
+
+        if not raw_messages:
+            return False
+
+        redis_id, fields = raw_messages[0]
+        message = self._deserialize_message(fields)
+        # Strip DLQ metadata before republishing
+        message.pop("_dlq_metadata", None)
+        self._publish(target_stream, message)
+        self.redis_instance.xdel(dlq_stream, self._decode_if_bytes(redis_id))
+        logger.info(f"Replayed DLQ message '{dlq_id}' to stream '{target_stream}'")
+        return True
+
+    def _dlq_replay_all(self, dlq_stream: str, target_stream: str) -> int:
+        """Replay all DLQ messages from a stream."""
+        try:
+            raw_messages = self.redis_instance.xrange(dlq_stream)
+        except redis.ResponseError:
+            return 0
+
+        replayed = 0
+        for redis_id, fields in raw_messages:
+            message = self._deserialize_message(fields)
+            message.pop("_dlq_metadata", None)
+            self._publish(target_stream, message)
+            self.redis_instance.xdel(dlq_stream, self._decode_if_bytes(redis_id))
+            replayed += 1
+        return replayed
+
+    def _dlq_purge(self, dlq_stream: str) -> int:
+        """Purge all messages from a DLQ stream."""
+        try:
+            count = self.redis_instance.xlen(dlq_stream)
+        except redis.ResponseError:
+            return 0
+        if count > 0:
+            self.redis_instance.delete(dlq_stream)
+        return count
+
+    def _parse_dlq_entry(
+        self, dlq_stream: str, redis_id: bytes | str, fields: dict
+    ) -> DLQEntry | None:
+        """Parse a raw Redis DLQ message into a DLQEntry."""
+        message = self._deserialize_message(fields)
+        if not message:
+            return None
+
+        dlq_meta = message.get("_dlq_metadata", {})
+        redis_id_str = self._decode_if_bytes(redis_id)
+
+        return DLQEntry(
+            dlq_id=redis_id_str,
+            original_id=dlq_meta.get("original_id", redis_id_str),
+            stream=dlq_meta.get("original_stream", dlq_stream.removesuffix(":dlq")),
+            consumer_group=dlq_meta.get("consumer_group", ""),
+            payload=message,
+            failure_reason=dlq_meta.get("failure_reason", "unknown"),
+            failed_at=dlq_meta.get("failed_at"),
+            retry_count=int(dlq_meta.get("retry_count", 0)),
+            dlq_stream=dlq_stream,
+        )
 
     def _ensure_group(self, group_name: str, stream: str) -> None:
         """Create consumer group if it doesn't exist"""

--- a/src/protean/adapters/broker/redis_pubsub.py
+++ b/src/protean/adapters/broker/redis_pubsub.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Dict
 
 import redis
 
-from protean.port.broker import BaseBroker, BrokerCapabilities, registry
+from protean.port.broker import BaseBroker, BrokerCapabilities, DLQEntry, registry
 
 if TYPE_CHECKING:
     from protean.domain import Domain
@@ -262,6 +262,25 @@ class RedisPubSubBroker(BaseBroker):
             self._consumer_groups.clear()
         except Exception as e:
             logger.error(f"Error during data reset: {e}")
+
+    # DLQ methods — not supported by PubSub broker (no DEAD_LETTER_QUEUE capability).
+    # These stubs satisfy the abstract interface; the capability gate in BaseBroker
+    # prevents them from ever being called.
+
+    def _dlq_list(self, dlq_streams: list[str], limit: int = 100) -> list[DLQEntry]:
+        return []
+
+    def _dlq_inspect(self, dlq_stream: str, dlq_id: str) -> DLQEntry | None:
+        return None
+
+    def _dlq_replay(self, dlq_stream: str, dlq_id: str, target_stream: str) -> bool:
+        return False
+
+    def _dlq_replay_all(self, dlq_stream: str, target_stream: str) -> int:
+        return 0
+
+    def _dlq_purge(self, dlq_stream: str) -> int:
+        return 0
 
 
 # Self-registration function for entry point

--- a/src/protean/cli/__init__.py
+++ b/src/protean/cli/__init__.py
@@ -22,6 +22,7 @@ from rich import print
 from typing_extensions import Annotated
 
 from protean.cli.database import app as db_app
+from protean.cli.dlq import app as dlq_app
 from protean.cli.docs import app as docs_app
 from protean.cli.events import app as events_app
 from protean.cli.generate import app as generate_app
@@ -47,6 +48,7 @@ app.command()(new)
 app.command()(observatory)
 app.command()(shell)
 app.add_typer(db_app, name="db")
+app.add_typer(dlq_app, name="dlq")
 app.add_typer(events_app, name="events")
 app.add_typer(generate_app, name="generate")
 app.add_typer(docs_app, name="docs")

--- a/src/protean/cli/dlq.py
+++ b/src/protean/cli/dlq.py
@@ -1,0 +1,308 @@
+"""CLI commands for managing dead letter queues.
+
+Provides commands for listing, inspecting, replaying, and purging
+messages that failed processing and were moved to DLQ streams.
+
+Usage::
+
+    # List all DLQ messages
+    protean dlq list --domain=my_domain
+
+    # List DLQ messages for a specific subscription
+    protean dlq list --subscription=order --domain=my_domain
+
+    # Inspect a specific DLQ message
+    protean dlq inspect <dlq_id> --domain=my_domain
+
+    # Replay a single message
+    protean dlq replay <dlq_id> --subscription=order --domain=my_domain
+
+    # Replay all messages for a subscription
+    protean dlq replay-all --subscription=order --domain=my_domain
+
+    # Purge all DLQ messages for a subscription
+    protean dlq purge --subscription=order --domain=my_domain
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import typer
+from rich import print
+from rich.table import Table
+from typing_extensions import Annotated
+
+from protean.exceptions import NoDomainException
+from protean.port.broker import BrokerCapabilities
+from protean.utils.dlq import collect_dlq_streams, discover_subscriptions
+from protean.utils.domain_discovery import derive_domain
+from protean.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from protean.domain import Domain
+
+logger = get_logger(__name__)
+
+app = typer.Typer(no_args_is_help=True)
+
+
+@app.callback()
+def callback():
+    """Manage dead letter queues."""
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_domain(domain_path: str) -> "Domain":
+    """Load and initialize a domain, handling errors consistently."""
+    try:
+        derived_domain = derive_domain(domain_path)
+    except NoDomainException as exc:
+        msg = f"Error loading Protean domain: {exc.args[0]}"
+        print(msg)
+        logger.error(msg)
+        raise typer.Abort()
+
+    assert derived_domain is not None
+    derived_domain.init()
+    return derived_domain
+
+
+def _get_broker(domain: "Domain"):
+    """Retrieve the default broker from the domain."""
+    broker = domain.brokers.get("default")
+    if broker is None:
+        print("Error: No default broker configured in domain.")
+        raise typer.Abort()
+    if not broker.has_capability(BrokerCapabilities.DEAD_LETTER_QUEUE):
+        print("Error: Configured broker does not support dead letter queues.")
+        raise typer.Abort()
+    return broker
+
+
+def _resolve_dlq_streams(domain: "Domain", subscription: str | None) -> list[str]:
+    """Resolve DLQ stream names, optionally filtered by subscription."""
+    if subscription:
+        # Map subscription name to DLQ stream(s)
+        infos = discover_subscriptions(domain)
+        streams = []
+        for info in infos:
+            if info.stream_category == subscription:
+                streams.append(info.dlq_stream)
+                if info.backfill_dlq_stream:
+                    streams.append(info.backfill_dlq_stream)
+        if not streams:
+            print(f"Error: No subscription found for stream category '{subscription}'.")
+            raise typer.Abort()
+        return streams
+    return collect_dlq_streams(domain)
+
+
+def _resolve_target_stream(subscription: str) -> str:
+    """Derive the target stream name from a subscription (stream category)."""
+    return subscription
+
+
+def _format_time(raw: str | None) -> str:
+    """Format an ISO timestamp for display."""
+    if not raw:
+        return "-"
+    try:
+        from datetime import datetime
+
+        return datetime.fromisoformat(raw).strftime("%Y-%m-%d %H:%M:%S")
+    except (ValueError, TypeError):
+        return raw
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+
+@app.command(name="list")
+def list_dlq(
+    domain: Annotated[str, typer.Option(help="Domain module path")] = ".",
+    subscription: Annotated[
+        str | None,
+        typer.Option(help="Filter by stream category (e.g. 'order')"),
+    ] = None,
+    limit: Annotated[
+        int, typer.Option(help="Maximum number of messages to show")
+    ] = 100,
+) -> None:
+    """List failed messages across DLQ streams."""
+    derived_domain = _load_domain(domain)
+    with derived_domain.domain_context():
+        broker = _get_broker(derived_domain)
+        dlq_streams = _resolve_dlq_streams(derived_domain, subscription)
+
+        if not dlq_streams:
+            print("No subscriptions found in domain.")
+            return
+
+        entries = broker.dlq_list(dlq_streams, limit=limit)
+
+        if not entries:
+            print("No DLQ messages found.")
+            return
+
+        table = Table()
+        table.add_column("DLQ ID", style="cyan")
+        table.add_column("Subscription")
+        table.add_column("Consumer Group", style="dim")
+        table.add_column("Failure Reason", style="red")
+        table.add_column("Failed At")
+        table.add_column("Retries", justify="right")
+
+        for entry in entries:
+            table.add_row(
+                entry.dlq_id[:16] + "..." if len(entry.dlq_id) > 16 else entry.dlq_id,
+                entry.stream,
+                entry.consumer_group[:30] + "..."
+                if len(entry.consumer_group) > 30
+                else entry.consumer_group,
+                entry.failure_reason,
+                _format_time(entry.failed_at),
+                str(entry.retry_count),
+            )
+
+        print(table)
+        print(f"\n{len(entries)} DLQ message(s) found.")
+
+
+@app.command()
+def inspect(
+    dlq_id: Annotated[str, typer.Argument(help="DLQ entry identifier")],
+    domain: Annotated[str, typer.Option(help="Domain module path")] = ".",
+    subscription: Annotated[
+        str | None,
+        typer.Option(help="Stream category to search in"),
+    ] = None,
+) -> None:
+    """Show full details of a DLQ message."""
+    derived_domain = _load_domain(domain)
+    with derived_domain.domain_context():
+        broker = _get_broker(derived_domain)
+        dlq_streams = _resolve_dlq_streams(derived_domain, subscription)
+
+        entry = None
+        for dlq_stream in dlq_streams:
+            entry = broker.dlq_inspect(dlq_stream, dlq_id)
+            if entry:
+                break
+
+        if not entry:
+            print(f"DLQ message '{dlq_id}' not found.")
+            raise typer.Abort()
+
+        print(f"[bold]DLQ ID:[/bold]          {entry.dlq_id}")
+        print(f"[bold]Original ID:[/bold]     {entry.original_id}")
+        print(f"[bold]Stream:[/bold]          {entry.stream}")
+        print(f"[bold]Consumer Group:[/bold]  {entry.consumer_group}")
+        print(f"[bold]DLQ Stream:[/bold]      {entry.dlq_stream}")
+        print(f"[bold]Failure Reason:[/bold]  {entry.failure_reason}")
+        print(f"[bold]Failed At:[/bold]       {_format_time(entry.failed_at)}")
+        print(f"[bold]Retry Count:[/bold]     {entry.retry_count}")
+        print("\n[bold]Payload:[/bold]")
+        # Strip DLQ metadata from display payload for clarity
+        display_payload = {
+            k: v for k, v in entry.payload.items() if k != "_dlq_metadata"
+        }
+        print(json.dumps(display_payload, indent=2, default=str))
+
+
+@app.command()
+def replay(
+    dlq_id: Annotated[str, typer.Argument(help="DLQ entry identifier to replay")],
+    domain: Annotated[str, typer.Option(help="Domain module path")] = ".",
+    subscription: Annotated[
+        str | None,
+        typer.Option(help="Stream category to search in"),
+    ] = None,
+) -> None:
+    """Replay a single DLQ message back to its original stream."""
+    derived_domain = _load_domain(domain)
+    with derived_domain.domain_context():
+        broker = _get_broker(derived_domain)
+        dlq_streams = _resolve_dlq_streams(derived_domain, subscription)
+
+        for dlq_stream in dlq_streams:
+            entry = broker.dlq_inspect(dlq_stream, dlq_id)
+            if entry:
+                target_stream = entry.stream
+                success = broker.dlq_replay(dlq_stream, dlq_id, target_stream)
+                if success:
+                    print(f"Replayed message '{dlq_id}' to stream '{target_stream}'.")
+                else:
+                    print(f"Failed to replay message '{dlq_id}'.")
+                return
+
+        print(f"DLQ message '{dlq_id}' not found.")
+        raise typer.Abort()
+
+
+@app.command(name="replay-all")
+def replay_all(
+    subscription: Annotated[
+        str,
+        typer.Option(help="Stream category (required)"),
+    ],
+    domain: Annotated[str, typer.Option(help="Domain module path")] = ".",
+    yes: Annotated[
+        bool, typer.Option("--yes", "-y", help="Skip confirmation prompt")
+    ] = False,
+) -> None:
+    """Replay all DLQ messages for a subscription back to their original stream."""
+    derived_domain = _load_domain(domain)
+    with derived_domain.domain_context():
+        broker = _get_broker(derived_domain)
+        dlq_streams = _resolve_dlq_streams(derived_domain, subscription)
+        target_stream = _resolve_target_stream(subscription)
+
+        if not yes:
+            typer.confirm(
+                f"Replay all DLQ messages for subscription '{subscription}'?",
+                abort=True,
+            )
+
+        total = 0
+        for dlq_stream in dlq_streams:
+            total += broker.dlq_replay_all(dlq_stream, target_stream)
+
+        print(f"Replayed {total} message(s) to stream '{target_stream}'.")
+
+
+@app.command()
+def purge(
+    subscription: Annotated[
+        str,
+        typer.Option(help="Stream category (required)"),
+    ],
+    domain: Annotated[str, typer.Option(help="Domain module path")] = ".",
+    yes: Annotated[
+        bool, typer.Option("--yes", "-y", help="Skip confirmation prompt")
+    ] = False,
+) -> None:
+    """Purge all DLQ messages for a subscription."""
+    derived_domain = _load_domain(domain)
+    with derived_domain.domain_context():
+        broker = _get_broker(derived_domain)
+        dlq_streams = _resolve_dlq_streams(derived_domain, subscription)
+
+        if not yes:
+            typer.confirm(
+                f"Purge all DLQ messages for subscription '{subscription}'? This cannot be undone.",
+                abort=True,
+            )
+
+        total = 0
+        for dlq_stream in dlq_streams:
+            total += broker.dlq_purge(dlq_stream)
+
+        print(f"Purged {total} message(s) from DLQ.")

--- a/src/protean/port/broker.py
+++ b/src/protean/port/broker.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from importlib import import_module, metadata
 import logging
 import time
@@ -22,6 +23,36 @@ BACKOFF_MULTIPLIER = 2.0
 MESSAGE_TIMEOUT = 300.0
 ENABLE_DLQ = True
 OPERATION_STATE_TTL_MAX = 60.0
+
+
+@dataclass
+class DLQEntry:
+    """Normalized representation of a dead letter queue message.
+
+    Provides a broker-agnostic view of a DLQ entry for use by CLI commands
+    and Observatory API endpoints.
+
+    Attributes:
+        dlq_id: Identifier within the DLQ (Redis stream ID or UUID).
+        original_id: Original message identifier before it entered DLQ.
+        stream: Original stream category the message belonged to.
+        consumer_group: Consumer group that failed to process the message.
+        payload: Full message payload dict.
+        failure_reason: Why the message was moved to DLQ.
+        failed_at: ISO 8601 timestamp of when the message failed.
+        retry_count: Number of retries attempted before DLQ.
+        dlq_stream: Name of the DLQ stream this entry lives in.
+    """
+
+    dlq_id: str
+    original_id: str
+    stream: str
+    consumer_group: str
+    payload: dict
+    failure_reason: str
+    failed_at: str | None
+    retry_count: int
+    dlq_stream: str
 
 
 class OperationState(Enum):
@@ -569,6 +600,105 @@ class BaseBroker(metaclass=ABCMeta):
         Returns:
             dict: Information about consumer groups and their consumers
         """
+
+    # ------------------------------------------------------------------
+    # Dead Letter Queue Management
+    # ------------------------------------------------------------------
+
+    def dlq_list(self, dlq_streams: list[str], limit: int = 100) -> list[DLQEntry]:
+        """List DLQ messages across specified DLQ streams.
+
+        Args:
+            dlq_streams: List of DLQ stream names to query.
+            limit: Maximum total messages to return.
+
+        Returns:
+            List of DLQEntry objects sorted by failure time (newest first).
+        """
+        if not self.has_capability(BrokerCapabilities.DEAD_LETTER_QUEUE):
+            logger.warning(f"Broker {self.name} does not support DLQ management")
+            return []
+        return self._dlq_list(dlq_streams, limit)
+
+    def dlq_inspect(self, dlq_stream: str, dlq_id: str) -> DLQEntry | None:
+        """Inspect a specific DLQ message by its DLQ entry ID.
+
+        Args:
+            dlq_stream: The DLQ stream to look in.
+            dlq_id: The entry identifier within the DLQ stream.
+
+        Returns:
+            DLQEntry if found, None otherwise.
+        """
+        if not self.has_capability(BrokerCapabilities.DEAD_LETTER_QUEUE):
+            logger.warning(f"Broker {self.name} does not support DLQ management")
+            return None
+        return self._dlq_inspect(dlq_stream, dlq_id)
+
+    def dlq_replay(self, dlq_stream: str, dlq_id: str, target_stream: str) -> bool:
+        """Replay a single DLQ message back to its original stream.
+
+        Args:
+            dlq_stream: The DLQ stream the message is in.
+            dlq_id: The entry identifier within the DLQ stream.
+            target_stream: The stream to re-publish the message to.
+
+        Returns:
+            True if replayed successfully, False otherwise.
+        """
+        if not self.has_capability(BrokerCapabilities.DEAD_LETTER_QUEUE):
+            logger.warning(f"Broker {self.name} does not support DLQ management")
+            return False
+        return self._dlq_replay(dlq_stream, dlq_id, target_stream)
+
+    def dlq_replay_all(self, dlq_stream: str, target_stream: str) -> int:
+        """Replay all DLQ messages from a stream back to the original stream.
+
+        Args:
+            dlq_stream: The DLQ stream to drain.
+            target_stream: The stream to re-publish messages to.
+
+        Returns:
+            Number of messages replayed.
+        """
+        if not self.has_capability(BrokerCapabilities.DEAD_LETTER_QUEUE):
+            logger.warning(f"Broker {self.name} does not support DLQ management")
+            return 0
+        return self._dlq_replay_all(dlq_stream, target_stream)
+
+    def dlq_purge(self, dlq_stream: str) -> int:
+        """Purge all messages from a DLQ stream.
+
+        Args:
+            dlq_stream: The DLQ stream to purge.
+
+        Returns:
+            Number of messages purged.
+        """
+        if not self.has_capability(BrokerCapabilities.DEAD_LETTER_QUEUE):
+            logger.warning(f"Broker {self.name} does not support DLQ management")
+            return 0
+        return self._dlq_purge(dlq_stream)
+
+    @abstractmethod
+    def _dlq_list(self, dlq_streams: list[str], limit: int) -> list[DLQEntry]:
+        """List DLQ messages across specified DLQ streams."""
+
+    @abstractmethod
+    def _dlq_inspect(self, dlq_stream: str, dlq_id: str) -> DLQEntry | None:
+        """Inspect a specific DLQ message."""
+
+    @abstractmethod
+    def _dlq_replay(self, dlq_stream: str, dlq_id: str, target_stream: str) -> bool:
+        """Replay a single DLQ message back to its original stream."""
+
+    @abstractmethod
+    def _dlq_replay_all(self, dlq_stream: str, target_stream: str) -> int:
+        """Replay all DLQ messages from a stream."""
+
+    @abstractmethod
+    def _dlq_purge(self, dlq_stream: str) -> int:
+        """Purge all messages from a DLQ stream."""
 
     def register(self, subscriber_cls: Type[BaseSubscriber]) -> None:
         """Register a subscriber to this broker against its stream.

--- a/src/protean/server/observatory/api.py
+++ b/src/protean/server/observatory/api.py
@@ -432,6 +432,276 @@ def create_api_router(domains: List[Domain]) -> APIRouter:
 
         return JSONResponse(content=result)
 
+    # ------------------------------------------------------------------
+    # DLQ Management Endpoints
+    # ------------------------------------------------------------------
+
+    @router.get("/dlq")
+    async def dlq_list(
+        subscription: Optional[str] = Query(
+            None, description="Filter by stream category"
+        ),
+        limit: int = Query(100, ge=1, le=1000, description="Maximum entries"),
+    ):
+        """List DLQ messages across all subscriptions."""
+        from protean.port.broker import BrokerCapabilities
+        from protean.utils.dlq import collect_dlq_streams, discover_subscriptions
+
+        domain = domains[0]
+        try:
+            with domain.domain_context():
+                broker = domain.brokers.get("default")
+                if broker is None:
+                    return JSONResponse(
+                        content={"error": "No default broker configured"},
+                        status_code=503,
+                    )
+                if not broker.has_capability(BrokerCapabilities.DEAD_LETTER_QUEUE):
+                    return JSONResponse(
+                        content={"error": "Broker does not support DLQ"},
+                        status_code=501,
+                    )
+
+                if subscription:
+                    infos = discover_subscriptions(domain)
+                    dlq_streams = []
+                    for info in infos:
+                        if info.stream_category == subscription:
+                            dlq_streams.append(info.dlq_stream)
+                            if info.backfill_dlq_stream:
+                                dlq_streams.append(info.backfill_dlq_stream)
+                    if not dlq_streams:
+                        return JSONResponse(
+                            content={"error": f"No subscription for '{subscription}'"},
+                            status_code=404,
+                        )
+                else:
+                    dlq_streams = collect_dlq_streams(domain)
+
+                entries = broker.dlq_list(dlq_streams, limit=limit)
+                return JSONResponse(
+                    content={
+                        "entries": [
+                            {
+                                "dlq_id": e.dlq_id,
+                                "original_id": e.original_id,
+                                "stream": e.stream,
+                                "consumer_group": e.consumer_group,
+                                "failure_reason": e.failure_reason,
+                                "failed_at": e.failed_at,
+                                "retry_count": e.retry_count,
+                                "dlq_stream": e.dlq_stream,
+                            }
+                            for e in entries
+                        ],
+                        "count": len(entries),
+                    }
+                )
+        except Exception as e:
+            logger.error(f"Error listing DLQ: {e}", exc_info=True)
+            return JSONResponse(
+                content={"error": "Failed to list DLQ messages"},
+                status_code=500,
+            )
+
+    @router.get("/dlq/{dlq_id}")
+    async def dlq_inspect(dlq_id: str):
+        """Inspect a single DLQ message with full payload."""
+        from protean.port.broker import BrokerCapabilities
+        from protean.utils.dlq import collect_dlq_streams
+
+        domain = domains[0]
+        try:
+            with domain.domain_context():
+                broker = domain.brokers.get("default")
+                if broker is None or not broker.has_capability(
+                    BrokerCapabilities.DEAD_LETTER_QUEUE
+                ):
+                    return JSONResponse(
+                        content={"error": "DLQ not available"},
+                        status_code=503,
+                    )
+
+                dlq_streams = collect_dlq_streams(domain)
+                for dlq_stream in dlq_streams:
+                    entry = broker.dlq_inspect(dlq_stream, dlq_id)
+                    if entry:
+                        # Strip internal DLQ metadata from displayed payload
+                        payload = {
+                            k: v
+                            for k, v in entry.payload.items()
+                            if k != "_dlq_metadata"
+                        }
+                        return JSONResponse(
+                            content={
+                                "dlq_id": entry.dlq_id,
+                                "original_id": entry.original_id,
+                                "stream": entry.stream,
+                                "consumer_group": entry.consumer_group,
+                                "failure_reason": entry.failure_reason,
+                                "failed_at": entry.failed_at,
+                                "retry_count": entry.retry_count,
+                                "dlq_stream": entry.dlq_stream,
+                                "payload": payload,
+                            }
+                        )
+
+                return JSONResponse(
+                    content={"error": f"DLQ message '{dlq_id}' not found"},
+                    status_code=404,
+                )
+        except Exception as e:
+            logger.error(f"Error inspecting DLQ message: {e}", exc_info=True)
+            return JSONResponse(
+                content={"error": "Failed to inspect DLQ message"},
+                status_code=500,
+            )
+
+    @router.post("/dlq/{dlq_id}/replay")
+    async def dlq_replay(dlq_id: str):
+        """Replay a single DLQ message back to its original stream."""
+        from protean.port.broker import BrokerCapabilities
+        from protean.utils.dlq import collect_dlq_streams
+
+        domain = domains[0]
+        try:
+            with domain.domain_context():
+                broker = domain.brokers.get("default")
+                if broker is None or not broker.has_capability(
+                    BrokerCapabilities.DEAD_LETTER_QUEUE
+                ):
+                    return JSONResponse(
+                        content={"error": "DLQ not available"},
+                        status_code=503,
+                    )
+
+                dlq_streams = collect_dlq_streams(domain)
+                for dlq_stream in dlq_streams:
+                    entry = broker.dlq_inspect(dlq_stream, dlq_id)
+                    if entry:
+                        success = broker.dlq_replay(dlq_stream, dlq_id, entry.stream)
+                        if success:
+                            return JSONResponse(
+                                content={
+                                    "status": "ok",
+                                    "replayed": True,
+                                    "target_stream": entry.stream,
+                                }
+                            )
+                        return JSONResponse(
+                            content={"error": "Replay failed"},
+                            status_code=500,
+                        )
+
+                return JSONResponse(
+                    content={"error": f"DLQ message '{dlq_id}' not found"},
+                    status_code=404,
+                )
+        except Exception as e:
+            logger.error(f"Error replaying DLQ message: {e}", exc_info=True)
+            return JSONResponse(
+                content={"error": "Failed to replay DLQ message"},
+                status_code=500,
+            )
+
+    @router.post("/dlq/replay-all")
+    async def dlq_replay_all(
+        subscription: str = Query(..., description="Stream category (required)"),
+    ):
+        """Replay all DLQ messages for a subscription."""
+        from protean.port.broker import BrokerCapabilities
+        from protean.utils.dlq import discover_subscriptions
+
+        domain = domains[0]
+        try:
+            with domain.domain_context():
+                broker = domain.brokers.get("default")
+                if broker is None or not broker.has_capability(
+                    BrokerCapabilities.DEAD_LETTER_QUEUE
+                ):
+                    return JSONResponse(
+                        content={"error": "DLQ not available"},
+                        status_code=503,
+                    )
+
+                infos = discover_subscriptions(domain)
+                dlq_streams = []
+                for info in infos:
+                    if info.stream_category == subscription:
+                        dlq_streams.append(info.dlq_stream)
+                        if info.backfill_dlq_stream:
+                            dlq_streams.append(info.backfill_dlq_stream)
+
+                if not dlq_streams:
+                    return JSONResponse(
+                        content={"error": f"No subscription for '{subscription}'"},
+                        status_code=404,
+                    )
+
+                total = 0
+                for dlq_stream in dlq_streams:
+                    total += broker.dlq_replay_all(dlq_stream, subscription)
+
+                return JSONResponse(
+                    content={
+                        "status": "ok",
+                        "replayed": total,
+                        "target_stream": subscription,
+                    }
+                )
+        except Exception as e:
+            logger.error(f"Error replaying all DLQ messages: {e}", exc_info=True)
+            return JSONResponse(
+                content={"error": "Failed to replay DLQ messages"},
+                status_code=500,
+            )
+
+    @router.delete("/dlq")
+    async def dlq_purge(
+        subscription: str = Query(..., description="Stream category (required)"),
+    ):
+        """Purge all DLQ messages for a subscription."""
+        from protean.port.broker import BrokerCapabilities
+        from protean.utils.dlq import discover_subscriptions
+
+        domain = domains[0]
+        try:
+            with domain.domain_context():
+                broker = domain.brokers.get("default")
+                if broker is None or not broker.has_capability(
+                    BrokerCapabilities.DEAD_LETTER_QUEUE
+                ):
+                    return JSONResponse(
+                        content={"error": "DLQ not available"},
+                        status_code=503,
+                    )
+
+                infos = discover_subscriptions(domain)
+                dlq_streams = []
+                for info in infos:
+                    if info.stream_category == subscription:
+                        dlq_streams.append(info.dlq_stream)
+                        if info.backfill_dlq_stream:
+                            dlq_streams.append(info.backfill_dlq_stream)
+
+                if not dlq_streams:
+                    return JSONResponse(
+                        content={"error": f"No subscription for '{subscription}'"},
+                        status_code=404,
+                    )
+
+                total = 0
+                for dlq_stream in dlq_streams:
+                    total += broker.dlq_purge(dlq_stream)
+
+                return JSONResponse(content={"status": "ok", "purged": total})
+        except Exception as e:
+            logger.error(f"Error purging DLQ: {e}", exc_info=True)
+            return JSONResponse(
+                content={"error": "Failed to purge DLQ"},
+                status_code=500,
+            )
+
     @router.delete("/traces")
     async def delete_traces():
         """Clear all persisted trace history."""

--- a/src/protean/server/observatory/dashboard.html
+++ b/src/protean/server/observatory/dashboard.html
@@ -1242,6 +1242,7 @@ body {
         <button class="feed-tab active" id="tabMessages" onclick="setViewTab('messages')" title="Messages grouped by message ID, showing the full lifecycle of each event across all handlers.">Messages</button>
         <button class="feed-tab" id="tabEvents" onclick="setViewTab('events')" title="Chronological stream of individual trace events (published, started, completed, failed, acked).">Events</button>
         <button class="feed-tab" id="tabErrors" onclick="setViewTab('errors')" title="Messages that have at least one error event (handler failure, DLQ, nack).">Errors <span class="error-badge" id="errorBadge" style="display:none">0</span></button>
+        <button class="feed-tab" id="tabDlq" onclick="setViewTab('dlq')" title="Dead letter queue messages that can be inspected, replayed, or purged.">DLQ <span class="error-badge" id="dlqBadge" style="display:none">0</span></button>
       </div>
       <div class="feed-controls">
         <select id="filterStream">
@@ -1260,6 +1261,33 @@ body {
     <!-- Events tab content (hidden by default) -->
     <div class="tab-content" id="eventsContent" style="display:none">
       <div class="feed-empty" id="eventsEmpty">Loading history...</div>
+    </div>
+    <!-- DLQ tab content (hidden by default) -->
+    <div class="tab-content" id="dlqContent" style="display:none">
+      <div style="padding:8px 12px; display:flex; align-items:center; gap:8px; border-bottom:1px solid var(--border)">
+        <select id="dlqSubscriptionFilter" style="font-family:var(--font-text);font-size:13px;padding:4px 8px;border:1px solid var(--border);border-radius:4px;background:var(--surface);color:var(--text)">
+          <option value="">All subscriptions</option>
+        </select>
+        <button onclick="pollDlq()" style="font-family:var(--font-text);font-size:13px;padding:4px 12px;border:1px solid var(--border);border-radius:4px;background:var(--surface);color:var(--text);cursor:pointer" title="Refresh DLQ list">Refresh</button>
+        <button onclick="dlqReplayAll()" id="dlqReplayAllBtn" style="font-family:var(--font-text);font-size:13px;padding:4px 12px;border:1px solid var(--success);border-radius:4px;background:var(--surface);color:var(--success);cursor:pointer;display:none" title="Replay all messages for selected subscription">Replay All</button>
+        <button onclick="dlqPurgeAll()" id="dlqPurgeBtn" style="font-family:var(--font-text);font-size:13px;padding:4px 12px;border:1px solid var(--accent);border-radius:4px;background:var(--surface);color:var(--accent);cursor:pointer;display:none" title="Purge all DLQ messages for selected subscription">Purge</button>
+        <span style="font-size:11px;color:var(--text-muted);font-family:var(--font-code);margin-left:auto" id="dlqLastUpdated"></span>
+      </div>
+      <table style="width:100%;border-collapse:collapse;font-size:13px" id="dlqTable">
+        <thead>
+          <tr style="border-bottom:1px solid var(--border)">
+            <th style="text-align:left;padding:8px 12px;font-weight:600;font-size:12px;color:var(--text-muted)">DLQ ID</th>
+            <th style="text-align:left;padding:8px 12px;font-weight:600;font-size:12px;color:var(--text-muted)">Subscription</th>
+            <th style="text-align:left;padding:8px 12px;font-weight:600;font-size:12px;color:var(--text-muted)">Failure</th>
+            <th style="text-align:left;padding:8px 12px;font-weight:600;font-size:12px;color:var(--text-muted)">Failed At</th>
+            <th style="text-align:right;padding:8px 12px;font-weight:600;font-size:12px;color:var(--text-muted)">Retries</th>
+            <th style="text-align:center;padding:8px 12px;font-weight:600;font-size:12px;color:var(--text-muted)">Actions</th>
+          </tr>
+        </thead>
+        <tbody id="dlqTableBody">
+          <tr><td colspan="6" style="text-align:center;padding:24px;color:var(--text-muted)">Loading...</td></tr>
+        </tbody>
+      </table>
     </div>
   </div>
 
@@ -2362,10 +2390,13 @@ function setViewTab(tab) {
   document.getElementById('tabMessages').classList.toggle('active', tab === 'messages');
   document.getElementById('tabEvents').classList.toggle('active', tab === 'events');
   document.getElementById('tabErrors').classList.toggle('active', tab === 'errors');
+  document.getElementById('tabDlq').classList.toggle('active', tab === 'dlq');
 
   document.getElementById('messagesContent').style.display = (tab === 'messages' || tab === 'errors') ? '' : 'none';
   document.getElementById('eventsContent').style.display = tab === 'events' ? '' : 'none';
+  document.getElementById('dlqContent').style.display = tab === 'dlq' ? '' : 'none';
 
+  if (tab === 'dlq') pollDlq();
   applyFilters();
 }
 
@@ -2837,6 +2868,7 @@ async function pollSubscriptions() {
     if (!resp.ok) return;
     const data = await resp.json();
     updateSubscriptionTable(data);
+    populateDlqFilter(data);
     const el = document.getElementById('subLastUpdated');
     if (el) el.textContent = new Date().toLocaleTimeString();
   } catch (e) { /* silent */ }
@@ -2921,6 +2953,155 @@ document.getElementById('filterSearch').addEventListener('input', () => {
   }
 });
 
+// --- DLQ Management ---
+let dlqEntries = [];
+
+async function pollDlq() {
+  try {
+    const sub = document.getElementById('dlqSubscriptionFilter').value;
+    const url = sub ? `/api/dlq?subscription=${encodeURIComponent(sub)}` : '/api/dlq';
+    const resp = await fetch(url);
+    if (!resp.ok) {
+      if (resp.status === 501) {
+        document.getElementById('dlqTableBody').innerHTML =
+          '<tr><td colspan="6" style="text-align:center;padding:24px;color:var(--text-muted)">Broker does not support DLQ</td></tr>';
+        return;
+      }
+      return;
+    }
+    const data = await resp.json();
+    dlqEntries = data.entries || [];
+    renderDlqTable();
+    updateDlqBadge();
+    const el = document.getElementById('dlqLastUpdated');
+    if (el) el.textContent = new Date().toLocaleTimeString();
+
+    // Show/hide bulk action buttons
+    const hasSub = !!document.getElementById('dlqSubscriptionFilter').value;
+    document.getElementById('dlqReplayAllBtn').style.display = hasSub && dlqEntries.length > 0 ? '' : 'none';
+    document.getElementById('dlqPurgeBtn').style.display = hasSub && dlqEntries.length > 0 ? '' : 'none';
+  } catch (e) { /* silent */ }
+}
+
+function renderDlqTable() {
+  const tbody = document.getElementById('dlqTableBody');
+  if (!tbody) return;
+  if (dlqEntries.length === 0) {
+    tbody.innerHTML = '<tr><td colspan="6" style="text-align:center;padding:24px;color:var(--text-muted)">No DLQ messages</td></tr>';
+    return;
+  }
+  let html = '';
+  for (const e of dlqEntries) {
+    const shortId = e.dlq_id.length > 16 ? e.dlq_id.substring(0, 16) + '...' : e.dlq_id;
+    const failedAt = e.failed_at ? new Date(e.failed_at).toLocaleString() : '-';
+    html += '<tr style="border-bottom:1px solid var(--border)">';
+    html += '<td style="padding:8px 12px;font-family:var(--font-code);font-size:12px" title="' + escapeHtml(e.dlq_id) + '">' + escapeHtml(shortId) + '</td>';
+    html += '<td style="padding:8px 12px">' + escapeHtml(e.stream) + '</td>';
+    html += '<td style="padding:8px 12px;color:var(--accent)">' + escapeHtml(e.failure_reason) + '</td>';
+    html += '<td style="padding:8px 12px;font-size:12px">' + escapeHtml(failedAt) + '</td>';
+    html += '<td style="padding:8px 12px;text-align:right;font-family:var(--font-code)">' + e.retry_count + '</td>';
+    html += '<td style="padding:8px 12px;text-align:center">';
+    html += '<button onclick="dlqInspect(\'' + escapeHtml(e.dlq_id) + '\')" style="font-size:11px;padding:2px 8px;margin:0 2px;border:1px solid var(--border);border-radius:3px;background:var(--surface);color:var(--text);cursor:pointer" title="Inspect">Inspect</button>';
+    html += '<button onclick="dlqReplay(\'' + escapeHtml(e.dlq_id) + '\')" style="font-size:11px;padding:2px 8px;margin:0 2px;border:1px solid var(--success);border-radius:3px;background:var(--surface);color:var(--success);cursor:pointer" title="Replay">Replay</button>';
+    html += '</td></tr>';
+  }
+  tbody.innerHTML = html;
+}
+
+function updateDlqBadge() {
+  const badge = document.getElementById('dlqBadge');
+  if (dlqEntries.length > 0) {
+    badge.textContent = dlqEntries.length > 99 ? '99+' : dlqEntries.length;
+    badge.style.display = 'inline';
+  } else {
+    badge.style.display = 'none';
+  }
+}
+
+async function dlqInspect(dlqId) {
+  try {
+    const resp = await fetch('/api/dlq/' + encodeURIComponent(dlqId));
+    if (!resp.ok) { alert('Message not found'); return; }
+    const data = await resp.json();
+    const payload = data.payload ? JSON.stringify(data.payload, null, 2) : '{}';
+    alert(
+      'DLQ ID: ' + data.dlq_id + '\n' +
+      'Original ID: ' + data.original_id + '\n' +
+      'Stream: ' + data.stream + '\n' +
+      'Consumer Group: ' + data.consumer_group + '\n' +
+      'Failure: ' + data.failure_reason + '\n' +
+      'Failed At: ' + (data.failed_at || '-') + '\n' +
+      'Retries: ' + data.retry_count + '\n\n' +
+      'Payload:\n' + payload
+    );
+  } catch (e) { alert('Failed to inspect message'); }
+}
+
+async function dlqReplay(dlqId) {
+  if (!confirm('Replay this message?')) return;
+  try {
+    const resp = await fetch('/api/dlq/' + encodeURIComponent(dlqId) + '/replay', { method: 'POST' });
+    if (resp.ok) {
+      pollDlq();
+    } else {
+      alert('Replay failed');
+    }
+  } catch (e) { alert('Replay failed'); }
+}
+
+async function dlqReplayAll() {
+  const sub = document.getElementById('dlqSubscriptionFilter').value;
+  if (!sub) { alert('Select a subscription first'); return; }
+  if (!confirm('Replay ALL DLQ messages for subscription "' + sub + '"?')) return;
+  try {
+    const resp = await fetch('/api/dlq/replay-all?subscription=' + encodeURIComponent(sub), { method: 'POST' });
+    if (resp.ok) {
+      const data = await resp.json();
+      alert('Replayed ' + data.replayed + ' message(s)');
+      pollDlq();
+    } else { alert('Replay failed'); }
+  } catch (e) { alert('Replay failed'); }
+}
+
+async function dlqPurgeAll() {
+  const sub = document.getElementById('dlqSubscriptionFilter').value;
+  if (!sub) { alert('Select a subscription first'); return; }
+  if (!confirm('PURGE all DLQ messages for subscription "' + sub + '"? This cannot be undone.')) return;
+  try {
+    const resp = await fetch('/api/dlq?subscription=' + encodeURIComponent(sub), { method: 'DELETE' });
+    if (resp.ok) {
+      const data = await resp.json();
+      alert('Purged ' + data.purged + ' message(s)');
+      pollDlq();
+    } else { alert('Purge failed'); }
+  } catch (e) { alert('Purge failed'); }
+}
+
+document.getElementById('dlqSubscriptionFilter').addEventListener('change', () => {
+  pollDlq();
+});
+
+// Populate DLQ subscription filter from subscription status data
+function populateDlqFilter(data) {
+  const select = document.getElementById('dlqSubscriptionFilter');
+  if (!select) return;
+  const current = select.value;
+  const streams = new Set();
+  for (const [, info] of Object.entries(data)) {
+    if (info.status !== 'ok' || !info.subscriptions) continue;
+    for (const s of info.subscriptions) {
+      if (s.stream_category) streams.add(s.stream_category);
+    }
+  }
+  // Preserve selected value
+  let html = '<option value="">All subscriptions</option>';
+  for (const s of [...streams].sort()) {
+    const sel = s === current ? ' selected' : '';
+    html += '<option value="' + escapeHtml(s) + '"' + sel + '>' + escapeHtml(s) + '</option>';
+  }
+  select.innerHTML = html;
+}
+
 // --- Init ---
 async function init() {
   initScrollListener();
@@ -2930,11 +3111,13 @@ async function init() {
   pollInfrastructure();
   pollQueueDepth();
   pollSubscriptions();
+  pollDlq();
   setInterval(tickThroughput, 1000);
   setInterval(tickQueueDepth, 1000);
   setInterval(() => { loadStats(); pollInfrastructure(); }, 5000);
   setInterval(pollQueueDepth, 2000);
   setInterval(pollSubscriptions, 5000);
+  setInterval(pollDlq, 5000);
   drawSparkline();
   drawQueueSparkline();
 }

--- a/src/protean/utils/dlq.py
+++ b/src/protean/utils/dlq.py
@@ -1,0 +1,127 @@
+"""DLQ discovery utility.
+
+Walks the domain registry to enumerate subscriptions and derive their
+associated DLQ stream names. This avoids Redis keyspace scanning and
+keeps the mapping consistent with how the Engine creates subscriptions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from protean.utils import DomainObjects
+
+if TYPE_CHECKING:
+    from protean.domain import Domain
+
+
+@dataclass
+class SubscriptionInfo:
+    """Describes a handler subscription and its DLQ stream(s)."""
+
+    handler_name: str
+    handler_fqn: str
+    stream_category: str
+    dlq_stream: str
+    backfill_dlq_stream: str | None
+
+
+def _infer_stream_category(handler_cls: type) -> str | None:
+    """Infer stream category from a handler class.
+
+    Mirrors ``Engine._infer_stream_category`` resolution order:
+    1. Explicit ``meta_.stream_category``
+    2. Aggregate's ``meta_.stream_category`` via ``part_of``
+    """
+    meta = getattr(handler_cls, "meta_", None)
+    if meta is None:
+        return None
+
+    stream_category = getattr(meta, "stream_category", None)
+    if stream_category:
+        return stream_category
+
+    part_of = getattr(meta, "part_of", None)
+    if part_of:
+        aggregate_meta = getattr(part_of, "meta_", None)
+        if aggregate_meta:
+            return getattr(aggregate_meta, "stream_category", None)
+
+    return None
+
+
+def discover_subscriptions(domain: "Domain") -> list[SubscriptionInfo]:
+    """Walk the domain registry and return subscription metadata.
+
+    Inspects event handlers, command handlers, and projectors to derive
+    their stream categories and DLQ stream names.
+    """
+    from protean.utils import fqn
+
+    server_config = domain.config.get("server", {})
+    lanes_config = server_config.get("priority_lanes", {})
+    lanes_enabled = lanes_config.get("enabled", False)
+    backfill_suffix = lanes_config.get("backfill_suffix", "backfill")
+
+    seen_streams: dict[str, SubscriptionInfo] = {}
+    infos: list[SubscriptionInfo] = []
+
+    def _add(handler_cls: type, stream_cat: str) -> None:
+        key = f"{fqn(handler_cls)}:{stream_cat}"
+        if key in seen_streams:
+            return
+
+        backfill_dlq = f"{stream_cat}:{backfill_suffix}:dlq" if lanes_enabled else None
+        info = SubscriptionInfo(
+            handler_name=handler_cls.__name__,
+            handler_fqn=fqn(handler_cls),
+            stream_category=stream_cat,
+            dlq_stream=f"{stream_cat}:dlq",
+            backfill_dlq_stream=backfill_dlq,
+        )
+        seen_streams[key] = info
+        infos.append(info)
+
+    # Event handlers
+    for _, record in domain.registry._elements.get(
+        DomainObjects.EVENT_HANDLER.value, {}
+    ).items():
+        handler_cls = record.cls
+        stream_cat = _infer_stream_category(handler_cls)
+        if stream_cat:
+            _add(handler_cls, stream_cat)
+
+    # Command handlers
+    for _, record in domain.registry._elements.get(
+        DomainObjects.COMMAND_HANDLER.value, {}
+    ).items():
+        handler_cls = record.cls
+        stream_cat = _infer_stream_category(handler_cls)
+        if stream_cat:
+            _add(handler_cls, stream_cat)
+
+    # Projectors (may subscribe to multiple stream categories)
+    for _, record in domain.registry._elements.get(
+        DomainObjects.PROJECTOR.value, {}
+    ).items():
+        handler_cls = record.cls
+        stream_categories = getattr(
+            getattr(handler_cls, "meta_", None), "stream_categories", None
+        )
+        if stream_categories:
+            for stream_cat in stream_categories:
+                _add(handler_cls, stream_cat)
+
+    return infos
+
+
+def collect_dlq_streams(domain: "Domain") -> list[str]:
+    """Return a flat list of all DLQ stream names for the domain."""
+    streams: list[str] = []
+    for info in discover_subscriptions(domain):
+        streams.append(info.dlq_stream)
+        if info.backfill_dlq_stream:
+            streams.append(info.backfill_dlq_stream)
+    # Deduplicate while preserving order
+    return list(dict.fromkeys(streams))

--- a/tests/adapters/broker/inline/test_broker_info.py
+++ b/tests/adapters/broker/inline/test_broker_info.py
@@ -242,7 +242,9 @@ def test_broker_capabilities(broker):
     from protean.port.broker import BrokerCapabilities
 
     capabilities = broker.capabilities
-    assert capabilities == BrokerCapabilities.RELIABLE_MESSAGING
+    assert capabilities == (
+        BrokerCapabilities.RELIABLE_MESSAGING | BrokerCapabilities.DEAD_LETTER_QUEUE
+    )
 
 
 def test_info_tracking_with_operations(broker):

--- a/tests/adapters/broker/inline/test_dlq_management.py
+++ b/tests/adapters/broker/inline/test_dlq_management.py
@@ -1,0 +1,202 @@
+"""Tests for DLQ management API in InlineBroker."""
+
+import time
+
+
+def test_dlq_list_returns_entries_across_streams(broker):
+    """Test dlq_list returns entries from multiple streams."""
+    broker._max_retries = 0
+
+    # Publish to two streams and NACK both
+    id1 = broker.publish("stream1", {"data": "one"})
+    broker.get_next("stream1", "group1")
+    broker.nack("stream1", id1, "group1")
+
+    id2 = broker.publish("stream2", {"data": "two"})
+    broker.get_next("stream2", "group1")
+    broker.nack("stream2", id2, "group1")
+
+    entries = broker.dlq_list(["stream1:dlq", "stream2:dlq"])
+    assert len(entries) == 2
+    streams = {e.stream for e in entries}
+    assert streams == {"stream1", "stream2"}
+
+
+def test_dlq_list_with_limit(broker):
+    """Test dlq_list respects the limit parameter."""
+    broker._max_retries = 0
+
+    for i in range(5):
+        msg_id = broker.publish("stream1", {"i": i})
+        broker.get_next("stream1", "group1")
+        broker.nack("stream1", msg_id, "group1")
+
+    entries = broker.dlq_list(["stream1:dlq"], limit=3)
+    assert len(entries) == 3
+
+
+def test_dlq_list_empty_returns_empty(broker):
+    """Test dlq_list with no messages returns empty list."""
+    entries = broker.dlq_list(["nonexistent:dlq"])
+    assert entries == []
+
+
+def test_dlq_list_filters_by_stream(broker):
+    """Test dlq_list only returns entries for requested streams."""
+    broker._max_retries = 0
+
+    id1 = broker.publish("stream1", {"data": "one"})
+    broker.get_next("stream1", "group1")
+    broker.nack("stream1", id1, "group1")
+
+    id2 = broker.publish("stream2", {"data": "two"})
+    broker.get_next("stream2", "group1")
+    broker.nack("stream2", id2, "group1")
+
+    entries = broker.dlq_list(["stream1:dlq"])
+    assert len(entries) == 1
+    assert entries[0].stream == "stream1"
+
+
+def test_dlq_inspect_found(broker):
+    """Test dlq_inspect returns entry when found."""
+    broker._max_retries = 0
+
+    msg_id = broker.publish("stream1", {"key": "value"})
+    broker.get_next("stream1", "group1")
+    broker.nack("stream1", msg_id, "group1")
+
+    entry = broker.dlq_inspect("stream1:dlq", msg_id)
+    assert entry is not None
+    assert entry.dlq_id == msg_id
+    assert entry.original_id == msg_id
+    assert entry.stream == "stream1"
+    assert entry.consumer_group == "group1"
+    assert entry.payload == {"key": "value"}
+    assert entry.failure_reason == "max_retries_exceeded"
+    assert entry.failed_at is not None
+    assert entry.dlq_stream == "stream1:dlq"
+
+
+def test_dlq_inspect_not_found(broker):
+    """Test dlq_inspect returns None when not found."""
+    entry = broker.dlq_inspect("stream1:dlq", "nonexistent-id")
+    assert entry is None
+
+
+def test_dlq_inspect_wrong_stream(broker):
+    """Test dlq_inspect returns None when searching wrong stream."""
+    broker._max_retries = 0
+
+    msg_id = broker.publish("stream1", {"key": "value"})
+    broker.get_next("stream1", "group1")
+    broker.nack("stream1", msg_id, "group1")
+
+    entry = broker.dlq_inspect("stream2:dlq", msg_id)
+    assert entry is None
+
+
+def test_dlq_replay_success(broker):
+    """Test dlq_replay moves message back to target stream."""
+    broker._max_retries = 0
+
+    msg_id = broker.publish("stream1", {"key": "value"})
+    broker.get_next("stream1", "group1")
+    broker.nack("stream1", msg_id, "group1")
+
+    # Verify in DLQ
+    assert len(broker.dlq_list(["stream1:dlq"])) == 1
+
+    # Replay to target stream
+    result = broker.dlq_replay("stream1:dlq", msg_id, "stream1")
+    assert result is True
+
+    # DLQ should be empty
+    assert len(broker.dlq_list(["stream1:dlq"])) == 0
+
+    # Message should be available on the target stream for new consumers
+    # (It was published as a new message)
+    retrieved = broker.get_next("stream1", "new_consumer")
+    assert retrieved is not None
+    _, msg = retrieved
+    assert msg == {"key": "value"}
+
+
+def test_dlq_replay_not_found(broker):
+    """Test dlq_replay returns False when message doesn't exist."""
+    result = broker.dlq_replay("stream1:dlq", "nonexistent", "stream1")
+    assert result is False
+
+
+def test_dlq_replay_all_drains_stream(broker):
+    """Test dlq_replay_all replays all messages and clears DLQ."""
+    broker._max_retries = 0
+
+    ids = []
+    for i in range(3):
+        msg_id = broker.publish("stream1", {"i": i})
+        broker.get_next("stream1", "group1")
+        broker.nack("stream1", msg_id, "group1")
+        ids.append(msg_id)
+
+    assert len(broker.dlq_list(["stream1:dlq"])) == 3
+
+    count = broker.dlq_replay_all("stream1:dlq", "stream1")
+    assert count == 3
+    assert len(broker.dlq_list(["stream1:dlq"])) == 0
+
+
+def test_dlq_replay_all_empty_stream(broker):
+    """Test dlq_replay_all returns 0 for empty DLQ."""
+    count = broker.dlq_replay_all("nonexistent:dlq", "stream1")
+    assert count == 0
+
+
+def test_dlq_purge_clears_messages(broker):
+    """Test dlq_purge removes all messages from a DLQ stream."""
+    broker._max_retries = 0
+
+    for i in range(4):
+        msg_id = broker.publish("stream1", {"i": i})
+        broker.get_next("stream1", "group1")
+        broker.nack("stream1", msg_id, "group1")
+
+    assert len(broker.dlq_list(["stream1:dlq"])) == 4
+
+    count = broker.dlq_purge("stream1:dlq")
+    assert count == 4
+    assert len(broker.dlq_list(["stream1:dlq"])) == 0
+
+
+def test_dlq_purge_empty_stream(broker):
+    """Test dlq_purge returns 0 for empty DLQ."""
+    count = broker.dlq_purge("nonexistent:dlq")
+    assert count == 0
+
+
+def test_dlq_list_sorted_newest_first(broker):
+    """Test dlq_list returns entries sorted by failed_at descending."""
+    broker._max_retries = 0
+
+    id1 = broker.publish("stream1", {"order": 1})
+    broker.get_next("stream1", "group1")
+    broker.nack("stream1", id1, "group1")
+
+    time.sleep(0.01)  # Small delay to ensure different timestamps
+
+    id2 = broker.publish("stream1", {"order": 2})
+    broker.get_next("stream1", "group1")
+    broker.nack("stream1", id2, "group1")
+
+    entries = broker.dlq_list(["stream1:dlq"])
+    assert len(entries) == 2
+    # Newest first
+    assert entries[0].payload == {"order": 2}
+    assert entries[1].payload == {"order": 1}
+
+
+def test_dlq_capability_flag(broker):
+    """Test that InlineBroker reports DEAD_LETTER_QUEUE capability."""
+    from protean.port.broker import BrokerCapabilities
+
+    assert broker.has_capability(BrokerCapabilities.DEAD_LETTER_QUEUE)

--- a/tests/cli/test_dlq.py
+++ b/tests/cli/test_dlq.py
@@ -1,0 +1,544 @@
+"""Tests for CLI DLQ commands (protean dlq ...)."""
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from protean.cli import app
+from protean.cli.dlq import _format_time
+from protean.exceptions import NoDomainException
+from protean.port.broker import DLQEntry
+from tests.shared import change_working_directory_to
+
+runner = CliRunner()
+
+
+def _make_dlq_entry(
+    dlq_id: str = "abc-123",
+    stream: str = "order",
+    consumer_group: str = "handler.OrderHandler",
+    failure_reason: str = "max_retries_exceeded",
+    retry_count: int = 3,
+) -> DLQEntry:
+    """Create a DLQEntry for testing."""
+    return DLQEntry(
+        dlq_id=dlq_id,
+        original_id=dlq_id,
+        stream=stream,
+        consumer_group=consumer_group,
+        payload={"type": "OrderPlaced", "data": {"order_id": "123"}},
+        failure_reason=failure_reason,
+        failed_at="2026-02-23T10:00:00+00:00",
+        retry_count=retry_count,
+        dlq_stream=f"{stream}:dlq",
+    )
+
+
+def _mock_domain_with_broker(
+    dlq_entries: list[DLQEntry] | None = None,
+    has_dlq: bool = True,
+):
+    """Create a mock domain with a broker that supports DLQ."""
+    mock_domain = MagicMock()
+    mock_broker = MagicMock()
+
+    if has_dlq:
+        mock_broker.has_capability.return_value = True
+    else:
+        mock_broker.has_capability.return_value = False
+
+    mock_broker.dlq_list.return_value = dlq_entries or []
+    mock_broker.dlq_inspect.return_value = dlq_entries[0] if dlq_entries else None
+    mock_broker.dlq_replay.return_value = True
+    mock_broker.dlq_replay_all.return_value = len(dlq_entries) if dlq_entries else 0
+    mock_broker.dlq_purge.return_value = len(dlq_entries) if dlq_entries else 0
+
+    mock_domain.brokers = {"default": mock_broker}
+    mock_domain.config = {"server": {}}
+    mock_domain.registry._elements = {}
+
+    return mock_domain
+
+
+# ---------------------------------------------------------------------------
+# protean dlq list
+# ---------------------------------------------------------------------------
+
+
+class TestDlqList:
+    @pytest.fixture(autouse=True)
+    def reset_path(self):
+        original_path = sys.path[:]
+        cwd = Path.cwd()
+        yield
+        sys.path[:] = original_path
+        os.chdir(cwd)
+
+    def test_list_with_entries(self):
+        change_working_directory_to("test7")
+        entries = [_make_dlq_entry(), _make_dlq_entry(dlq_id="def-456", stream="user")]
+        mock_domain = _mock_domain_with_broker(entries)
+
+        with (
+            patch("protean.cli.dlq.derive_domain", return_value=mock_domain),
+            patch(
+                "protean.cli.dlq.collect_dlq_streams",
+                return_value=["order:dlq", "user:dlq"],
+            ),
+        ):
+            result = runner.invoke(app, ["dlq", "list", "--domain", "publishing7.py"])
+            assert result.exit_code == 0
+            assert "2 DLQ message(s) found" in result.output
+
+    def test_list_empty(self):
+        change_working_directory_to("test7")
+        mock_domain = _mock_domain_with_broker([])
+
+        with (
+            patch("protean.cli.dlq.derive_domain", return_value=mock_domain),
+            patch(
+                "protean.cli.dlq.collect_dlq_streams",
+                return_value=["order:dlq"],
+            ),
+        ):
+            result = runner.invoke(app, ["dlq", "list", "--domain", "publishing7.py"])
+            assert result.exit_code == 0
+            assert "No DLQ messages found" in result.output
+
+    def test_list_no_broker_dlq_support(self):
+        change_working_directory_to("test7")
+        mock_domain = _mock_domain_with_broker(has_dlq=False)
+
+        with patch("protean.cli.dlq.derive_domain", return_value=mock_domain):
+            result = runner.invoke(app, ["dlq", "list", "--domain", "publishing7.py"])
+            assert result.exit_code != 0
+            assert "does not support" in result.output
+
+    def test_list_no_domain_found(self):
+        change_working_directory_to("test7")
+
+        with patch(
+            "protean.cli.dlq.derive_domain",
+            side_effect=NoDomainException("Could not find domain"),
+        ):
+            result = runner.invoke(app, ["dlq", "list", "--domain", "nonexistent.py"])
+            assert result.exit_code != 0
+            assert "Error loading" in result.output
+
+    def test_list_no_broker_configured(self):
+        change_working_directory_to("test7")
+        mock_domain = MagicMock()
+        mock_domain.brokers = {"default": None}
+
+        with patch("protean.cli.dlq.derive_domain", return_value=mock_domain):
+            result = runner.invoke(app, ["dlq", "list", "--domain", "publishing7.py"])
+            assert result.exit_code != 0
+
+    def test_list_no_subscriptions_returns_empty(self):
+        change_working_directory_to("test7")
+        mock_domain = _mock_domain_with_broker([])
+
+        with (
+            patch("protean.cli.dlq.derive_domain", return_value=mock_domain),
+            patch("protean.cli.dlq.collect_dlq_streams", return_value=[]),
+        ):
+            result = runner.invoke(app, ["dlq", "list", "--domain", "publishing7.py"])
+            assert result.exit_code == 0
+            assert "No subscriptions found" in result.output
+
+    def test_list_with_subscription_filter(self):
+        change_working_directory_to("test7")
+        entries = [_make_dlq_entry()]
+        mock_domain = _mock_domain_with_broker(entries)
+
+        with (
+            patch("protean.cli.dlq.derive_domain", return_value=mock_domain),
+            patch(
+                "protean.cli.dlq.discover_subscriptions",
+                return_value=[
+                    MagicMock(
+                        stream_category="order",
+                        dlq_stream="order:dlq",
+                        backfill_dlq_stream="order:backfill:dlq",
+                    )
+                ],
+            ),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "dlq",
+                    "list",
+                    "--subscription",
+                    "order",
+                    "--domain",
+                    "publishing7.py",
+                ],
+            )
+            assert result.exit_code == 0
+
+    def test_list_with_invalid_subscription_filter(self):
+        change_working_directory_to("test7")
+        mock_domain = _mock_domain_with_broker([])
+
+        with (
+            patch("protean.cli.dlq.derive_domain", return_value=mock_domain),
+            patch("protean.cli.dlq.discover_subscriptions", return_value=[]),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "dlq",
+                    "list",
+                    "--subscription",
+                    "nonexistent_sub",
+                    "--domain",
+                    "publishing7.py",
+                ],
+            )
+            assert result.exit_code != 0
+            assert "No subscription found" in result.output
+
+    def test_list_with_long_dlq_id_and_consumer_group(self):
+        """Test that long DLQ IDs and consumer groups are truncated in list output."""
+        change_working_directory_to("test7")
+        entries = [
+            _make_dlq_entry(
+                dlq_id="a-very-long-dlq-id-that-exceeds-sixteen-chars",
+                consumer_group="some.very.long.module.path.to.a.handler.ClassName",
+            )
+        ]
+        mock_domain = _mock_domain_with_broker(entries)
+
+        with (
+            patch("protean.cli.dlq.derive_domain", return_value=mock_domain),
+            patch(
+                "protean.cli.dlq.collect_dlq_streams",
+                return_value=["order:dlq"],
+            ),
+        ):
+            result = runner.invoke(app, ["dlq", "list", "--domain", "publishing7.py"])
+            assert result.exit_code == 0
+            # Rich truncates long text with ellipsis (… or ...)
+            assert "1 DLQ message(s) found" in result.output
+
+
+# ---------------------------------------------------------------------------
+# protean dlq inspect
+# ---------------------------------------------------------------------------
+
+
+class TestDlqInspect:
+    @pytest.fixture(autouse=True)
+    def reset_path(self):
+        original_path = sys.path[:]
+        cwd = Path.cwd()
+        yield
+        sys.path[:] = original_path
+        os.chdir(cwd)
+
+    def test_inspect_found(self):
+        change_working_directory_to("test7")
+        entry = _make_dlq_entry()
+        mock_domain = _mock_domain_with_broker([entry])
+        mock_broker = mock_domain.brokers["default"]
+        mock_broker.dlq_inspect.return_value = entry
+
+        with (
+            patch("protean.cli.dlq.derive_domain", return_value=mock_domain),
+            patch(
+                "protean.cli.dlq.collect_dlq_streams",
+                return_value=["order:dlq"],
+            ),
+        ):
+            result = runner.invoke(
+                app, ["dlq", "inspect", "abc-123", "--domain", "publishing7.py"]
+            )
+            assert result.exit_code == 0
+            assert "abc-123" in result.output
+            assert "order" in result.output
+            assert "max_retries_exceeded" in result.output
+
+    def test_inspect_not_found(self):
+        change_working_directory_to("test7")
+        mock_domain = _mock_domain_with_broker([])
+        mock_broker = mock_domain.brokers["default"]
+        mock_broker.dlq_inspect.return_value = None
+
+        with (
+            patch("protean.cli.dlq.derive_domain", return_value=mock_domain),
+            patch(
+                "protean.cli.dlq.collect_dlq_streams",
+                return_value=["order:dlq"],
+            ),
+        ):
+            result = runner.invoke(
+                app,
+                ["dlq", "inspect", "nonexistent", "--domain", "publishing7.py"],
+            )
+            assert result.exit_code != 0
+            assert "not found" in result.output
+
+
+# ---------------------------------------------------------------------------
+# protean dlq replay
+# ---------------------------------------------------------------------------
+
+
+class TestDlqReplay:
+    @pytest.fixture(autouse=True)
+    def reset_path(self):
+        original_path = sys.path[:]
+        cwd = Path.cwd()
+        yield
+        sys.path[:] = original_path
+        os.chdir(cwd)
+
+    def test_replay_success(self):
+        change_working_directory_to("test7")
+        entry = _make_dlq_entry()
+        mock_domain = _mock_domain_with_broker([entry])
+        mock_broker = mock_domain.brokers["default"]
+        mock_broker.dlq_inspect.return_value = entry
+        mock_broker.dlq_replay.return_value = True
+
+        with (
+            patch("protean.cli.dlq.derive_domain", return_value=mock_domain),
+            patch(
+                "protean.cli.dlq.collect_dlq_streams",
+                return_value=["order:dlq"],
+            ),
+        ):
+            result = runner.invoke(
+                app, ["dlq", "replay", "abc-123", "--domain", "publishing7.py"]
+            )
+            assert result.exit_code == 0
+            assert "Replayed" in result.output
+
+    def test_replay_not_found(self):
+        change_working_directory_to("test7")
+        mock_domain = _mock_domain_with_broker([])
+        mock_broker = mock_domain.brokers["default"]
+        mock_broker.dlq_inspect.return_value = None
+
+        with (
+            patch("protean.cli.dlq.derive_domain", return_value=mock_domain),
+            patch(
+                "protean.cli.dlq.collect_dlq_streams",
+                return_value=["order:dlq"],
+            ),
+        ):
+            result = runner.invoke(
+                app,
+                ["dlq", "replay", "nonexistent", "--domain", "publishing7.py"],
+            )
+            assert result.exit_code != 0
+            assert "not found" in result.output
+
+    def test_replay_failure(self):
+        change_working_directory_to("test7")
+        entry = _make_dlq_entry()
+        mock_domain = _mock_domain_with_broker([entry])
+        mock_broker = mock_domain.brokers["default"]
+        mock_broker.dlq_inspect.return_value = entry
+        mock_broker.dlq_replay.return_value = False
+
+        with (
+            patch("protean.cli.dlq.derive_domain", return_value=mock_domain),
+            patch(
+                "protean.cli.dlq.collect_dlq_streams",
+                return_value=["order:dlq"],
+            ),
+        ):
+            result = runner.invoke(
+                app, ["dlq", "replay", "abc-123", "--domain", "publishing7.py"]
+            )
+            assert result.exit_code == 0
+            assert "Failed to replay" in result.output
+
+
+# ---------------------------------------------------------------------------
+# protean dlq replay-all
+# ---------------------------------------------------------------------------
+
+
+class TestDlqReplayAll:
+    @pytest.fixture(autouse=True)
+    def reset_path(self):
+        original_path = sys.path[:]
+        cwd = Path.cwd()
+        yield
+        sys.path[:] = original_path
+        os.chdir(cwd)
+
+    def test_replay_all_success(self):
+        change_working_directory_to("test7")
+        entries = [_make_dlq_entry(), _make_dlq_entry(dlq_id="def-456")]
+        mock_domain = _mock_domain_with_broker(entries)
+
+        with (
+            patch("protean.cli.dlq.derive_domain", return_value=mock_domain),
+            patch(
+                "protean.cli.dlq.discover_subscriptions",
+                return_value=[
+                    MagicMock(
+                        stream_category="order",
+                        dlq_stream="order:dlq",
+                        backfill_dlq_stream=None,
+                    )
+                ],
+            ),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "dlq",
+                    "replay-all",
+                    "--subscription",
+                    "order",
+                    "--yes",
+                    "--domain",
+                    "publishing7.py",
+                ],
+            )
+            assert result.exit_code == 0
+            assert "Replayed" in result.output
+
+
+# ---------------------------------------------------------------------------
+# protean dlq purge
+# ---------------------------------------------------------------------------
+
+
+class TestDlqPurge:
+    @pytest.fixture(autouse=True)
+    def reset_path(self):
+        original_path = sys.path[:]
+        cwd = Path.cwd()
+        yield
+        sys.path[:] = original_path
+        os.chdir(cwd)
+
+    def test_purge_success(self):
+        change_working_directory_to("test7")
+        entries = [_make_dlq_entry()]
+        mock_domain = _mock_domain_with_broker(entries)
+
+        with (
+            patch("protean.cli.dlq.derive_domain", return_value=mock_domain),
+            patch(
+                "protean.cli.dlq.discover_subscriptions",
+                return_value=[
+                    MagicMock(
+                        stream_category="order",
+                        dlq_stream="order:dlq",
+                        backfill_dlq_stream=None,
+                    )
+                ],
+            ),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "dlq",
+                    "purge",
+                    "--subscription",
+                    "order",
+                    "--yes",
+                    "--domain",
+                    "publishing7.py",
+                ],
+            )
+            assert result.exit_code == 0
+            assert "Purged" in result.output
+
+    def test_purge_with_confirmation_prompt(self):
+        change_working_directory_to("test7")
+        entries = [_make_dlq_entry()]
+        mock_domain = _mock_domain_with_broker(entries)
+
+        with (
+            patch("protean.cli.dlq.derive_domain", return_value=mock_domain),
+            patch(
+                "protean.cli.dlq.discover_subscriptions",
+                return_value=[
+                    MagicMock(
+                        stream_category="order",
+                        dlq_stream="order:dlq",
+                        backfill_dlq_stream=None,
+                    )
+                ],
+            ),
+        ):
+            # Answer "y" to confirmation
+            result = runner.invoke(
+                app,
+                [
+                    "dlq",
+                    "purge",
+                    "--subscription",
+                    "order",
+                    "--domain",
+                    "publishing7.py",
+                ],
+                input="y\n",
+            )
+            assert result.exit_code == 0
+            assert "Purged" in result.output
+
+    def test_replay_all_with_confirmation_prompt(self):
+        change_working_directory_to("test7")
+        entries = [_make_dlq_entry()]
+        mock_domain = _mock_domain_with_broker(entries)
+
+        with (
+            patch("protean.cli.dlq.derive_domain", return_value=mock_domain),
+            patch(
+                "protean.cli.dlq.discover_subscriptions",
+                return_value=[
+                    MagicMock(
+                        stream_category="order",
+                        dlq_stream="order:dlq",
+                        backfill_dlq_stream=None,
+                    )
+                ],
+            ),
+        ):
+            # Answer "y" to confirmation
+            result = runner.invoke(
+                app,
+                [
+                    "dlq",
+                    "replay-all",
+                    "--subscription",
+                    "order",
+                    "--domain",
+                    "publishing7.py",
+                ],
+                input="y\n",
+            )
+            assert result.exit_code == 0
+            assert "Replayed" in result.output
+
+
+# ---------------------------------------------------------------------------
+# _format_time helper
+# ---------------------------------------------------------------------------
+
+
+class TestFormatTime:
+    def test_format_valid_iso_timestamp(self):
+        assert _format_time("2026-02-23T10:00:00+00:00") == "2026-02-23 10:00:00"
+
+    def test_format_none_returns_dash(self):
+        assert _format_time(None) == "-"
+
+    def test_format_empty_string_returns_dash(self):
+        assert _format_time("") == "-"
+
+    def test_format_invalid_timestamp_returns_raw(self):
+        assert _format_time("not-a-timestamp") == "not-a-timestamp"

--- a/tests/utils/test_dlq_discovery.py
+++ b/tests/utils/test_dlq_discovery.py
@@ -1,0 +1,273 @@
+"""Tests for DLQ discovery utility."""
+
+import pytest
+
+from protean import Domain
+from protean.utils.dlq import (
+    _infer_stream_category,
+    collect_dlq_streams,
+    discover_subscriptions,
+)
+
+
+@pytest.mark.no_test_domain
+class TestDiscoverSubscriptions:
+    def test_discover_subscriptions_with_event_handlers(self):
+        domain = Domain(__file__, "TestDLQ")
+
+        @domain.aggregate
+        class Order:
+            name: str
+
+        @domain.event(part_of=Order)
+        class OrderPlaced:
+            order_id: str
+
+        @domain.event_handler(part_of=Order)
+        class OrderEventHandler:
+            pass
+
+        domain.init()
+
+        infos = discover_subscriptions(domain)
+        assert len(infos) >= 1
+
+        order_info = next(
+            (i for i in infos if "OrderEventHandler" in i.handler_name), None
+        )
+        assert order_info is not None
+        assert order_info.dlq_stream.endswith(":dlq")
+        assert order_info.backfill_dlq_stream is None  # No priority lanes by default
+
+    def test_discover_subscriptions_empty_domain(self):
+        domain = Domain(__file__, "EmptyDLQ")
+        domain.init()
+
+        infos = discover_subscriptions(domain)
+        assert infos == []
+
+    def test_collect_dlq_streams(self):
+        domain = Domain(__file__, "TestCollect")
+
+        @domain.aggregate
+        class User:
+            name: str
+
+        @domain.event(part_of=User)
+        class UserRegistered:
+            user_id: str
+
+        @domain.event_handler(part_of=User)
+        class UserHandler:
+            pass
+
+        domain.init()
+
+        streams = collect_dlq_streams(domain)
+        assert len(streams) >= 1
+        assert all(s.endswith(":dlq") for s in streams)
+
+    def test_collect_dlq_streams_deduplicates(self):
+        domain = Domain(__file__, "TestDedup")
+
+        @domain.aggregate
+        class Account:
+            name: str
+
+        @domain.event(part_of=Account)
+        class AccountCreated:
+            account_id: str
+
+        @domain.event_handler(part_of=Account)
+        class AccountHandler1:
+            pass
+
+        @domain.event_handler(part_of=Account)
+        class AccountHandler2:
+            pass
+
+        domain.init()
+
+        streams = collect_dlq_streams(domain)
+        # Even with two handlers for the same stream, DLQ stream names are deduplicated
+        dlq_stream_count = sum(1 for s in streams if "account" in s.lower())
+        assert dlq_stream_count >= 1
+
+    def test_discover_subscriptions_with_command_handlers(self):
+        domain = Domain(__file__, "TestCmdHandler")
+
+        @domain.aggregate
+        class Invoice:
+            amount: float
+
+        @domain.command(part_of=Invoice)
+        class CreateInvoice:
+            amount: float
+
+        @domain.command_handler(part_of=Invoice)
+        class InvoiceCommandHandler:
+            pass
+
+        domain.init()
+
+        infos = discover_subscriptions(domain)
+        cmd_info = next(
+            (i for i in infos if "InvoiceCommandHandler" in i.handler_name), None
+        )
+        assert cmd_info is not None
+        assert "invoice" in cmd_info.stream_category
+        assert cmd_info.dlq_stream.endswith(":dlq")
+
+    def test_discover_subscriptions_with_projectors(self):
+        from protean.fields import Identifier, String
+
+        domain = Domain(__file__, "TestProjector")
+
+        @domain.aggregate
+        class Product:
+            name: str
+
+        @domain.event(part_of=Product)
+        class ProductCreated:
+            name: str
+
+        @domain.projection
+        class ProductListing:
+            product_id: Identifier(identifier=True)
+            name: String()
+
+        @domain.projector(projector_for=ProductListing, aggregates=[Product])
+        class ProductProjector:
+            pass
+
+        domain.init()
+
+        infos = discover_subscriptions(domain)
+        proj_info = next(
+            (i for i in infos if "ProductProjector" in i.handler_name), None
+        )
+        assert proj_info is not None
+        assert proj_info.dlq_stream.endswith(":dlq")
+        assert "product" in proj_info.stream_category
+
+    def test_discover_subscriptions_with_priority_lanes(self):
+        domain = Domain(__file__, "TestLanes")
+        domain.config["server"] = {
+            "priority_lanes": {
+                "enabled": True,
+                "backfill_suffix": "backfill",
+            }
+        }
+
+        @domain.aggregate
+        class Shipment:
+            tracking: str
+
+        @domain.event(part_of=Shipment)
+        class ShipmentCreated:
+            tracking: str
+
+        @domain.event_handler(part_of=Shipment)
+        class ShipmentHandler:
+            pass
+
+        domain.init()
+
+        infos = discover_subscriptions(domain)
+        ship_info = next(
+            (i for i in infos if "ShipmentHandler" in i.handler_name), None
+        )
+        assert ship_info is not None
+        assert ship_info.dlq_stream.endswith(":dlq")
+        assert ship_info.backfill_dlq_stream is not None
+        assert ship_info.backfill_dlq_stream.endswith(":backfill:dlq")
+
+    def test_collect_dlq_streams_includes_backfill_when_lanes_enabled(self):
+        domain = Domain(__file__, "TestLanesCollect")
+        domain.config["server"] = {
+            "priority_lanes": {
+                "enabled": True,
+                "backfill_suffix": "backfill",
+            }
+        }
+
+        @domain.aggregate
+        class Ticket:
+            title: str
+
+        @domain.event(part_of=Ticket)
+        class TicketOpened:
+            title: str
+
+        @domain.event_handler(part_of=Ticket)
+        class TicketHandler:
+            pass
+
+        domain.init()
+
+        streams = collect_dlq_streams(domain)
+        # Should have both primary DLQ and backfill DLQ
+        assert len(streams) == 2
+        assert any(s.endswith(":backfill:dlq") for s in streams)
+        # Primary DLQ stream ends with :dlq but not :backfill:dlq
+        primary = [s for s in streams if not s.endswith(":backfill:dlq")]
+        assert len(primary) == 1
+        assert primary[0].endswith(":dlq")
+
+    def test_infer_stream_category_no_meta(self):
+        class NoMeta:
+            pass
+
+        assert _infer_stream_category(NoMeta) is None
+
+    def test_infer_stream_category_with_explicit_stream(self):
+        domain = Domain(__file__, "TestInfer")
+
+        @domain.aggregate
+        class Cart:
+            item: str
+
+        @domain.event(part_of=Cart)
+        class CartUpdated:
+            item: str
+
+        @domain.event_handler(part_of=Cart, stream_category="all_carts")
+        class CartHandler:
+            pass
+
+        domain.init()
+
+        assert _infer_stream_category(CartHandler) == "all_carts"
+
+    def test_infer_stream_category_via_part_of(self):
+        domain = Domain(__file__, "TestInferPartOf")
+
+        @domain.aggregate
+        class Warehouse:
+            location: str
+
+        @domain.event(part_of=Warehouse)
+        class WarehouseCreated:
+            location: str
+
+        @domain.event_handler(part_of=Warehouse)
+        class WarehouseHandler:
+            pass
+
+        domain.init()
+
+        stream_cat = _infer_stream_category(WarehouseHandler)
+        assert stream_cat is not None
+        assert "warehouse" in stream_cat
+
+    def test_infer_stream_category_no_part_of(self):
+        """Test _infer_stream_category with meta but no part_of or stream_category."""
+
+        class FakeMeta:
+            stream_category = None
+            part_of = None
+
+        class FakeHandler:
+            meta_ = FakeMeta()
+
+        assert _infer_stream_category(FakeHandler) is None


### PR DESCRIPTION
Add dead letter queue management for inspecting, replaying, and purging failed messages

Messages that fail processing in the async engine end up in Dead Letter Queues but there was no way to inspect, replay, or manage them. This adds a broker-agnostic DLQ management API, CLI commands, and Observatory dashboard integration.

Port/Adapter layer:
- Add DLQEntry dataclass to port/broker.py for normalized DLQ messages
- Add 5 capability-gated public methods to BaseBroker: dlq_list, dlq_inspect, dlq_replay, dlq_replay_all, dlq_purge
- Implement _dlq_* methods in InlineBroker (in-memory DLQ iteration)
- Implement _dlq_* methods in RedisBroker (XRANGE/XDEL/XADD)
- Add no-op _dlq_* stubs to RedisPubSubBroker (no DLQ capability)
- Update InlineBroker and RedisBroker capabilities to include DEAD_LETTER_QUEUE flag

DLQ discovery utility (src/protean/utils/dlq.py):
- SubscriptionInfo dataclass mapping handlers to DLQ stream names
- discover_subscriptions() walks domain registry for event handlers, command handlers, and projectors to derive stream categories
- collect_dlq_streams() returns deduplicated list of all DLQ streams
- Supports priority lanes (backfill DLQ streams)

CLI commands (src/protean/cli/dlq.py):
- protean dlq list — list failed messages across all DLQ streams
- protean dlq inspect <id> — show full details of a DLQ message
- protean dlq replay <id> — replay a single message to its stream
- protean dlq replay-all --subscription <name> — replay all for a sub
- protean dlq purge --subscription <name> — clear a subscription's DLQ
- Destructive commands require --yes or interactive confirmation

Observatory integration:
- REST API endpoints: GET/POST/DELETE /api/dlq/*
- Dashboard DLQ tab with list, inspect, replay, purge UI
- Subscription filter dropdown and bulk action buttons
- Auto-refresh polling at 5-second intervals