### PR TITLE
Add domain.query_for() and ReadOnlyQuerySet for CQRS read-side projection queries

### DIFF
--- a/docs/concepts/building-blocks/projections.md
+++ b/docs/concepts/building-blocks/projections.md
@@ -55,6 +55,13 @@ business-rule enforcement, while the read side can be denormalized and
 optimized for query performance. Changes to one do not force changes on the
 other.
 
+### Projections have a dedicated read-only query API. { data-toc-label="Query API" }
+
+Use `domain.query_for(ProjectionClass)` to query projections. This returns a
+`ReadOnlyQuerySet` that supports filtering, ordering, and pagination but
+structurally prevents mutation. This enforces the CQRS contract at the API
+level — reads cannot accidentally write.
+
 ### Projections can aggregate data across aggregates. { data-toc-label="Cross-Aggregate Views" }
 
 A single projection can combine data from multiple aggregate streams. For

--- a/docs/concepts/internals/query-system.md
+++ b/docs/concepts/internals/query-system.md
@@ -329,6 +329,38 @@ aggregates, adds them to the active Unit of Work's identity map.
 
 ---
 
+## ReadOnlyQuerySet
+
+`ReadOnlyQuerySet` is a `QuerySet` subclass that blocks mutation methods.
+It is returned by `domain.query_for()` to enforce CQRS read-only access
+on projections.
+
+**Blocked methods:** `update()`, `delete()`, `update_all()`, `delete_all()`.
+All raise `NotSupportedError`.
+
+**Read methods work identically:** `filter()`, `exclude()`, `order_by()`,
+`limit()`, `offset()`, `all()`, `raw()`, and all properties.
+
+The clone-on-write pattern preserves the type — chaining `.filter()` on a
+`ReadOnlyQuerySet` returns another `ReadOnlyQuerySet`, because `_clone()`
+uses `self.__class__()`.
+
+```python
+# domain.query_for() returns a ReadOnlyQuerySet
+qs = domain.query_for(OrderSummary)
+
+# All read operations work
+results = qs.filter(status="shipped").order_by("-placed_at").limit(20).all()
+
+# Mutation attempts raise NotSupportedError
+qs.update(status="cancelled")      # raises NotSupportedError
+qs.delete()                        # raises NotSupportedError
+```
+
+**Key source file:** `src/protean/core/queryset.py`
+
+---
+
 ## Entity state tracking
 
 When entities flow through the repository/DAO layer, their `state_` property

--- a/docs/guides/change-state/retrieve-aggregates.md
+++ b/docs/guides/change-state/retrieve-aggregates.md
@@ -114,6 +114,11 @@ def email_taken(self, person_id: str, email: str) -> bool:
 
 ## QuerySet
 
+!!! tip "Querying projections?"
+    For projection queries, use `domain.query_for(ProjectionClass)` instead.
+    It returns a `ReadOnlyQuerySet` that enforces CQRS read-only access.
+    See [Querying Projections](../consume-state/projections.md#querying-projections).
+
 A QuerySet represents a collection of objects from your database that can be
 filtered, ordered, and paginated. You access a QuerySet through the DAO's
 `.query` property:

--- a/docs/guides/consume-state/projections.md
+++ b/docs/guides/consume-state/projections.md
@@ -84,22 +84,48 @@ class ProductInventory:
 
 ### Querying Projections
 
-Projections are optimized for querying. You can use the repository pattern to query projections:
+Projections are optimized for querying. Use `domain.query_for()` to get a
+read-only query interface for any projection:
 
 ```python
-# Get a single projection record by ID
-inventory = repository.get(ProductInventory, id=1)
+# Filter and retrieve projections
+results = domain.query_for(ProductInventory).filter(
+    stock_quantity__lt=10
+).order_by("name").all()
 
-# Query projection with filters
-low_stock_items = repository._dao.filter(
-    ProductInventory, 
-    quantity__lt=10,
-    limit=20
-)
+for item in results:
+    print(f"{item.name}: {item.stock_quantity} remaining")
 ```
 
-<!-- FIXME Add note that one can use anything to query projections, and that
-repositories are essentially write-side artifacts. -->
+The returned `ReadOnlyQuerySet` supports all read operations — `filter()`,
+`exclude()`, `order_by()`, `limit()`, `offset()`, and `all()` — but blocks
+mutations (`update`, `delete`) to enforce CQRS read/write separation.
+
+```python
+# Pagination
+page = domain.query_for(ProductInventory).order_by("name").limit(20).offset(40).all()
+page.total       # Total matching records across all pages
+page.has_next    # True if more pages exist
+page.has_prev    # True if previous pages exist
+
+# Single result
+first_item = domain.query_for(ProductInventory).filter(
+    product_id="abc-123"
+).first
+```
+
+For write operations (used inside projectors), continue using
+`domain.repository_for()`:
+
+```python
+repo = domain.repository_for(ProductInventory)
+repo.add(inventory_record)
+```
+
+!!! note
+    `domain.query_for()` is specifically for projections. To query aggregates,
+    use [repositories](../change-state/retrieve-aggregates.md) with custom
+    query methods.
 
 ---
 

--- a/src/protean/__init__.py
+++ b/src/protean/__init__.py
@@ -3,7 +3,7 @@ __version__ = "0.14.2"
 from .core.aggregate import apply, atomic_change
 from .core.application_service import use_case
 from .core.entity import invariant
-from .core.queryset import Q, QuerySet
+from .core.queryset import Q, QuerySet, ReadOnlyQuerySet
 from .core.unit_of_work import UnitOfWork
 from .domain import Domain
 from .server import Engine
@@ -28,6 +28,7 @@ __all__ = [
     "processing_priority",
     "Q",
     "QuerySet",
+    "ReadOnlyQuerySet",
     "UnitOfWork",
     "use_case",
 ]

--- a/src/protean/core/queryset.py
+++ b/src/protean/core/queryset.py
@@ -4,6 +4,7 @@ import copy
 import logging
 from typing import TYPE_CHECKING, Any, Union
 
+from protean.exceptions import NotSupportedError
 from protean.utils import DomainObjects
 from protean.utils.globals import current_uow
 from protean.utils.query import Q
@@ -467,6 +468,40 @@ class QuerySet:
     def has_prev(self):
         """Return True if there are previous values present"""
         return self._data.has_prev
+
+
+class ReadOnlyQuerySet(QuerySet):
+    """A QuerySet that blocks all mutation operations.
+
+    Used by ``domain.query_for()`` to enforce CQRS read-only access
+    on projections. All read operations (filter, exclude, order_by,
+    limit, offset, all, raw) work unchanged. Mutation methods raise
+    ``NotSupportedError``.
+    """
+
+    def update(self, *data: Any, **kwargs: Any) -> int:
+        raise NotSupportedError(
+            "Updates are not allowed on a read-only query. "
+            "Use domain.repository_for() if you need to mutate projections."
+        )
+
+    def delete(self) -> int:
+        raise NotSupportedError(
+            "Deletes are not allowed on a read-only query. "
+            "Use domain.repository_for() if you need to mutate projections."
+        )
+
+    def update_all(self, *args: Any, **kwargs: Any) -> int:
+        raise NotSupportedError(
+            "Bulk updates are not allowed on a read-only query. "
+            "Use domain.repository_for() if you need to mutate projections."
+        )
+
+    def delete_all(self, *args: Any, **kwargs: Any) -> int:
+        raise NotSupportedError(
+            "Bulk deletes are not allowed on a read-only query. "
+            "Use domain.repository_for() if you need to mutate projections."
+        )
 
 
 class ResultSet(object):

--- a/src/protean/domain/__init__.py
+++ b/src/protean/domain/__init__.py
@@ -25,6 +25,7 @@ from typing import (
 )
 
 if TYPE_CHECKING:
+    from protean.core.queryset import ReadOnlyQuerySet
     from protean.utils.projection_rebuilder import RebuildResult
 from uuid import uuid4
 
@@ -1983,6 +1984,53 @@ class Domain:
         else:
             # This is a regular aggregate or a projection
             return self.providers.repository_for(element_cls)
+
+    def query_for(self, projection_cls: type) -> "ReadOnlyQuerySet":
+        """Return a read-only QuerySet for querying a projection.
+
+        This is the public entry point for projection reads. The returned
+        ``ReadOnlyQuerySet`` supports ``filter()``, ``exclude()``,
+        ``order_by()``, ``limit()``, ``offset()``, and ``all()`` but
+        blocks all mutation operations (``update``, ``delete``,
+        ``update_all``, ``delete_all``).
+
+        Args:
+            projection_cls: A registered projection class.
+
+        Returns:
+            A ``ReadOnlyQuerySet`` bound to the projection's data store.
+
+        Raises:
+            IncorrectUsageError: If the element is not a projection.
+
+        Example::
+
+            results = domain.query_for(OrderSummary).filter(
+                status="shipped"
+            ).order_by("-placed_at").all()
+        """
+        from protean.core.queryset import ReadOnlyQuerySet
+
+        if isinstance(projection_cls, str):
+            raise IncorrectUsageError(
+                f"Element {projection_cls} is not registered in domain {self.name}"
+            )
+
+        if projection_cls.element_type != DomainObjects.PROJECTION:
+            raise IncorrectUsageError(
+                f"`query_for` is only available for projections. "
+                f"Received {projection_cls.__name__} "
+                f"({projection_cls.element_type})."
+            )
+
+        repo = self.providers.repository_for(projection_cls)
+        dao = repo._dao
+
+        return ReadOnlyQuerySet(
+            dao,
+            self,
+            projection_cls,
+        )
 
     #######################
     # Cache Functionality #

--- a/tests/projections/test_query_for.py
+++ b/tests/projections/test_query_for.py
@@ -1,0 +1,275 @@
+"""Tests for domain.query_for() and ReadOnlyQuerySet.
+
+Validates:
+- ReadOnlyQuerySet blocks all mutation operations with NotSupportedError
+- ReadOnlyQuerySet preserves all read operations (filter, exclude, order_by, etc.)
+- Chained operations on ReadOnlyQuerySet preserve the type
+- domain.query_for() returns ReadOnlyQuerySet for projections
+- domain.query_for() rejects non-projection types
+- Filtering, ordering, pagination work through the new API
+- Backward compatibility: domain.repository_for(Projection) still works
+"""
+
+import pytest
+from pydantic import Field
+
+from protean.core.aggregate import BaseAggregate
+from protean.core.projection import BaseProjection
+from protean.core.queryset import ReadOnlyQuerySet
+from protean.exceptions import IncorrectUsageError, NotSupportedError
+
+
+# ---------------------------------------------------------------------------
+# Test domain elements
+# ---------------------------------------------------------------------------
+class PersonProjection(BaseProjection):
+    person_id: str = Field(json_schema_extra={"identifier": True})
+    first_name: str
+    last_name: str | None = None
+    age: int = 21
+
+
+class Person(BaseAggregate):
+    first_name: str
+    last_name: str | None = None
+    age: int = 21
+
+
+@pytest.fixture(autouse=True)
+def register_elements(test_domain):
+    test_domain.register(PersonProjection)
+    test_domain.register(Person)
+    test_domain.init(traverse=False)
+
+
+# ---------------------------------------------------------------------------
+# Helper: seed projection data
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def seeded_projections(test_domain):
+    repo = test_domain.repository_for(PersonProjection)
+    repo.add(
+        PersonProjection(person_id="1", first_name="John", last_name="Doe", age=38)
+    )
+    repo.add(
+        PersonProjection(person_id="2", first_name="Jane", last_name="Doe", age=36)
+    )
+    repo.add(
+        PersonProjection(person_id="3", first_name="Bob", last_name="Smith", age=25)
+    )
+    repo.add(PersonProjection(person_id="4", first_name="Baby", last_name="Doe", age=3))
+
+
+# ---------------------------------------------------------------------------
+# Tests: ReadOnlyQuerySet — mutation blocking
+# ---------------------------------------------------------------------------
+@pytest.mark.database
+@pytest.mark.usefixtures("db")
+class TestReadOnlyQuerySetMutationBlocking:
+    def test_update_raises_not_supported(self, test_domain):
+        qs = test_domain.query_for(PersonProjection)
+
+        with pytest.raises(NotSupportedError, match="Updates are not allowed"):
+            qs.update(first_name="X")
+
+    def test_delete_raises_not_supported(self, test_domain):
+        qs = test_domain.query_for(PersonProjection)
+
+        with pytest.raises(NotSupportedError, match="Deletes are not allowed"):
+            qs.delete()
+
+    def test_update_all_raises_not_supported(self, test_domain):
+        qs = test_domain.query_for(PersonProjection)
+
+        with pytest.raises(NotSupportedError, match="Bulk updates are not allowed"):
+            qs.update_all(first_name="X")
+
+    def test_delete_all_raises_not_supported(self, test_domain):
+        qs = test_domain.query_for(PersonProjection)
+
+        with pytest.raises(NotSupportedError, match="Bulk deletes are not allowed"):
+            qs.delete_all()
+
+    def test_error_messages_guide_user(self, test_domain):
+        qs = test_domain.query_for(PersonProjection)
+
+        with pytest.raises(NotSupportedError, match="domain.repository_for"):
+            qs.update(first_name="X")
+
+        with pytest.raises(NotSupportedError, match="domain.repository_for"):
+            qs.delete()
+
+        with pytest.raises(NotSupportedError, match="domain.repository_for"):
+            qs.update_all(first_name="X")
+
+        with pytest.raises(NotSupportedError, match="domain.repository_for"):
+            qs.delete_all()
+
+
+# ---------------------------------------------------------------------------
+# Tests: ReadOnlyQuerySet — type preservation through chaining
+# ---------------------------------------------------------------------------
+@pytest.mark.database
+@pytest.mark.usefixtures("db")
+class TestReadOnlyQuerySetChaining:
+    def test_filter_returns_read_only_queryset(self, test_domain):
+        qs = test_domain.query_for(PersonProjection).filter(last_name="Doe")
+        assert isinstance(qs, ReadOnlyQuerySet)
+
+    def test_exclude_returns_read_only_queryset(self, test_domain):
+        qs = test_domain.query_for(PersonProjection).exclude(last_name="Doe")
+        assert isinstance(qs, ReadOnlyQuerySet)
+
+    def test_order_by_returns_read_only_queryset(self, test_domain):
+        qs = test_domain.query_for(PersonProjection).order_by("age")
+        assert isinstance(qs, ReadOnlyQuerySet)
+
+    def test_limit_returns_read_only_queryset(self, test_domain):
+        qs = test_domain.query_for(PersonProjection).limit(10)
+        assert isinstance(qs, ReadOnlyQuerySet)
+
+    def test_offset_returns_read_only_queryset(self, test_domain):
+        qs = test_domain.query_for(PersonProjection).offset(5)
+        assert isinstance(qs, ReadOnlyQuerySet)
+
+    def test_deeply_chained_remains_read_only(self, test_domain):
+        qs = (
+            test_domain.query_for(PersonProjection)
+            .filter(last_name="Doe")
+            .exclude(age=3)
+            .order_by("-age")
+            .limit(10)
+            .offset(0)
+        )
+        assert isinstance(qs, ReadOnlyQuerySet)
+
+    def test_chained_mutation_still_blocked(self, test_domain):
+        qs = test_domain.query_for(PersonProjection).filter(last_name="Doe")
+
+        with pytest.raises(NotSupportedError):
+            qs.update(first_name="X")
+
+        with pytest.raises(NotSupportedError):
+            qs.delete()
+
+
+# ---------------------------------------------------------------------------
+# Tests: domain.query_for() — entry point
+# ---------------------------------------------------------------------------
+@pytest.mark.database
+@pytest.mark.usefixtures("db")
+class TestQueryFor:
+    def test_returns_read_only_queryset(self, test_domain):
+        qs = test_domain.query_for(PersonProjection)
+        assert isinstance(qs, ReadOnlyQuerySet)
+
+    def test_rejects_aggregate_class(self, test_domain):
+        with pytest.raises(IncorrectUsageError, match="only available for projections"):
+            test_domain.query_for(Person)
+
+    def test_rejects_string_argument(self, test_domain):
+        with pytest.raises(IncorrectUsageError, match="not registered"):
+            test_domain.query_for("PersonProjection")
+
+    def test_filter_and_all(self, test_domain, seeded_projections):
+        results = test_domain.query_for(PersonProjection).filter(last_name="Doe").all()
+
+        assert results.total == 3
+        names = {item.first_name for item in results}
+        assert names == {"John", "Jane", "Baby"}
+
+    def test_exclude(self, test_domain, seeded_projections):
+        results = test_domain.query_for(PersonProjection).exclude(last_name="Doe").all()
+
+        assert results.total == 1
+        assert results.first.first_name == "Bob"
+
+    def test_order_by(self, test_domain, seeded_projections):
+        results = test_domain.query_for(PersonProjection).order_by("age").all()
+
+        ages = [item.age for item in results]
+        assert ages == [3, 25, 36, 38]
+
+    def test_order_by_descending(self, test_domain, seeded_projections):
+        results = test_domain.query_for(PersonProjection).order_by("-age").all()
+
+        ages = [item.age for item in results]
+        assert ages == [38, 36, 25, 3]
+
+    def test_limit_and_offset(self, test_domain, seeded_projections):
+        results = (
+            test_domain.query_for(PersonProjection)
+            .order_by("age")
+            .limit(2)
+            .offset(1)
+            .all()
+        )
+
+        assert len(results.items) == 2
+        ages = [item.age for item in results]
+        assert ages == [25, 36]
+
+    def test_result_set_properties(self, test_domain, seeded_projections):
+        results = test_domain.query_for(PersonProjection).order_by("age").limit(2).all()
+
+        assert results.total == 4
+        assert len(results.items) == 2
+        assert results.first.age == 3
+        assert results.last.age == 25
+        assert results.has_next is True
+        assert results.has_prev is False
+
+    def test_iteration(self, test_domain, seeded_projections):
+        names = []
+        for item in test_domain.query_for(PersonProjection).filter(last_name="Doe"):
+            names.append(item.first_name)
+
+        assert len(names) == 3
+        assert set(names) == {"John", "Jane", "Baby"}
+
+    def test_empty_result(self, test_domain):
+        results = (
+            test_domain.query_for(PersonProjection)
+            .filter(last_name="Nonexistent")
+            .all()
+        )
+
+        assert results.total == 0
+        assert results.items == []
+        assert results.first is None
+        assert results.last is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: Backward compatibility
+# ---------------------------------------------------------------------------
+@pytest.mark.database
+@pytest.mark.usefixtures("db")
+class TestBackwardCompatibility:
+    def test_repository_for_still_works(self, test_domain):
+        """domain.repository_for(Projection) continues to work unchanged."""
+        repo = test_domain.repository_for(PersonProjection)
+        person = PersonProjection(person_id="1", first_name="John", last_name="Doe")
+        repo.add(person)
+
+        refreshed = repo.get("1")
+        assert refreshed.first_name == "John"
+
+    def test_repository_for_allows_mutations(self, test_domain):
+        """Mutations through repository_for() are not affected."""
+        repo = test_domain.repository_for(PersonProjection)
+        repo.add(PersonProjection(person_id="1", first_name="John", last_name="Doe"))
+        repo.add(PersonProjection(person_id="2", first_name="Jane", last_name="Doe"))
+
+        # Mutation through DAO still works
+        count = repo._dao.query.filter(last_name="Doe").delete()
+        assert count == 2
+
+    def test_query_for_and_repository_for_see_same_data(
+        self, test_domain, seeded_projections
+    ):
+        """query_for() and repository_for() query the same backing store."""
+        query_results = test_domain.query_for(PersonProjection).all()
+        repo_results = test_domain.repository_for(PersonProjection)._dao.query.all()
+
+        assert query_results.total == repo_results.total


### PR DESCRIPTION
Projections had no public query API — users had to reach through `repo._dao.query` (a semi-private API) and nothing prevented accidental mutations through the query interface. This adds a clean, read-only entry point that enforces CQRS separation at the API level.

- Add `ReadOnlyQuerySet` subclass in `queryset.py` that overrides `update()`, `delete()`, `update_all()`, `delete_all()` to raise `NotSupportedError` with actionable error messages
- Add `domain.query_for(projection_cls)` method that validates the argument is a projection and returns a `ReadOnlyQuerySet`
- Export `ReadOnlyQuerySet` from the public `protean` package
- Add 26 tests covering mutation blocking, type preservation through chaining, integration queries, input validation, and backward compatibility with `domain.repository_for()`
- Update documentation across 4 files: projection guide, projection concepts, query system internals, and aggregate retrieval guide