### PR TITLE
Add ValueObject support in Projections for CQRS read-side views

### DIFF
--- a/docs/concepts/building-blocks/projections.md
+++ b/docs/concepts/building-blocks/projections.md
@@ -19,13 +19,18 @@ data from multiple [aggregates](./aggregates.md) into a single queryable
 record. The goal is to make reads fast, simple, and free from joins or
 post-processing.
 
-### Projections only support simple field types. { data-toc-label="Simple Fields" }
+### Projections support simple field types and value objects. { data-toc-label="Supported Fields" }
 
-Unlike aggregates and entities, projections cannot contain associations,
-references, or nested [value objects](./value-objects.md). They hold only
-simple, scalar field types — strings, integers, floats, identifiers,
-timestamps. This restriction keeps projections close to the storage layer and
-avoids the complexity of object-graph management on the read side.
+Projections hold simple, scalar field types — strings, integers, floats,
+identifiers, timestamps — and may also embed
+[value objects](./value-objects.md) for grouping related attributes (e.g. an
+address or monetary amount). Value objects are persisted as flattened shadow
+fields (e.g. `billing_address_street`, `billing_address_city`), making them
+queryable by individual attribute.
+
+Projections cannot contain associations (`HasOne`, `HasMany`) or references
+(`Reference`). These navigational constructs belong to the domain model, not
+the read side.
 
 ### Projections can be stored in a database or cache. { data-toc-label="Storage Options" }
 

--- a/docs/guides/consume-state/projections.md
+++ b/docs/guides/consume-state/projections.md
@@ -322,9 +322,29 @@ sequenceDiagram
 
 ## Supported Field Types
 
-Projections can only contain basic field types. References, Associations, and ValueObjects
-are not supported in projections. This is because projections are designed to be flattened,
-denormalized representations of data.
+Projections support basic field types (`String`, `Integer`, `Float`,
+`Identifier`, `DateTime`, `Boolean`, etc.) and `ValueObject` fields.
+References and Associations (`HasOne`, `HasMany`) are not supported.
+
+ValueObject fields preserve domain semantics in your projections while being
+stored as flattened shadow fields for efficient querying:
+
+```python
+@domain.projection
+class OrderSummary(BaseProjection):
+    order_id = Identifier(identifier=True)
+    customer_name = String(max_length=100)
+    total_amount = Float()
+    shipping_address = ValueObject(Address)  # Stored as shipping_address_street, etc.
+```
+
+You can query on individual shadow fields:
+
+```python
+results = domain.query_for(OrderSummary).filter(
+    shipping_address_city="Springfield"
+).all()
+```
 
 ## Best Practices
 

--- a/docs/guides/getting-started/tutorial/07-projections.md
+++ b/docs/guides/getting-started/tutorial/07-projections.md
@@ -25,8 +25,9 @@ A projection is a flat data structure optimized for queries:
 ```
 
 Notice that the projection has only simple fields — `String`, `Float`,
-`Identifier`. No associations, no value objects. The `identifier=True`
-on `book_id` marks it as the primary key.
+`Identifier`. No associations or references. (ValueObject fields are also
+allowed in projections when you need to group related attributes.) The
+`identifier=True` on `book_id` marks it as the primary key.
 
 ## Building a Projector
 

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -36,6 +36,14 @@ application with a real database. It covers:
 - **Part III** — Projections and real database persistence
 - **Part IV** — Testing strategies and next steps
 
+## Event Sourcing Tutorial
+
+If you're interested in Event Sourcing, work through
+[Building Fidelis](./guides/getting-started/es-tutorial/index.md) — a
+22-chapter deep dive that builds a banking ledger with immutable audit trails,
+projections, and production tooling. It assumes familiarity with the Bookshelf
+tutorial above.
+
 ## Core concepts
 
 Get to know the driving principles and core ideas that shape this framework

--- a/src/protean/core/projection.py
+++ b/src/protean/core/projection.py
@@ -1,6 +1,7 @@
 """Projection Functionality and Classes"""
 
 import logging
+import threading
 from typing import Any, ClassVar, TypeVar
 
 from pydantic import BaseModel, ConfigDict, PrivateAttr
@@ -23,9 +24,15 @@ from protean.utils import (
     inflection,
 )
 from protean.utils.container import OptionsMixin
-from protean.utils.reflection import _FIELDS, _ID_FIELD_NAME
+from protean.utils.reflection import _FIELDS, _ID_FIELD_NAME, value_object_fields
 
 logger = logging.getLogger(__name__)
+
+# Thread-local stack used to pass init context (shadow kwargs) from
+# __init__ to model_post_init across the Pydantic super().__init__() boundary.
+# Pydantic clears __dict__ during validation, so we cannot stash data on the
+# instance directly.
+_projection_init_context: threading.local = threading.local()
 
 
 # ---------------------------------------------------------------------------
@@ -35,11 +42,15 @@ class BaseProjection(BaseModel, OptionsMixin):
     """Base class for projections -- read-optimized, denormalized views
     maintained by projectors in response to domain events.
 
-    Projections are mutable with identity-based equality. They only support
+    Projections are mutable with identity-based equality. They support
     basic field types (``String``, ``Integer``, ``Float``, ``Identifier``,
-    ``DateTime``, etc.) — no ``Reference``, ``HasOne``, ``HasMany``, or
-    ``ValueObject`` fields. Every projection must have at least one field
-    marked with ``identifier=True``.
+    ``DateTime``, etc.) and ``ValueObject`` fields. ``Reference``,
+    ``HasOne``, and ``HasMany`` fields are not allowed. Every projection
+    must have at least one field marked with ``identifier=True``.
+
+    ValueObject fields are stored as flattened shadow fields for persistence
+    (e.g. ``billing_address_street``, ``billing_address_city``) and are
+    queryable by individual attribute.
 
     Projections can be backed by a database provider or a cache (e.g. Redis).
     When ``cache`` is specified, it overrides the database ``provider``.
@@ -65,6 +76,7 @@ class BaseProjection(BaseModel, OptionsMixin):
             customer_name = String(max_length=100)
             total_amount = Float()
             status = String(max_length=20)
+            shipping_address = ValueObject(Address)
     """
 
     element_type: ClassVar[str] = DomainObjects.PROJECTION
@@ -126,15 +138,37 @@ class BaseProjection(BaseModel, OptionsMixin):
     def _resolve_fieldspecs(cls) -> None:
         from protean.fields.spec import resolve_fieldspecs
 
+        # Migrate annotation-style ValueObject descriptors to the class namespace.
+        # Python puts ``field: ValueObject(Email)`` values into __annotations__
+        # (not vars(cls)).  Pydantic and __pydantic_init_subclass__ scan vars(cls)
+        # for descriptors, so they must live there.  We also explicitly trigger
+        # __set_name__ because setattr does NOT invoke it.
+        own_annots = getattr(cls, "__annotations__", {})
+        to_remove: list[str] = []
+        for name, value in list(own_annots.items()):
+            if isinstance(value, ValueObject):
+                setattr(cls, name, value)
+                value.__set_name__(cls, name)
+                to_remove.append(name)
+        if to_remove:
+            annots = dict(own_annots)
+            for name in to_remove:
+                del annots[name]
+            cls.__annotations__ = annots
+
         resolve_fieldspecs(cls)
 
     @classmethod
     def __validate_for_basic_field_types(cls) -> None:
-        """Reject non-basic field descriptors (ValueObject, Reference, Association)."""
+        """Reject Reference and Association descriptors.
+
+        ValueObject descriptors are allowed — they are handled via shadow
+        fields for flat persistence storage.
+        """
         for field_name, field_obj in vars(cls).items():
-            if isinstance(field_obj, (Reference, Association, ValueObject)):
+            if isinstance(field_obj, (Reference, Association)):
                 raise IncorrectUsageError(
-                    f"Projections can only contain basic field types. "
+                    f"Projections can only contain basic field types and ValueObjects. "
                     f"Remove {field_name} ({field_obj.__class__.__name__}) from class {cls.__name__}"
                 )
 
@@ -144,9 +178,17 @@ class BaseProjection(BaseModel, OptionsMixin):
         super().__pydantic_init_subclass__(**kwargs)
 
         # Build __container_fields__ bridge from Pydantic model_fields
-        fields_dict: dict[str, ResolvedField] = {}
+        fields_dict: dict[str, ResolvedField | ValueObject] = {}
         for fname, finfo in cls.model_fields.items():
             fields_dict[fname] = ResolvedField(fname, finfo, finfo.annotation)
+
+        # Add ValueObject descriptors from the full MRO so that
+        # reflection utilities (attributes, value_object_fields, etc.) work.
+        for klass in cls.__mro__:
+            for name, attr in vars(klass).items():
+                if isinstance(attr, ValueObject) and name not in fields_dict:
+                    fields_dict[name] = attr
+
         setattr(cls, _FIELDS, fields_dict)
 
         # Track identity field
@@ -166,6 +208,14 @@ class BaseProjection(BaseModel, OptionsMixin):
         except StopIteration:
             pass
 
+    @staticmethod
+    def _is_vo_descriptor(klass: type, name: str) -> bool:
+        """Check if *name* is a ValueObject descriptor on *klass*'s MRO."""
+        for mro_cls in klass.__mro__:
+            if name in vars(mro_cls) and isinstance(vars(mro_cls)[name], ValueObject):
+                return True
+        return False
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         # Check abstract before Pydantic validation to give a clear error
         # (abstract classes may lack fields, causing misleading Pydantic errors)
@@ -174,6 +224,25 @@ class BaseProjection(BaseModel, OptionsMixin):
                 f"{self.__class__.__name__} class has been marked abstract"
                 f" and cannot be instantiated"
             )
+
+        # Pop VO descriptor kwargs and shadow field kwargs before Pydantic init.
+        # Shadow fields (e.g. address_street, address_city) are dynamically
+        # generated and must not reach Pydantic's __init__ (extra="forbid").
+        descriptor_kwargs: dict[str, Any] = {}
+        shadow_kwargs: dict[str, Any] = {}
+
+        # Build the set of known shadow field names from VO descriptors
+        _shadow_field_names: set[str] = set()
+        for _, fobj in getattr(type(self), _FIELDS, {}).items():
+            if isinstance(fobj, ValueObject):
+                for sf in fobj.embedded_fields.values():
+                    _shadow_field_names.add(sf.attribute_name)
+
+        for name in list(kwargs):
+            if name in _shadow_field_names:
+                shadow_kwargs[name] = kwargs.pop(name)
+            elif self._is_vo_descriptor(type(self), name):
+                descriptor_kwargs[name] = kwargs.pop(name)
 
         # Support template dict pattern: Projection({"key": "val"}, key2="val2")
         # Keyword args take precedence over template dict values.
@@ -186,9 +255,27 @@ class BaseProjection(BaseModel, OptionsMixin):
                         f"This argument serves as a template for loading common "
                         f"values.",
                     )
+                # Also separate descriptor and shadow kwargs from template dicts
+                for tname in list(template):
+                    if tname in _shadow_field_names:
+                        shadow_kwargs[tname] = template.pop(tname)
+                    elif self._is_vo_descriptor(type(self), tname):
+                        descriptor_kwargs[tname] = template.pop(tname)
                 merged.update(template)
             merged.update(kwargs)
             kwargs = merged
+
+        # Push context onto thread-local stack for model_post_init to retrieve.
+        # Pydantic clears __dict__ during super().__init__(), so we cannot
+        # stash data on the instance.
+        stack: list[dict[str, Any]] = getattr(_projection_init_context, "stack", [])
+        stack.append(
+            {
+                "descriptor_kwargs": descriptor_kwargs,
+                "shadow_kwargs": shadow_kwargs,
+            }
+        )
+        _projection_init_context.stack = stack
 
         try:
             super().__init__(**kwargs)
@@ -196,6 +283,49 @@ class BaseProjection(BaseModel, OptionsMixin):
             raise ValidationError(convert_pydantic_errors(e))
 
     def model_post_init(self, __context: Any) -> None:
+        # Pop init context from the thread-local stack (pushed by __init__)
+        stack: list[dict[str, Any]] = getattr(_projection_init_context, "stack", [])
+        if stack:
+            ctx = stack.pop()
+            descriptor_kwargs: dict[str, Any] = ctx["descriptor_kwargs"]
+            shadow_kwargs: dict[str, Any] = ctx["shadow_kwargs"]
+        else:
+            descriptor_kwargs = {}
+            shadow_kwargs = {}
+
+        # Restore shadow field values directly into __dict__ (they bypass Pydantic)
+        for name, value in shadow_kwargs.items():
+            self.__dict__[name] = value  # type: ignore[reportIndexIssue]
+
+        # Reconstruct ValueObjects from shadow kwargs when the VO itself
+        # was not explicitly provided (e.g. during repository retrieval).
+        for field_name, field_obj in value_object_fields(self).items():
+            if field_name not in descriptor_kwargs and not getattr(
+                self, field_name, None
+            ):
+                vo_kwargs: dict[str, Any] = {}
+                for embedded_field in field_obj.embedded_fields.values():
+                    vo_kwargs[embedded_field.field_name] = shadow_kwargs.get(
+                        embedded_field.attribute_name
+                    )
+                # Only reconstruct if at least one value is not None
+                if any(v is not None for v in vo_kwargs.values()):
+                    descriptor_kwargs[field_name] = field_obj.value_object_cls(
+                        **vo_kwargs
+                    )
+
+        # Set VO values via descriptors (triggers __set__ which populates
+        # shadow fields and the VO instance in __dict__).
+        for name, value in descriptor_kwargs.items():
+            object.__setattr__(self, name, value)
+
+        # Initialize VO shadow fields to None when the VO itself is not set
+        for field_obj in value_object_fields(self).values():
+            for _, shadow_field in field_obj.get_shadow_fields():
+                attr_name = shadow_field.attribute_name
+                if attr_name not in self.__dict__:
+                    self.__dict__[attr_name] = None  # type: ignore[reportIndexIssue]
+
         self.defaults()
         self._initialized = True
 
@@ -227,6 +357,13 @@ class BaseProjection(BaseModel, OptionsMixin):
 
             # Mark projection as changed so repository persists updates
             self._state.mark_changed()
+        elif getattr(self, "_initialized", False) and self._is_vo_descriptor(
+            type(self), name
+        ):
+            # ValueObject descriptor: use object.__setattr__ to trigger
+            # the descriptor protocol directly (bypassing Pydantic).
+            object.__setattr__(self, name, value)
+            self._state.mark_changed()
         else:
             super().__setattr__(name, value)
 
@@ -255,14 +392,13 @@ class BaseProjection(BaseModel, OptionsMixin):
     def to_dict(self) -> dict[str, Any]:
         """Return projection data as a dictionary.
 
-        Internal fields (prefixed with ``_``) are excluded for consistency
-        with the entity ``to_dict()`` behaviour.
+        ValueObject fields are serialized via the descriptor's
+        ``as_dict()`` method.
         """
         result: dict[str, Any] = {}
         for fname, shim in getattr(self, _FIELDS, {}).items():
-            if fname.startswith("_"):
-                continue
-            result[fname] = shim.as_dict(getattr(self, fname, None))
+            value = getattr(self, fname, None)
+            result[fname] = shim.as_dict(value)
         return result
 
     @property

--- a/tests/projections/test_projection_validations_for_fields.py
+++ b/tests/projections/test_projection_validations_for_fields.py
@@ -33,17 +33,18 @@ def test_that_projections_should_have_at_least_one_identifier_field(test_domain)
     )
 
 
-def test_that_projections_cannot_have_value_object_fields():
-    with pytest.raises(IncorrectUsageError) as exception:
+def test_that_projections_can_have_value_object_fields():
+    """ValueObject fields are now supported in projections."""
 
-        class User(BaseProjection):
-            user_id: Identifier(identifier=True)
-            email = ValueObject(Email)
+    class UserView(BaseProjection):
+        user_id: Identifier(identifier=True)
+        email = ValueObject(Email)
 
-    assert (
-        exception.value.args[0]
-        == "Projections can only contain basic field types. Remove email (ValueObject) from class User"
-    )
+    from protean.utils.reflection import _FIELDS
+
+    cf = getattr(UserView, _FIELDS, {})
+    assert "email" in cf
+    assert isinstance(cf["email"], ValueObject)
 
 
 def test_that_projections_cannot_have_references():
@@ -55,7 +56,7 @@ def test_that_projections_cannot_have_references():
 
     assert (
         exception.value.args[0]
-        == "Projections can only contain basic field types. Remove role (Reference) from class User"
+        == "Projections can only contain basic field types and ValueObjects. Remove role (Reference) from class User"
     )
 
 
@@ -68,5 +69,5 @@ def test_that_projections_cannot_have_associations():
 
     assert (
         exception.value.args[0]
-        == "Projections can only contain basic field types. Remove role (HasOne) from class User"
+        == "Projections can only contain basic field types and ValueObjects. Remove role (HasOne) from class User"
     )

--- a/tests/projections/test_projection_with_value_objects.py
+++ b/tests/projections/test_projection_with_value_objects.py
@@ -1,0 +1,384 @@
+"""Tests for ValueObject support in BaseProjection.
+
+Validates:
+- Projection with VO field can be defined and registered
+- VO field appears in __container_fields__ correctly
+- Projection can be instantiated with VO object directly
+- Projection can be instantiated with shadow kwargs
+- VO reconstruction from shadow kwargs works
+- to_dict() serializes VO correctly
+- attributes() returns flattened shadow fields
+- Persistence round-trip with Memory provider
+- Querying/filtering on shadow field values works
+- VO mutation tracking
+- None VO handling
+- Annotation-style VO declaration
+"""
+
+import pytest
+from pydantic import Field
+
+from protean.core.projection import BaseProjection
+from protean.core.value_object import BaseValueObject
+from protean.fields import Identifier, String, ValueObject
+from protean.utils.reflection import (
+    _FIELDS,
+    attributes,
+    value_object_fields,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test domain elements
+# ---------------------------------------------------------------------------
+class Address(BaseValueObject):
+    street: str = ""
+    city: str = ""
+    zip_code: str = ""
+
+
+class CustomerView(BaseProjection):
+    customer_id: str = Field(json_schema_extra={"identifier": True})
+    name: str = ""
+    billing_address = ValueObject(Address)
+
+
+class CustomerViewAnnotation(BaseProjection):
+    customer_id: Identifier(identifier=True)
+    name: String()
+    shipping_address: ValueObject(Address)
+
+
+class CustomerViewMultiVO(BaseProjection):
+    customer_id: str = Field(json_schema_extra={"identifier": True})
+    name: str = ""
+    billing_address = ValueObject(Address)
+    shipping_address = ValueObject(Address)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+@pytest.fixture(autouse=True)
+def register_elements(test_domain):
+    test_domain.register(Address)
+    test_domain.register(CustomerView)
+    test_domain.register(CustomerViewAnnotation)
+    test_domain.register(CustomerViewMultiVO)
+    test_domain.init(traverse=False)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Structure & Reflection
+# ---------------------------------------------------------------------------
+class TestVOFieldsStructure:
+    def test_vo_descriptor_in_container_fields(self):
+        cf = getattr(CustomerView, _FIELDS, {})
+        assert "billing_address" in cf
+        assert isinstance(cf["billing_address"], ValueObject)
+
+    def test_pydantic_fields_coexist_with_vo(self):
+        cf = getattr(CustomerView, _FIELDS, {})
+        assert "customer_id" in cf
+        assert "name" in cf
+        assert "billing_address" in cf
+
+    def test_value_object_fields_utility(self):
+        vof = value_object_fields(CustomerView)
+        assert "billing_address" in vof
+        assert isinstance(vof["billing_address"], ValueObject)
+
+    def test_shadow_fields_in_attributes(self):
+        attr = attributes(CustomerView)
+        assert "billing_address_street" in attr
+        assert "billing_address_city" in attr
+        assert "billing_address_zip_code" in attr
+
+    def test_annotation_style_vo_in_container_fields(self):
+        cf = getattr(CustomerViewAnnotation, _FIELDS, {})
+        assert "shipping_address" in cf
+        assert isinstance(cf["shipping_address"], ValueObject)
+
+    def test_annotation_style_shadow_fields(self):
+        attr = attributes(CustomerViewAnnotation)
+        assert "shipping_address_street" in attr
+        assert "shipping_address_city" in attr
+        assert "shipping_address_zip_code" in attr
+
+    def test_multiple_vo_fields(self):
+        cf = getattr(CustomerViewMultiVO, _FIELDS, {})
+        assert "billing_address" in cf
+        assert "shipping_address" in cf
+        assert isinstance(cf["billing_address"], ValueObject)
+        assert isinstance(cf["shipping_address"], ValueObject)
+
+    def test_multiple_vo_shadow_fields_distinct(self):
+        attr = attributes(CustomerViewMultiVO)
+        assert "billing_address_street" in attr
+        assert "shipping_address_street" in attr
+        assert "billing_address_city" in attr
+        assert "shipping_address_city" in attr
+
+
+# ---------------------------------------------------------------------------
+# Tests: Initialization
+# ---------------------------------------------------------------------------
+class TestVOInitialization:
+    def test_init_with_vo_instance(self):
+        addr = Address(street="123 Main St", city="Springfield", zip_code="62704")
+        view = CustomerView(customer_id="C1", name="Alice", billing_address=addr)
+        assert view.billing_address is not None
+        assert view.billing_address.street == "123 Main St"
+        assert view.billing_address.city == "Springfield"
+        assert view.billing_address.zip_code == "62704"
+
+    def test_init_with_shadow_kwargs(self):
+        view = CustomerView(
+            customer_id="C1",
+            name="Alice",
+            billing_address_street="123 Main St",
+            billing_address_city="Springfield",
+            billing_address_zip_code="62704",
+        )
+        assert view.billing_address is not None
+        assert view.billing_address.street == "123 Main St"
+        assert view.billing_address.city == "Springfield"
+
+    def test_shadow_kwargs_and_instance_are_equivalent(self):
+        addr = Address(street="123 Main St", city="Springfield", zip_code="62704")
+        via_instance = CustomerView(
+            customer_id="C1", name="Alice", billing_address=addr
+        )
+        via_flat = CustomerView(
+            customer_id="C1",
+            name="Alice",
+            billing_address_street="123 Main St",
+            billing_address_city="Springfield",
+            billing_address_zip_code="62704",
+        )
+        assert via_instance.billing_address == via_flat.billing_address
+
+    def test_none_vo_by_default(self):
+        view = CustomerView(customer_id="C1", name="Bob")
+        assert view.billing_address is None
+
+    def test_shadow_fields_populated_when_vo_set(self):
+        addr = Address(street="123 Main St", city="Springfield", zip_code="62704")
+        view = CustomerView(customer_id="C1", name="Alice", billing_address=addr)
+        assert view.__dict__["billing_address_street"] == "123 Main St"
+        assert view.__dict__["billing_address_city"] == "Springfield"
+        assert view.__dict__["billing_address_zip_code"] == "62704"
+
+    def test_shadow_fields_none_when_vo_not_set(self):
+        view = CustomerView(customer_id="C1", name="Bob")
+        assert view.__dict__.get("billing_address_street") is None
+        assert view.__dict__.get("billing_address_city") is None
+        assert view.__dict__.get("billing_address_zip_code") is None
+
+    def test_template_dict_with_vo_instance(self):
+        addr = Address(street="123 Main St", city="Springfield", zip_code="62704")
+        view = CustomerView(
+            {"customer_id": "C1", "name": "Alice", "billing_address": addr}
+        )
+        assert view.billing_address is not None
+        assert view.billing_address.street == "123 Main St"
+
+    def test_template_dict_with_shadow_kwargs(self):
+        view = CustomerView(
+            {
+                "customer_id": "C1",
+                "name": "Alice",
+                "billing_address_street": "123 Main St",
+                "billing_address_city": "Springfield",
+                "billing_address_zip_code": "62704",
+            }
+        )
+        assert view.billing_address is not None
+        assert view.billing_address.street == "123 Main St"
+
+    def test_annotation_style_init_with_vo(self):
+        addr = Address(street="456 Elm Ave", city="Shelbyville", zip_code="62705")
+        view = CustomerViewAnnotation(
+            customer_id="C1", name="Alice", shipping_address=addr
+        )
+        assert view.shipping_address.street == "456 Elm Ave"
+
+    def test_annotation_style_init_with_shadow_kwargs(self):
+        view = CustomerViewAnnotation(
+            customer_id="C1",
+            name="Alice",
+            shipping_address_street="456 Elm Ave",
+            shipping_address_city="Shelbyville",
+            shipping_address_zip_code="62705",
+        )
+        assert view.shipping_address is not None
+        assert view.shipping_address.street == "456 Elm Ave"
+
+
+# ---------------------------------------------------------------------------
+# Tests: Mutation
+# ---------------------------------------------------------------------------
+class TestVOMutation:
+    def test_replace_vo(self):
+        addr1 = Address(street="123 Main St", city="Springfield", zip_code="62704")
+        view = CustomerView(customer_id="C1", name="Alice", billing_address=addr1)
+
+        addr2 = Address(street="456 Elm Ave", city="Shelbyville", zip_code="62705")
+        view.billing_address = addr2
+        assert view.billing_address == addr2
+        assert view.__dict__["billing_address_street"] == "456 Elm Ave"
+        assert view.__dict__["billing_address_city"] == "Shelbyville"
+
+    def test_set_vo_to_none(self):
+        addr = Address(street="123 Main St", city="Springfield", zip_code="62704")
+        view = CustomerView(customer_id="C1", name="Alice", billing_address=addr)
+        view.billing_address = None
+        assert view.billing_address is None
+
+    def test_vo_mutation_marks_changed(self):
+        view = CustomerView(customer_id="C1", name="Alice")
+        view._state.mark_saved()
+        assert not view._state.is_changed
+
+        view.billing_address = Address(street="789 Oak Ln")
+        assert view._state.is_changed
+
+
+# ---------------------------------------------------------------------------
+# Tests: Serialization
+# ---------------------------------------------------------------------------
+class TestVOSerialization:
+    def test_to_dict_includes_vo(self):
+        addr = Address(street="123 Main St", city="Springfield", zip_code="62704")
+        view = CustomerView(customer_id="C1", name="Alice", billing_address=addr)
+        d = view.to_dict()
+        assert "billing_address" in d
+        assert d["billing_address"]["street"] == "123 Main St"
+        assert d["billing_address"]["city"] == "Springfield"
+        assert d["billing_address"]["zip_code"] == "62704"
+
+    def test_to_dict_none_vo(self):
+        view = CustomerView(customer_id="C1", name="Bob")
+        d = view.to_dict()
+        # None VOs serialize as None
+        assert d["billing_address"] is None
+
+    def test_to_dict_regular_fields_unaffected(self):
+        addr = Address(street="123 Main St", city="Springfield", zip_code="62704")
+        view = CustomerView(customer_id="C1", name="Alice", billing_address=addr)
+        d = view.to_dict()
+        assert d["customer_id"] == "C1"
+        assert d["name"] == "Alice"
+
+    def test_to_dict_with_multiple_vos(self):
+        addr1 = Address(street="123 Main St", city="Springfield", zip_code="62704")
+        addr2 = Address(street="456 Elm Ave", city="Shelbyville", zip_code="62705")
+        view = CustomerViewMultiVO(
+            customer_id="C1",
+            name="Alice",
+            billing_address=addr1,
+            shipping_address=addr2,
+        )
+        d = view.to_dict()
+        assert d["billing_address"]["street"] == "123 Main St"
+        assert d["shipping_address"]["street"] == "456 Elm Ave"
+
+
+# ---------------------------------------------------------------------------
+# Tests: Edge cases for coverage
+# ---------------------------------------------------------------------------
+class TestVOEdgeCases:
+    def test_model_post_init_without_init_context(self):
+        """Ensure model_post_init handles an empty thread-local stack gracefully.
+
+        This exercises the defensive else branch in model_post_init when
+        the thread-local stack has been consumed or is absent.
+        """
+        from protean.core.projection import _projection_init_context
+
+        view = CustomerView(customer_id="C1", name="Alice")
+        # Clear the thread-local stack, then call model_post_init directly
+        _projection_init_context.stack = []
+        view._initialized = False
+        view.model_post_init(None)
+        # Should not crash; VO remains None
+        assert view.billing_address is None
+
+    def test_setting_identifier_to_same_value_is_allowed(self):
+        """Setting the identifier field to its current value should not raise."""
+        view = CustomerView(customer_id="C1", name="Alice")
+        # Re-setting the same value should succeed silently
+        view.customer_id = "C1"
+        assert view.customer_id == "C1"
+
+
+# ---------------------------------------------------------------------------
+# Tests: Persistence round-trip
+# ---------------------------------------------------------------------------
+@pytest.mark.database
+@pytest.mark.usefixtures("db")
+class TestVOPersistence:
+    def test_persist_and_retrieve_with_vo(self, test_domain):
+        addr = Address(street="123 Main St", city="Springfield", zip_code="62704")
+        view = CustomerView(customer_id="C1", name="Alice", billing_address=addr)
+        test_domain.repository_for(CustomerView).add(view)
+
+        refreshed = test_domain.repository_for(CustomerView).get("C1")
+        assert refreshed.billing_address is not None
+        assert refreshed.billing_address.street == "123 Main St"
+        assert refreshed.billing_address.city == "Springfield"
+        assert refreshed.billing_address.zip_code == "62704"
+
+    def test_persist_and_retrieve_without_vo(self, test_domain):
+        view = CustomerView(customer_id="C2", name="Bob")
+        test_domain.repository_for(CustomerView).add(view)
+
+        refreshed = test_domain.repository_for(CustomerView).get("C2")
+        assert refreshed.billing_address is None
+
+    def test_update_vo_and_retrieve(self, test_domain):
+        addr = Address(street="123 Main St", city="Springfield", zip_code="62704")
+        view = CustomerView(customer_id="C1", name="Alice", billing_address=addr)
+        test_domain.repository_for(CustomerView).add(view)
+
+        view.billing_address = Address(
+            street="456 Elm Ave", city="Shelbyville", zip_code="62705"
+        )
+        test_domain.repository_for(CustomerView).add(view)
+
+        refreshed = test_domain.repository_for(CustomerView).get("C1")
+        assert refreshed.billing_address.street == "456 Elm Ave"
+        assert refreshed.billing_address.city == "Shelbyville"
+
+    def test_filter_on_shadow_field(self, test_domain):
+        addr1 = Address(street="123 Main St", city="Springfield", zip_code="62704")
+        addr2 = Address(street="456 Elm Ave", city="Shelbyville", zip_code="62705")
+        test_domain.repository_for(CustomerView).add(
+            CustomerView(customer_id="C1", name="Alice", billing_address=addr1)
+        )
+        test_domain.repository_for(CustomerView).add(
+            CustomerView(customer_id="C2", name="Bob", billing_address=addr2)
+        )
+
+        results = (
+            test_domain.repository_for(CustomerView)
+            ._dao.query.filter(billing_address_city="Springfield")
+            .all()
+        )
+        assert len(results) == 1
+        assert results.first.customer_id == "C1"
+
+    def test_persist_multiple_vos(self, test_domain):
+        addr1 = Address(street="123 Main St", city="Springfield", zip_code="62704")
+        addr2 = Address(street="456 Elm Ave", city="Shelbyville", zip_code="62705")
+        view = CustomerViewMultiVO(
+            customer_id="C1",
+            name="Alice",
+            billing_address=addr1,
+            shipping_address=addr2,
+        )
+        test_domain.repository_for(CustomerViewMultiVO).add(view)
+
+        refreshed = test_domain.repository_for(CustomerViewMultiVO).get("C1")
+        assert refreshed.billing_address.street == "123 Main St"
+        assert refreshed.shipping_address.street == "456 Elm Ave"


### PR DESCRIPTION
Projections previously rejected ValueObject fields alongside Reference and Association types. This was overly restrictive — ValueObjects are immutable structural field clusters (Address, Money, Email), not ORM relationships. Developers had to manually flatten VOs into individual scalar fields, losing domain semantics in read models.

This change allows ValueObject fields in projections while keeping Reference, HasOne, and HasMany blocked. VOs are stored as flattened shadow fields (e.g. billing_address_street, billing_address_city) for efficient querying and persistence, and reconstructed transparently on retrieval.

Core changes in src/protean/core/projection.py:
- Remove ValueObject from the rejected types in validation
- Add thread-local init context to shuttle shadow kwargs across Pydantic's super().__init__() boundary (extra="forbid" rejects unknown kwargs)
- Migrate annotation-style VO descriptors from __annotations__ to class namespace in _resolve_fieldspecs()
- Include VO descriptors in __container_fields__ via MRO scan in __pydantic_init_subclass__()
- Rewrite __init__() to separate shadow/descriptor kwargs before Pydantic validation
- Rewrite model_post_init() to restore shadow fields, reconstruct VOs from shadow kwargs, and initialize None shadow fields
- Add VO descriptor branch in __setattr__() for mutation tracking
- Remove dead code (unreachable underscore-prefix guard in to_dict, unnecessary hasattr guard in _resolve_fieldspecs)