### PR TITLE
Add ReadView and domain.view_for() for read-only projection access

### DIFF
--- a/docs/concepts/building-blocks/projections.md
+++ b/docs/concepts/building-blocks/projections.md
@@ -67,6 +67,14 @@ Use `domain.query_for(ProjectionClass)` to query projections. This returns a
 structurally prevents mutation. This enforces the CQRS contract at the API
 level — reads cannot accidentally write.
 
+### Projections have a read-only view facade. { data-toc-label="ReadView" }
+
+Use `domain.view_for(ProjectionClass)` to obtain a `ReadView` — a read-only
+facade that exposes `get()`, `query`, `find_by()`, `count()`, and `exists()`
+but no write methods. This is the recommended way to access projections from
+API endpoints and query handlers, ensuring CQRS separation is enforced
+structurally rather than by convention.
+
 ### Projections can aggregate data across aggregates. { data-toc-label="Cross-Aggregate Views" }
 
 A single projection can combine data from multiple aggregate streams. For

--- a/docs/guides/consume-state/projections.md
+++ b/docs/guides/consume-state/projections.md
@@ -127,6 +127,51 @@ repo.add(inventory_record)
     use [repositories](../change-state/retrieve-aggregates.md) with custom
     query methods.
 
+### ReadView — Read-Only Projection Access
+
+For a higher-level, read-only interface, use `domain.view_for()`. It returns
+a `ReadView` — a lightweight facade that bundles the most common read
+operations and structurally prevents writes:
+
+```python
+view = domain.view_for(ProductInventory)
+
+# Single lookup by identifier
+item = view.get("abc-123")
+
+# Fluent filtering via ReadOnlyQuerySet
+low_stock = view.query.filter(stock_quantity__lt=10).order_by("name").all()
+
+# Convenience single-item lookup by criteria
+item = view.find_by(product_id="abc-123")
+
+# Total count and existence checks
+total = view.count()
+found = view.exists("abc-123")
+```
+
+`ReadView` does not expose `add()`, `_dao`, or any mutation methods — it is
+safe to pass to API endpoints and query handlers without risking accidental
+writes.
+
+#### Cache-backed projections
+
+When a projection is stored in a cache (Redis, in-memory), `view.get()`,
+`view.count()`, and `view.exists()` work as expected. However, `view.query`
+and `view.find_by()` raise `NotSupportedError` because cache backends are
+key-value stores and do not support field-based filtering.
+
+#### Three levels of read access
+
+Protean provides three levels of projection read access, each suited to
+different use cases:
+
+| Level | Entry point | Returns | Use when |
+|-------|-------------|---------|----------|
+| **ReadView** | `domain.view_for(Proj)` | `ReadView` | Default for endpoints and query handlers — read-only by design |
+| **QuerySet** | `domain.query_for(Proj)` | `ReadOnlyQuerySet` | Direct QuerySet access for custom filtering |
+| **Repository** | `domain.repository_for(Proj)` | `BaseRepository` | Inside projectors — when you need to write |
+
 ---
 
 ## Projectors

--- a/src/protean/__init__.py
+++ b/src/protean/__init__.py
@@ -5,6 +5,7 @@ from .core.application_service import use_case
 from .core.entity import invariant
 from .core.queryset import Q, QuerySet, ReadOnlyQuerySet
 from .core.unit_of_work import UnitOfWork
+from .core.view import ReadView
 from .domain import Domain
 from .server import Engine
 from .utils import get_version
@@ -29,6 +30,7 @@ __all__ = [
     "Q",
     "QuerySet",
     "ReadOnlyQuerySet",
+    "ReadView",
     "UnitOfWork",
     "use_case",
 ]

--- a/src/protean/adapters/cache/__init__.py
+++ b/src/protean/adapters/cache/__init__.py
@@ -80,9 +80,12 @@ class Caches(collections.abc.MutableMapping):
         if self._caches is None:
             self._initialize()
 
-        projection_provider = projection_cls.meta_.provider
+        # Use meta_.cache (the cache adapter name) when the projection is
+        # cache-backed.  Fall back to meta_.provider for backward compatibility
+        # with projections that call cache_for() without formal registration.
+        cache_name = projection_cls.meta_.cache or projection_cls.meta_.provider
 
-        cache = self.get(projection_provider)
+        cache = self.get(cache_name)
 
         projection_name = underscore(projection_cls.__name__)
         if projection_name not in cache._projections:

--- a/src/protean/core/view.py
+++ b/src/protean/core/view.py
@@ -1,0 +1,126 @@
+"""Read-only facade for querying projections.
+
+``ReadView`` wraps the underlying repository (database-backed) or cache
+(cache-backed) and exposes only read operations.  Obtain an instance via
+``domain.view_for(ProjectionClass)``.
+"""
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from protean.exceptions import NotSupportedError, ObjectNotFoundError
+from protean.utils.inflection import underscore
+
+if TYPE_CHECKING:
+    from protean.core.projection import BaseProjection
+    from protean.core.queryset import ReadOnlyQuerySet
+    from protean.domain import Domain
+
+logger = logging.getLogger(__name__)
+
+
+class ReadView:
+    """Read-only facade for querying projections.
+
+    Exposes ``get()``, ``query`` (``ReadOnlyQuerySet``), ``find_by()``,
+    ``count()``, and ``exists()`` — but no ``add()``, ``update()``,
+    ``delete()``, or ``_dao`` access.
+
+    For **database-backed** projections every method works.  For
+    **cache-backed** projections only ``get()``, ``count()``, and
+    ``exists()`` are available; ``query`` and ``find_by()`` raise
+    ``NotSupportedError`` because cache stores are key-value backends
+    and do not support field-based filtering.
+    """
+
+    def __init__(
+        self,
+        domain: "Domain",
+        projection_cls: type["BaseProjection"],
+    ) -> None:
+        self._domain = domain
+        self._projection_cls = projection_cls
+        self._is_cache_backed: bool = bool(projection_cls.meta_.cache)
+
+    def __repr__(self) -> str:  # pragma: no cover
+        backend = "cache" if self._is_cache_backed else "database"
+        return f"<ReadView for {self._projection_cls.__name__} ({backend})>"
+
+    # ── Internal helpers ─────────────────────────────────────
+
+    def _repo(self):
+        """Return the repository for a database-backed projection."""
+        return self._domain.providers.repository_for(self._projection_cls)
+
+    def _cache(self):
+        """Return the cache adapter for a cache-backed projection."""
+        return self._domain.caches.cache_for(self._projection_cls)
+
+    # ── Public read API ──────────────────────────────────────
+
+    @property
+    def query(self) -> "ReadOnlyQuerySet":
+        """Return a ``ReadOnlyQuerySet`` for fluent filtering, ordering,
+        and pagination.
+
+        Only available for database-backed projections.  Cache-backed
+        projections raise ``NotSupportedError``.
+        """
+        if self._is_cache_backed:
+            raise NotSupportedError(
+                f"Querying with filters is not supported for cache-backed "
+                f"projection `{self._projection_cls.__name__}`. "
+                f"Use get() for key-based lookups."
+            )
+        return self._domain.query_for(self._projection_cls)
+
+    def get(self, identifier: Any) -> "BaseProjection":
+        """Retrieve a single projection record by its identifier.
+
+        Raises ``ObjectNotFoundError`` if the record does not exist.
+        """
+        if self._is_cache_backed:
+            projection_name = underscore(self._projection_cls.__name__)
+            key = f"{projection_name}:::{identifier}"
+            result = self._cache().get(key)
+            if result is None:
+                raise ObjectNotFoundError(
+                    f"`{self._projection_cls.__name__}` object with identifier "
+                    f"{identifier} does not exist."
+                )
+            return result
+        else:
+            return self._repo()._dao.get(identifier)
+
+    def find_by(self, **kwargs: Any) -> "BaseProjection":
+        """Find a single projection record matching the given criteria.
+
+        Returns exactly one record.  Raises ``ObjectNotFoundError`` if
+        none match and ``TooManyObjectsError`` if more than one matches.
+
+        Only available for database-backed projections.
+        """
+        if self._is_cache_backed:
+            raise NotSupportedError(
+                f"find_by() is not supported for cache-backed "
+                f"projection `{self._projection_cls.__name__}`. "
+                f"Use get() for key-based lookups."
+            )
+        return self._repo()._dao.find_by(**kwargs)
+
+    def count(self) -> int:
+        """Return the total number of projection records."""
+        if self._is_cache_backed:
+            projection_name = underscore(self._projection_cls.__name__)
+            key_pattern = f"{projection_name}:::.*"
+            return self._cache().count(key_pattern)
+        else:
+            return self._domain.query_for(self._projection_cls).all().total
+
+    def exists(self, identifier: Any) -> bool:
+        """Return ``True`` if a record with *identifier* exists."""
+        try:
+            self.get(identifier)
+            return True
+        except ObjectNotFoundError:
+            return False

--- a/src/protean/domain/__init__.py
+++ b/src/protean/domain/__init__.py
@@ -26,6 +26,7 @@ from typing import (
 
 if TYPE_CHECKING:
     from protean.core.queryset import ReadOnlyQuerySet
+    from protean.core.view import ReadView
     from protean.utils.projection_rebuilder import RebuildResult
 from uuid import uuid4
 
@@ -2031,6 +2032,50 @@ class Domain:
             self,
             projection_cls,
         )
+
+    ###########################
+    # ReadView Functionality #
+    ###########################
+
+    def view_for(self, projection_cls: type) -> "ReadView":
+        """Return a read-only :class:`ReadView` for querying a projection.
+
+        The returned ``ReadView`` exposes ``get()``, ``query``
+        (``ReadOnlyQuerySet``), ``find_by()``, ``count()``, and
+        ``exists()`` — but no mutation methods.
+
+        Works with both database-backed and cache-backed projections.
+
+        Args:
+            projection_cls: A registered projection class.
+
+        Returns:
+            A ``ReadView`` bound to the projection's data store.
+
+        Raises:
+            IncorrectUsageError: If the element is not a projection.
+
+        Example::
+
+            view = domain.view_for(OrderSummary)
+            order = view.get("order-123")
+            results = view.query.filter(status="shipped").all()
+        """
+        from protean.core.view import ReadView
+
+        if isinstance(projection_cls, str):
+            raise IncorrectUsageError(
+                f"Element {projection_cls} is not registered in domain {self.name}"
+            )
+
+        if projection_cls.element_type != DomainObjects.PROJECTION:
+            raise IncorrectUsageError(
+                f"`view_for` is only available for projections. "
+                f"Received {projection_cls.__name__} "
+                f"({projection_cls.element_type})."
+            )
+
+        return ReadView(self, projection_cls)
 
     #######################
     # Cache Functionality #

--- a/tests/projections/test_view_for.py
+++ b/tests/projections/test_view_for.py
@@ -1,0 +1,364 @@
+"""Tests for domain.view_for() and ReadView.
+
+Validates:
+- domain.view_for() returns a ReadView for projections
+- domain.view_for() rejects non-projection types
+- ReadView.get() retrieves by identifier (database and cache)
+- ReadView.query returns ReadOnlyQuerySet (database only)
+- ReadView.find_by() finds by criteria (database only)
+- ReadView.count() returns total record count
+- ReadView.exists() checks existence by identifier
+- ReadView does not expose write methods (add, _dao, delete)
+- Cache-backed projections: query and find_by raise NotSupportedError
+- ReadView and repository_for see the same data
+"""
+
+import pytest
+from pydantic import Field
+
+from protean.core.aggregate import BaseAggregate
+from protean.core.projection import BaseProjection
+from protean.core.queryset import ReadOnlyQuerySet
+from protean.core.view import ReadView
+from protean.exceptions import (
+    IncorrectUsageError,
+    NotSupportedError,
+    ObjectNotFoundError,
+    TooManyObjectsError,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test domain elements
+# ---------------------------------------------------------------------------
+class PersonProjection(BaseProjection):
+    person_id: str = Field(json_schema_extra={"identifier": True})
+    first_name: str
+    last_name: str | None = None
+    age: int = 21
+
+
+class Person(BaseAggregate):
+    first_name: str
+    last_name: str | None = None
+    age: int = 21
+
+
+class CachedPersonProjection(BaseProjection):
+    person_id: str = Field(json_schema_extra={"identifier": True})
+    first_name: str
+    last_name: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: database-backed
+# ---------------------------------------------------------------------------
+@pytest.fixture(autouse=True)
+def register_elements(test_domain):
+    test_domain.register(PersonProjection)
+    test_domain.register(Person)
+    test_domain.init(traverse=False)
+
+
+@pytest.fixture
+def seeded_projections(test_domain):
+    repo = test_domain.repository_for(PersonProjection)
+    repo.add(
+        PersonProjection(person_id="1", first_name="John", last_name="Doe", age=38)
+    )
+    repo.add(
+        PersonProjection(person_id="2", first_name="Jane", last_name="Doe", age=36)
+    )
+    repo.add(
+        PersonProjection(person_id="3", first_name="Bob", last_name="Smith", age=25)
+    )
+    repo.add(PersonProjection(person_id="4", first_name="Baby", last_name="Doe", age=3))
+
+
+# ---------------------------------------------------------------------------
+# Tests: domain.view_for() — entry point
+# ---------------------------------------------------------------------------
+@pytest.mark.database
+@pytest.mark.usefixtures("db")
+class TestViewForEntryPoint:
+    def test_returns_read_view_instance(self, test_domain):
+        view = test_domain.view_for(PersonProjection)
+        assert isinstance(view, ReadView)
+
+    def test_rejects_aggregate_class(self, test_domain):
+        with pytest.raises(IncorrectUsageError, match="only available for projections"):
+            test_domain.view_for(Person)
+
+    def test_rejects_string_argument(self, test_domain):
+        with pytest.raises(IncorrectUsageError, match="not registered"):
+            test_domain.view_for("PersonProjection")
+
+
+# ---------------------------------------------------------------------------
+# Tests: ReadView.get()
+# ---------------------------------------------------------------------------
+@pytest.mark.database
+@pytest.mark.usefixtures("db")
+class TestReadViewGet:
+    def test_get_by_identifier(self, test_domain, seeded_projections):
+        view = test_domain.view_for(PersonProjection)
+        person = view.get("1")
+
+        assert person.first_name == "John"
+        assert person.last_name == "Doe"
+        assert person.age == 38
+
+    def test_get_nonexistent_raises_not_found(self, test_domain):
+        view = test_domain.view_for(PersonProjection)
+
+        with pytest.raises(ObjectNotFoundError):
+            view.get("nonexistent")
+
+
+# ---------------------------------------------------------------------------
+# Tests: ReadView.query
+# ---------------------------------------------------------------------------
+@pytest.mark.database
+@pytest.mark.usefixtures("db")
+class TestReadViewQuery:
+    def test_query_returns_read_only_queryset(self, test_domain):
+        view = test_domain.view_for(PersonProjection)
+        assert isinstance(view.query, ReadOnlyQuerySet)
+
+    def test_query_filter_and_all(self, test_domain, seeded_projections):
+        view = test_domain.view_for(PersonProjection)
+        results = view.query.filter(last_name="Doe").all()
+
+        assert results.total == 3
+        names = {item.first_name for item in results}
+        assert names == {"John", "Jane", "Baby"}
+
+    def test_query_exclude(self, test_domain, seeded_projections):
+        view = test_domain.view_for(PersonProjection)
+        results = view.query.exclude(last_name="Doe").all()
+
+        assert results.total == 1
+        assert results.first.first_name == "Bob"
+
+    def test_query_order_by(self, test_domain, seeded_projections):
+        view = test_domain.view_for(PersonProjection)
+        results = view.query.order_by("age").all()
+
+        ages = [item.age for item in results]
+        assert ages == [3, 25, 36, 38]
+
+    def test_query_limit_and_offset(self, test_domain, seeded_projections):
+        view = test_domain.view_for(PersonProjection)
+        results = view.query.order_by("age").limit(2).offset(1).all()
+
+        assert len(results.items) == 2
+        ages = [item.age for item in results]
+        assert ages == [25, 36]
+
+    def test_query_mutation_blocked(self, test_domain):
+        view = test_domain.view_for(PersonProjection)
+
+        with pytest.raises(NotSupportedError):
+            view.query.update(first_name="X")
+
+        with pytest.raises(NotSupportedError):
+            view.query.delete()
+
+    def test_successive_query_calls_return_fresh_queryset(self, test_domain):
+        view = test_domain.view_for(PersonProjection)
+        qs1 = view.query
+        qs2 = view.query
+
+        assert qs1 is not qs2
+        assert isinstance(qs1, ReadOnlyQuerySet)
+        assert isinstance(qs2, ReadOnlyQuerySet)
+
+
+# ---------------------------------------------------------------------------
+# Tests: ReadView.find_by()
+# ---------------------------------------------------------------------------
+@pytest.mark.database
+@pytest.mark.usefixtures("db")
+class TestReadViewFindBy:
+    def test_find_by_single_field(self, test_domain, seeded_projections):
+        view = test_domain.view_for(PersonProjection)
+        person = view.find_by(first_name="Bob")
+
+        assert person.last_name == "Smith"
+        assert person.age == 25
+
+    def test_find_by_nonexistent_raises_not_found(self, test_domain):
+        view = test_domain.view_for(PersonProjection)
+
+        with pytest.raises(ObjectNotFoundError):
+            view.find_by(first_name="Nonexistent")
+
+    def test_find_by_multiple_results_raises_too_many(
+        self, test_domain, seeded_projections
+    ):
+        view = test_domain.view_for(PersonProjection)
+
+        with pytest.raises(TooManyObjectsError):
+            view.find_by(last_name="Doe")
+
+
+# ---------------------------------------------------------------------------
+# Tests: ReadView.count()
+# ---------------------------------------------------------------------------
+@pytest.mark.database
+@pytest.mark.usefixtures("db")
+class TestReadViewCount:
+    def test_count_all(self, test_domain, seeded_projections):
+        view = test_domain.view_for(PersonProjection)
+        assert view.count() == 4
+
+    def test_count_empty(self, test_domain):
+        view = test_domain.view_for(PersonProjection)
+        assert view.count() == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: ReadView.exists()
+# ---------------------------------------------------------------------------
+@pytest.mark.database
+@pytest.mark.usefixtures("db")
+class TestReadViewExists:
+    def test_exists_true(self, test_domain, seeded_projections):
+        view = test_domain.view_for(PersonProjection)
+        assert view.exists("1") is True
+
+    def test_exists_false(self, test_domain):
+        view = test_domain.view_for(PersonProjection)
+        assert view.exists("nonexistent") is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: ReadView does not expose write methods
+# ---------------------------------------------------------------------------
+@pytest.mark.database
+@pytest.mark.usefixtures("db")
+class TestReadViewNoWriteAccess:
+    def test_no_add_method(self, test_domain):
+        view = test_domain.view_for(PersonProjection)
+        assert not hasattr(view, "add")
+
+    def test_no_dao_access(self, test_domain):
+        view = test_domain.view_for(PersonProjection)
+        assert not hasattr(view, "_dao")
+
+    def test_no_delete_method(self, test_domain):
+        view = test_domain.view_for(PersonProjection)
+        assert not hasattr(view, "delete")
+
+    def test_no_update_method(self, test_domain):
+        view = test_domain.view_for(PersonProjection)
+        assert not hasattr(view, "update")
+
+
+# ---------------------------------------------------------------------------
+# Tests: Cache-backed ReadView
+# ---------------------------------------------------------------------------
+class TestCacheBackedReadView:
+    @pytest.fixture(autouse=True)
+    def register_cached_projection(self, test_domain):
+        test_domain.register(CachedPersonProjection, cache="default")
+        test_domain.init(traverse=False)
+
+    @pytest.fixture
+    def seeded_cache(self, test_domain):
+        cache = test_domain.cache_for(CachedPersonProjection)
+        cache.add(
+            CachedPersonProjection(person_id="1", first_name="John", last_name="Doe")
+        )
+        cache.add(
+            CachedPersonProjection(person_id="2", first_name="Jane", last_name="Doe")
+        )
+        cache.add(
+            CachedPersonProjection(person_id="3", first_name="Bob", last_name="Smith")
+        )
+
+    def test_get_by_identifier(self, test_domain, seeded_cache):
+        view = test_domain.view_for(CachedPersonProjection)
+        person = view.get("1")
+
+        assert person.first_name == "John"
+        assert person.last_name == "Doe"
+
+    def test_get_nonexistent_raises_not_found(self, test_domain):
+        view = test_domain.view_for(CachedPersonProjection)
+
+        with pytest.raises(ObjectNotFoundError):
+            view.get("nonexistent")
+
+    def test_query_raises_not_supported(self, test_domain):
+        view = test_domain.view_for(CachedPersonProjection)
+
+        with pytest.raises(NotSupportedError, match="cache-backed"):
+            view.query
+
+    def test_find_by_raises_not_supported(self, test_domain):
+        view = test_domain.view_for(CachedPersonProjection)
+
+        with pytest.raises(NotSupportedError, match="cache-backed"):
+            view.find_by(first_name="John")
+
+    def test_count_all(self, test_domain, seeded_cache):
+        view = test_domain.view_for(CachedPersonProjection)
+        assert view.count() == 3
+
+    def test_count_empty(self, test_domain):
+        view = test_domain.view_for(CachedPersonProjection)
+        assert view.count() == 0
+
+    def test_exists_true(self, test_domain, seeded_cache):
+        view = test_domain.view_for(CachedPersonProjection)
+        assert view.exists("1") is True
+
+    def test_exists_false(self, test_domain):
+        view = test_domain.view_for(CachedPersonProjection)
+        assert view.exists("nonexistent") is False
+
+    def test_not_supported_messages_guide_user(self, test_domain):
+        view = test_domain.view_for(CachedPersonProjection)
+
+        with pytest.raises(NotSupportedError, match="get()"):
+            view.query
+
+        with pytest.raises(NotSupportedError, match="get()"):
+            view.find_by(first_name="John")
+
+
+# ---------------------------------------------------------------------------
+# Tests: ReadView and repository_for coexistence
+# ---------------------------------------------------------------------------
+@pytest.mark.database
+@pytest.mark.usefixtures("db")
+class TestReadViewAndRepositoryCoexistence:
+    def test_view_and_repo_see_same_data(self, test_domain, seeded_projections):
+        """Data written via repository_for() is visible through view_for()."""
+        view = test_domain.view_for(PersonProjection)
+        person = view.get("1")
+        assert person.first_name == "John"
+
+    def test_view_and_query_for_see_same_data(self, test_domain, seeded_projections):
+        """view.query and domain.query_for() return the same results."""
+        view = test_domain.view_for(PersonProjection)
+        view_results = view.query.all()
+        query_results = test_domain.query_for(PersonProjection).all()
+
+        assert view_results.total == query_results.total
+
+    def test_repo_writes_visible_through_view(self, test_domain):
+        """Adding data via repo, then reading through view."""
+        repo = test_domain.repository_for(PersonProjection)
+        repo.add(
+            PersonProjection(
+                person_id="99", first_name="New", last_name="Person", age=99
+            )
+        )
+
+        view = test_domain.view_for(PersonProjection)
+        person = view.get("99")
+        assert person.first_name == "New"
+        assert view.count() == 1
+        assert view.exists("99") is True


### PR DESCRIPTION
Introduce a read-only facade over projection data that enforces CQRS read/write separation structurally, not just by convention.

ReadView is a lightweight runtime facade (not a domain element) that wraps the underlying repository or cache and exposes only read operations: get(), find_by(), query (ReadOnlyQuerySet), count(), and exists(). No add(), delete(), or _dao access is exposed.

domain.view_for(ProjectionClass) is the clean entry point, mirroring the existing domain.repository_for() and domain.query_for() patterns.

For cache-backed projections, query and find_by() raise NotSupportedError with a clear message, since caches are key-value stores that don't support filtered queries.

Also fixes a pre-existing bug in Caches.cache_for() where it read meta_.provider (which is None for cache-backed projections) instead of meta_.cache, preventing formally registered cache-backed projections from resolving their cache provider.