### PR TITLE
Add page, page_size, and total_pages properties to ResultSet

### DIFF
--- a/docs/concepts/internals/query-system.md
+++ b/docs/concepts/internals/query-system.md
@@ -309,15 +309,18 @@ structures from leaking into the domain layer:
 ```python
 class ResultSet:
     offset: int          # current page offset
-    limit: int           # requested page size
+    limit: int | None    # requested page size (None = unlimited)
     total: int           # total matching records
     items: list          # entity objects in current page
 
     # Properties
     has_prev → bool      # offset > 0 and items exist
-    has_next → bool      # (offset + limit) < total
+    has_next → bool      # more pages exist (always False when unlimited)
     first → entity|None  # items[0] if items, else None
     last → entity|None   # items[-1] if items, else None
+    page → int           # current page number (1-indexed)
+    page_size → int|None # alias for limit
+    total_pages → int    # math.ceil(total / limit), 0 when empty
 ```
 
 The `all()` method on QuerySet converts raw database results (dicts or model

--- a/docs/guides/change-state/retrieve-aggregates.md
+++ b/docs/guides/change-state/retrieve-aggregates.md
@@ -362,13 +362,16 @@ def get_page(self, page_number, page_size=10):
 
 ### Pagination navigation
 
-The result provides `has_next` and `has_prev` properties for pagination:
+The result provides pagination properties for navigating through pages:
 
 ```python
 result = repository._dao.query.offset(10).limit(10).all()
 
-result.has_next   # True if more pages exist beyond the current one
-result.has_prev   # True if this is not the first page
+result.page        # Current page number (1-indexed)
+result.page_size   # Number of items per page (alias for limit)
+result.total_pages # Total number of pages
+result.has_next    # True if more pages exist beyond the current one
+result.has_prev    # True if this is not the first page
 ```
 
 ## Evaluating a QuerySet
@@ -383,7 +386,7 @@ Evaluation is triggered when you:
 - **Slice**: `queryset[0]` or `queryset[0:5]`
 - Check **containment**: `person in queryset`
 - Access **properties**: `.total`, `.items`, `.first`, `.last`, `.has_next`,
-  `.has_prev`
+  `.has_prev`, `.page`, `.page_size`, `.total_pages`
 
 Once evaluated, results are cached internally. Call `.all()` again to force
 a fresh database query.
@@ -399,6 +402,9 @@ on first access:
 - **`last`** -- last result, or `None` if empty
 - **`has_next`** -- `True` if more pages exist
 - **`has_prev`** -- `True` if previous pages exist
+- **`page`** -- current page number (1-indexed, int)
+- **`page_size`** -- items per page, or `None` when unlimited (alias for `limit`)
+- **`total_pages`** -- total number of pages (0 when no results)
 
 ```shell
 In [1]: query = repository._dao.query.filter(country="CA").order_by("age")
@@ -486,11 +492,15 @@ DAO-specific data structures from leaking into the domain layer.
 - **`last`** -- last item, or `None` if empty
 - **`has_next`** -- `True` if more pages exist beyond the current one
 - **`has_prev`** -- `True` if this is not the first page
+- **`page`** -- current page number (1-indexed)
+- **`page_size`** -- number of items per page (alias for `limit`; `None` when unlimited)
+- **`total_pages`** -- total number of pages (0 when no results)
 
 ### Methods
 
 - **`to_dict()`** -- returns the result as a dictionary with `offset`,
-  `limit`, `total`, and `items` keys.
+  `limit`, `total`, `page`, `page_size`, `total_pages`, `has_next`,
+  `has_prev`, and `items` keys.
 
 A ResultSet also supports `bool()` (truthy if items exist), `iter()` (iterate
 over items), and `len()` (number of items in the current page, not the total).

--- a/docs/guides/getting-started/tutorial/21-query-patterns.md
+++ b/docs/guides/getting-started/tutorial/21-query-patterns.md
@@ -47,9 +47,14 @@ results = domain.query_for(BookCatalog).order_by("author", "-price").all()
 ```python
 # First page (10 items)
 page1 = domain.query_for(BookCatalog).limit(10).offset(0).all()
+page1.page         # 1
+page1.total_pages  # total pages based on matching records
+page1.has_next     # True if more pages exist
 
 # Second page
 page2 = domain.query_for(BookCatalog).limit(10).offset(10).all()
+page2.page         # 2
+page2.has_prev     # True
 ```
 
 ### Chaining

--- a/src/protean/core/queryset.py
+++ b/src/protean/core/queryset.py
@@ -2,6 +2,7 @@
 
 import copy
 import logging
+import math
 from typing import TYPE_CHECKING, Any, Union
 
 from protean.exceptions import NotSupportedError
@@ -469,6 +470,21 @@ class QuerySet:
         """Return True if there are previous values present"""
         return self._data.has_prev
 
+    @property
+    def page(self):
+        """Return the current page number"""
+        return self._data.page
+
+    @property
+    def page_size(self):
+        """Return the page size"""
+        return self._data.page_size
+
+    @property
+    def total_pages(self):
+        """Return the total number of pages"""
+        return self._data.total_pages
+
 
 class ReadOnlyQuerySet(QuerySet):
     """A QuerySet that blocks all mutation operations.
@@ -504,7 +520,7 @@ class ReadOnlyQuerySet(QuerySet):
         )
 
 
-class ResultSet(object):
+class ResultSet:
     """This is an internal helper class returned by DAO query operations.
 
     The purpose of this class is to prevent DAO-specific data structures from leaking into the domain layer.
@@ -512,10 +528,10 @@ class ResultSet(object):
     basic pagination support.
     """
 
-    def __init__(self, offset: int, limit: int, total: int, items: list):
+    def __init__(self, offset: int, limit: int | None, total: int, items: list) -> None:
         # the current offset (zero indexed)
         self.offset = offset
-        # the number of items to be fetched
+        # the number of items to be fetched (None means unlimited)
         self.limit = limit
         # the total number of items matching the query
         self.total = total
@@ -523,47 +539,86 @@ class ResultSet(object):
         self.items = items
 
     @property
-    def has_prev(self):
-        """Is `True` if the results are a subset of all results"""
+    def has_prev(self) -> bool:
+        """Is ``True`` if the results are a subset of all results."""
         return bool(self.items) and self.offset > 0
 
     @property
-    def has_next(self):
-        """Is `True` if more pages exist"""
+    def has_next(self) -> bool:
+        """Is ``True`` if more pages exist beyond the current one."""
+        if self.limit is None:
+            return False
         return (self.offset + self.limit) < self.total
 
     @property
-    def first(self):
-        """Return the first item from results"""
-        if self.items:
-            return self.items[0]
+    def page(self) -> int:
+        """Current page number (1-indexed).
+
+        Returns 1 when ``limit`` is ``None`` (unlimited).
+        """
+        if not self.limit:
+            return 1
+        return self.offset // self.limit + 1
 
     @property
-    def last(self):
-        """Return the last item from results"""
+    def page_size(self) -> int | None:
+        """Number of items per page. Alias for ``limit``.
+
+        Returns ``None`` when no limit is set (unlimited results).
+        """
+        return self.limit
+
+    @property
+    def total_pages(self) -> int:
+        """Total number of pages for the full result set.
+
+        Returns 0 when there are no results, 1 when ``limit`` is ``None``.
+        """
+        if self.total == 0:
+            return 0
+        if not self.limit:
+            return 1
+        return math.ceil(self.total / self.limit)
+
+    @property
+    def first(self) -> Any | None:
+        """Return the first item from results."""
+        if self.items:
+            return self.items[0]
+        return None
+
+    @property
+    def last(self) -> Any | None:
+        """Return the last item from results."""
         if self.items:
             return self.items[-1]
+        return None
 
-    def __bool__(self):
-        """Returns `True` when the resultset is not empty"""
+    def __bool__(self) -> bool:
+        """Returns ``True`` when the resultset is not empty."""
         return bool(self.items)
 
     def __iter__(self):
-        """Returns an iterable on items, to support traversal"""
+        """Returns an iterable on items, to support traversal."""
         return iter(self.items)
 
-    def __len__(self):
-        """Returns number of items in the resultset"""
+    def __len__(self) -> int:
+        """Returns number of items in the resultset."""
         return len(self.items)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<ResultSet: {len(self.items)} items>"
 
-    def to_dict(self):
-        """Return the resultset as a dictionary"""
+    def to_dict(self) -> dict:
+        """Return the resultset as a dictionary."""
         return {
             "offset": self.offset,
             "limit": self.limit,
             "total": self.total,
+            "page": self.page,
+            "page_size": self.page_size,
+            "total_pages": self.total_pages,
+            "has_next": self.has_next,
+            "has_prev": self.has_prev,
             "items": self.items,
         }

--- a/tests/query/test_queryset.py
+++ b/tests/query/test_queryset.py
@@ -643,6 +643,37 @@ class TestCriteriaConstruction:
         results = person_repo._dao.query.raw('{"last_name":"John", "age__in":[3,7]}')
         assert results.total == 2
 
+    def test_page(self, test_domain):
+        """Test page property on QuerySet proxy"""
+        person_repo = test_domain.repository_for(Person)
+
+        person_repo.add(Person(id=2, first_name="Murdock", age=7, last_name="John"))
+        person_repo.add(Person(id=3, first_name="Jean", age=3, last_name="John"))
+        person_repo.add(Person(id=4, first_name="Bart", age=6, last_name="Carrie"))
+
+        query = person_repo._dao.query.offset(2).limit(2)
+        assert query.page == 2
+
+    def test_page_size(self, test_domain):
+        """Test page_size property on QuerySet proxy"""
+        person_repo = test_domain.repository_for(Person)
+
+        person_repo.add(Person(id=2, first_name="Murdock", age=7, last_name="John"))
+
+        query = person_repo._dao.query.limit(5)
+        assert query.page_size == 5
+
+    def test_total_pages(self, test_domain):
+        """Test total_pages property on QuerySet proxy"""
+        person_repo = test_domain.repository_for(Person)
+
+        person_repo.add(Person(id=2, first_name="Murdock", age=7, last_name="John"))
+        person_repo.add(Person(id=3, first_name="Jean", age=3, last_name="John"))
+        person_repo.add(Person(id=4, first_name="Bart", age=6, last_name="Carrie"))
+
+        query = person_repo._dao.query.limit(2)
+        assert query.total_pages == 2
+
 
 # ---------------------------------------------------------------------------
 # Tests: ResultSet
@@ -687,7 +718,17 @@ class TestResultSet:
     def test_to_dict(self):
         rs = ResultSet(offset=5, limit=10, total=20, items=["a"])
         d = rs.to_dict()
-        assert d == {"offset": 5, "limit": 10, "total": 20, "items": ["a"]}
+        assert d == {
+            "offset": 5,
+            "limit": 10,
+            "total": 20,
+            "page": 1,
+            "page_size": 10,
+            "total_pages": 2,
+            "has_next": True,
+            "has_prev": True,
+            "items": ["a"],
+        }
 
     def test_has_prev_true(self):
         rs = ResultSet(offset=10, limit=10, total=20, items=["a"])
@@ -708,6 +749,38 @@ class TestResultSet:
     def test_has_next_false(self):
         rs = ResultSet(offset=10, limit=10, total=20, items=["a"])
         assert rs.has_next is False
+
+    def test_has_next_with_unlimited_limit(self):
+        rs = ResultSet(offset=0, limit=None, total=20, items=["a"])
+        assert rs.has_next is False
+
+    def test_page(self):
+        rs = ResultSet(offset=10, limit=10, total=30, items=["a"])
+        assert rs.page == 2
+
+    def test_page_with_unlimited_limit(self):
+        rs = ResultSet(offset=0, limit=None, total=30, items=["a"])
+        assert rs.page == 1
+
+    def test_page_size(self):
+        rs = ResultSet(offset=0, limit=10, total=20, items=["a"])
+        assert rs.page_size == 10
+
+    def test_page_size_unlimited(self):
+        rs = ResultSet(offset=0, limit=None, total=20, items=["a"])
+        assert rs.page_size is None
+
+    def test_total_pages(self):
+        rs = ResultSet(offset=0, limit=10, total=25, items=["a"])
+        assert rs.total_pages == 3
+
+    def test_total_pages_empty(self):
+        rs = ResultSet(offset=0, limit=10, total=0, items=[])
+        assert rs.total_pages == 0
+
+    def test_total_pages_unlimited(self):
+        rs = ResultSet(offset=0, limit=None, total=50, items=["a"])
+        assert rs.total_pages == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/repository/test_resultset.py
+++ b/tests/repository/test_resultset.py
@@ -52,5 +52,179 @@ class TestResultSet:
             "offset": 0,
             "limit": 10,
             "total": 2,
+            "page": 1,
+            "page_size": 10,
+            "total_pages": 1,
+            "has_next": False,
+            "has_prev": False,
             "items": ["foo", "bar"],
         }
+
+
+class TestPageProperty:
+    """Tests for ResultSet.page — current page number (1-indexed)."""
+
+    def test_page_first_page(self):
+        rs = ResultSet(offset=0, limit=10, total=50, items=["a"])
+        assert rs.page == 1
+
+    def test_page_second_page(self):
+        rs = ResultSet(offset=10, limit=10, total=50, items=["a"])
+        assert rs.page == 2
+
+    def test_page_third_page(self):
+        rs = ResultSet(offset=20, limit=10, total=50, items=["a"])
+        assert rs.page == 3
+
+    def test_page_last_page(self):
+        rs = ResultSet(offset=90, limit=10, total=100, items=["a"])
+        assert rs.page == 10
+
+    def test_page_mid_page_offset(self):
+        """Offset within the first page boundary still returns page 1."""
+        rs = ResultSet(offset=5, limit=10, total=50, items=["a"])
+        assert rs.page == 1
+
+    def test_page_with_unlimited_limit(self):
+        rs = ResultSet(offset=0, limit=None, total=50, items=["a"])
+        assert rs.page == 1
+
+    def test_page_with_offset_and_unlimited_limit(self):
+        rs = ResultSet(offset=5, limit=None, total=50, items=["a"])
+        assert rs.page == 1
+
+    def test_page_empty_results(self):
+        rs = ResultSet(offset=0, limit=10, total=0, items=[])
+        assert rs.page == 1
+
+
+class TestPageSizeProperty:
+    """Tests for ResultSet.page_size — alias for limit."""
+
+    def test_page_size_returns_limit(self):
+        rs = ResultSet(offset=0, limit=10, total=20, items=["a"])
+        assert rs.page_size == 10
+
+    def test_page_size_returns_none_when_unlimited(self):
+        rs = ResultSet(offset=0, limit=None, total=20, items=["a"])
+        assert rs.page_size is None
+
+    def test_page_size_with_large_limit(self):
+        rs = ResultSet(offset=0, limit=1000, total=50, items=["a"])
+        assert rs.page_size == 1000
+
+
+class TestTotalPagesProperty:
+    """Tests for ResultSet.total_pages — total number of pages."""
+
+    def test_total_pages_exact_division(self):
+        rs = ResultSet(offset=0, limit=10, total=30, items=["a"])
+        assert rs.total_pages == 3
+
+    def test_total_pages_with_remainder(self):
+        rs = ResultSet(offset=0, limit=10, total=25, items=["a"])
+        assert rs.total_pages == 3
+
+    def test_total_pages_single_page(self):
+        rs = ResultSet(offset=0, limit=10, total=5, items=["a"])
+        assert rs.total_pages == 1
+
+    def test_total_pages_empty_results(self):
+        rs = ResultSet(offset=0, limit=10, total=0, items=[])
+        assert rs.total_pages == 0
+
+    def test_total_pages_unlimited(self):
+        rs = ResultSet(offset=0, limit=None, total=50, items=["a"])
+        assert rs.total_pages == 1
+
+    def test_total_pages_unlimited_empty(self):
+        rs = ResultSet(offset=0, limit=None, total=0, items=[])
+        assert rs.total_pages == 0
+
+    def test_total_pages_exact_boundary(self):
+        rs = ResultSet(offset=0, limit=10, total=10, items=["a"])
+        assert rs.total_pages == 1
+
+    def test_total_pages_one_over_boundary(self):
+        rs = ResultSet(offset=0, limit=10, total=11, items=["a"])
+        assert rs.total_pages == 2
+
+    def test_total_pages_large_dataset(self):
+        rs = ResultSet(offset=0, limit=100, total=999, items=["a"])
+        assert rs.total_pages == 10
+
+
+class TestHasNextWithUnlimitedLimit:
+    """Tests for the has_next fix when limit is None."""
+
+    def test_has_next_returns_false_when_unlimited(self):
+        rs = ResultSet(offset=0, limit=None, total=50, items=["a"])
+        assert rs.has_next is False
+
+    def test_has_next_returns_false_when_unlimited_with_offset(self):
+        rs = ResultSet(offset=5, limit=None, total=50, items=["a"])
+        assert rs.has_next is False
+
+
+class TestToDictWithPaginationProperties:
+    """Tests for to_dict() including page properties."""
+
+    def test_to_dict_includes_page_properties(self):
+        rs = ResultSet(offset=10, limit=10, total=25, items=["a"])
+        d = rs.to_dict()
+        assert d == {
+            "offset": 10,
+            "limit": 10,
+            "total": 25,
+            "page": 2,
+            "page_size": 10,
+            "total_pages": 3,
+            "has_next": True,
+            "has_prev": True,
+            "items": ["a"],
+        }
+
+    def test_to_dict_with_unlimited_limit(self):
+        rs = ResultSet(offset=0, limit=None, total=50, items=["a", "b"])
+        d = rs.to_dict()
+        assert d["page"] == 1
+        assert d["page_size"] is None
+        assert d["total_pages"] == 1
+        assert d["has_next"] is False
+        assert d["has_prev"] is False
+
+
+class TestCombinedPaginationProperties:
+    """Tests verifying that all pagination properties work together correctly."""
+
+    def test_all_properties_mid_pagination(self):
+        rs = ResultSet(offset=20, limit=10, total=55, items=["a"] * 10)
+        assert rs.page == 3
+        assert rs.page_size == 10
+        assert rs.total_pages == 6
+        assert rs.has_next is True
+        assert rs.has_prev is True
+
+    def test_all_properties_first_page(self):
+        rs = ResultSet(offset=0, limit=10, total=55, items=["a"] * 10)
+        assert rs.page == 1
+        assert rs.page_size == 10
+        assert rs.total_pages == 6
+        assert rs.has_next is True
+        assert rs.has_prev is False
+
+    def test_all_properties_last_page(self):
+        rs = ResultSet(offset=50, limit=10, total=55, items=["a"] * 5)
+        assert rs.page == 6
+        assert rs.page_size == 10
+        assert rs.total_pages == 6
+        assert rs.has_next is False
+        assert rs.has_prev is True
+
+    def test_all_properties_single_item_single_page(self):
+        rs = ResultSet(offset=0, limit=10, total=1, items=["only"])
+        assert rs.page == 1
+        assert rs.page_size == 10
+        assert rs.total_pages == 1
+        assert rs.has_next is False
+        assert rs.has_prev is False


### PR DESCRIPTION
ResultSet now provides computed pagination properties that eliminate manual page calculation in API endpoints:

- `page`: current page number (1-indexed), derived from offset/limit
- `page_size`: alias for limit (None when unlimited)
- `total_pages`: ceil(total/limit), 0 for empty results

Also fixes a bug where `has_next` raised TypeError when limit was None (unlimited queries) — it now correctly returns False.

`to_dict()` includes all pagination metadata (page, page_size, total_pages, has_next, has_prev) alongside the existing offset, limit, total, and items keys.

QuerySet proxies the three new properties, matching the existing pattern for total, items, first, last, has_next, and has_prev.