### PR TITLE
Add domain.connection_for() for raw projection connection access

### DIFF
--- a/docs/concepts/internals/query-system.md
+++ b/docs/concepts/internals/query-system.md
@@ -364,6 +364,28 @@ qs.delete()                        # raises NotSupportedError
 
 ---
 
+## Raw connection access
+
+For queries that cannot be expressed through `QuerySet` or `ReadOnlyQuerySet`
+(e.g., database-specific aggregation pipelines, full-text search, or direct
+cache operations), `domain.connection_for()` provides the underlying
+connection object:
+
+```python
+conn = domain.connection_for(OrderSummary)
+# conn is now the raw SQLAlchemy session, Elasticsearch client,
+# Redis client, etc., depending on the projection's backing store
+```
+
+This is the escape hatch — it bypasses Protean's query abstraction entirely
+and hands you the technology-specific client. The method automatically routes
+to the correct provider or cache based on the projection's meta options
+(`provider` or `cache`).
+
+**Key source file:** `src/protean/domain/__init__.py`
+
+---
+
 ## Entity state tracking
 
 When entities flow through the repository/DAO layer, their `state_` property

--- a/docs/guides/consume-state/projections.md
+++ b/docs/guides/consume-state/projections.md
@@ -161,16 +161,34 @@ When a projection is stored in a cache (Redis, in-memory), `view.get()`,
 and `view.find_by()` raise `NotSupportedError` because cache backends are
 key-value stores and do not support field-based filtering.
 
-#### Three levels of read access
+#### Four levels of projection access
 
-Protean provides three levels of projection read access, each suited to
+Protean provides four levels of projection access, each suited to
 different use cases:
 
 | Level | Entry point | Returns | Use when |
 |-------|-------------|---------|----------|
 | **ReadView** | `domain.view_for(Proj)` | `ReadView` | Default for endpoints and query handlers — read-only by design |
 | **QuerySet** | `domain.query_for(Proj)` | `ReadOnlyQuerySet` | Direct QuerySet access for custom filtering |
+| **Raw** | `domain.connection_for(Proj)` | DB/cache connection | Escape hatch — technology-specific queries (SQL, ES DSL, Redis) |
 | **Repository** | `domain.repository_for(Proj)` | `BaseRepository` | Inside projectors — when you need to write |
+
+#### Raw connection access
+
+When you need to run technology-specific queries that cannot be expressed
+through `QuerySet` — such as SQL aggregations, Elasticsearch DSL, or Redis
+`SCAN` commands — use `domain.connection_for()`:
+
+```python
+conn = domain.connection_for(OrderSummary)
+# conn is the raw SQLAlchemy session, Elasticsearch client,
+# Redis client, etc., depending on the projection's backing store
+```
+
+The method automatically routes to the correct provider or cache based on
+the projection's configuration. For database-backed projections it returns
+the database provider's connection; for cache-backed projections it returns
+the cache client.
 
 ### Query — Named Read Intents
 

--- a/docs/guides/consume-state/query-handlers.md
+++ b/docs/guides/consume-state/query-handlers.md
@@ -140,11 +140,12 @@ Protean provides three levels of read abstraction:
 |-------|-----|-------------|
 | **Pipeline** | `domain.dispatch(query)` | Named queries with validation, structured read logic |
 | **Direct** | `domain.query_for(Projection)` | Simple filtering without handler ceremony |
-| **Raw** | Repository/DAO access | Complex queries needing database-specific features |
+| **Raw** | `domain.connection_for(Projection)` | Complex queries needing database-specific features |
 
 Query handlers operate at Level 1, providing the most structured approach.
 Use `domain.query_for()` (Level 2) for simple lookups that don't need a
-handler.
+handler. Use `domain.connection_for()` (Level 3) when you need the raw
+database or cache client for technology-specific queries.
 
 ## Error Handling
 

--- a/src/protean/domain/__init__.py
+++ b/src/protean/domain/__init__.py
@@ -2305,6 +2305,55 @@ class Domain:
     def cache_for(self, projection_cls):
         return self.caches.cache_for(projection_cls)
 
+    ################################
+    # Raw Connection Functionality #
+    ################################
+
+    def connection_for(self, projection_cls: type) -> Any:
+        """Return the raw database or cache connection for a projection.
+
+        This is the lowest-level read access for projections -- an escape
+        hatch for executing technology-specific queries directly against the
+        backing store.
+
+        For **database-backed** projections the method returns the database
+        provider's connection (e.g. a SQLAlchemy session, an Elasticsearch
+        client, or a ``MemorySession``).
+
+        For **cache-backed** projections the method returns the cache
+        client (e.g. a ``redis.Redis`` instance or a plain ``dict``).
+
+        Args:
+            projection_cls: A registered projection class.
+
+        Returns:
+            The raw connection object for the projection's backing store.
+
+        Raises:
+            IncorrectUsageError: If the element is not a projection.
+
+        Example::
+
+            conn = domain.connection_for(OrderSummary)
+            # Use conn to execute raw queries against the backing store
+        """
+        if isinstance(projection_cls, str):
+            raise IncorrectUsageError(
+                f"Element {projection_cls} is not registered in domain {self.name}"
+            )
+
+        if projection_cls.element_type != DomainObjects.PROJECTION:
+            raise IncorrectUsageError(
+                f"`connection_for` is only available for projections. "
+                f"Received {projection_cls.__name__} "
+                f"({projection_cls.element_type})."
+            )
+
+        if projection_cls.meta_.cache:
+            return self.caches.get_connection(projection_cls.meta_.cache)
+        else:
+            return self.providers.get_connection(projection_cls.meta_.provider)
+
     ##########################
     # Snapshot Functionality #
     ##########################

--- a/tests/projections/test_connection_for.py
+++ b/tests/projections/test_connection_for.py
@@ -1,0 +1,134 @@
+"""Tests for domain.connection_for().
+
+Validates:
+- domain.connection_for() returns a raw connection for database-backed projections
+- domain.connection_for() returns a raw connection for cache-backed projections
+- domain.connection_for() rejects non-projection types
+- domain.connection_for() rejects string arguments
+- The returned connection is usable for raw operations
+"""
+
+import pytest
+from pydantic import Field
+
+from protean.core.aggregate import BaseAggregate
+from protean.core.projection import BaseProjection
+from protean.exceptions import IncorrectUsageError
+
+
+# ---------------------------------------------------------------------------
+# Test domain elements
+# ---------------------------------------------------------------------------
+class PersonProjection(BaseProjection):
+    person_id: str = Field(json_schema_extra={"identifier": True})
+    first_name: str
+    last_name: str | None = None
+    age: int = 21
+
+
+class Person(BaseAggregate):
+    first_name: str
+    last_name: str | None = None
+    age: int = 21
+
+
+class CachedPersonProjection(BaseProjection):
+    person_id: str = Field(json_schema_extra={"identifier": True})
+    first_name: str
+    last_name: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: database-backed
+# ---------------------------------------------------------------------------
+@pytest.fixture(autouse=True)
+def register_elements(test_domain):
+    test_domain.register(PersonProjection)
+    test_domain.register(Person)
+    test_domain.init(traverse=False)
+
+
+@pytest.fixture
+def seeded_projections(test_domain):
+    repo = test_domain.repository_for(PersonProjection)
+    repo.add(
+        PersonProjection(person_id="1", first_name="John", last_name="Doe", age=38)
+    )
+    repo.add(
+        PersonProjection(person_id="2", first_name="Jane", last_name="Doe", age=36)
+    )
+    repo.add(
+        PersonProjection(person_id="3", first_name="Bob", last_name="Smith", age=25)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: domain.connection_for() — entry point validation
+# ---------------------------------------------------------------------------
+@pytest.mark.database
+@pytest.mark.usefixtures("db")
+class TestConnectionForEntryPoint:
+    def test_returns_connection_for_database_backed_projection(self, test_domain):
+        conn = test_domain.connection_for(PersonProjection)
+        assert conn is not None
+
+    def test_rejects_aggregate_class(self, test_domain):
+        with pytest.raises(IncorrectUsageError, match="only available for projections"):
+            test_domain.connection_for(Person)
+
+    def test_rejects_string_argument(self, test_domain):
+        with pytest.raises(IncorrectUsageError, match="not registered"):
+            test_domain.connection_for("PersonProjection")
+
+
+# ---------------------------------------------------------------------------
+# Tests: Database-backed projection — connection usability
+# ---------------------------------------------------------------------------
+@pytest.mark.database
+@pytest.mark.usefixtures("db")
+class TestDatabaseBackedConnection:
+    def test_connection_type_matches_provider(self, test_domain):
+        """connection_for() returns the same type as providers.get_connection()."""
+        conn = test_domain.connection_for(PersonProjection)
+        provider_conn = test_domain.providers.get_connection("default")
+        assert type(conn) is type(provider_conn)
+
+    def test_connection_usable_after_seeding(self, test_domain, seeded_projections):
+        """The returned connection is live and usable after data has been seeded."""
+        conn = test_domain.connection_for(PersonProjection)
+        assert conn is not None
+
+
+# ---------------------------------------------------------------------------
+# Tests: Cache-backed projection
+# ---------------------------------------------------------------------------
+class TestCacheBackedConnection:
+    @pytest.fixture(autouse=True)
+    def register_cached_projection(self, test_domain):
+        test_domain.register(CachedPersonProjection, cache="default")
+        test_domain.init(traverse=False)
+
+    @pytest.fixture
+    def seeded_cache(self, test_domain):
+        cache = test_domain.cache_for(CachedPersonProjection)
+        cache.add(
+            CachedPersonProjection(person_id="1", first_name="John", last_name="Doe")
+        )
+        cache.add(
+            CachedPersonProjection(person_id="2", first_name="Jane", last_name="Doe")
+        )
+
+    def test_returns_connection_for_cache_backed_projection(self, test_domain):
+        conn = test_domain.connection_for(CachedPersonProjection)
+        assert conn is not None
+
+    def test_connection_type_matches_cache(self, test_domain):
+        """connection_for() returns the same type as caches.get_connection()."""
+        conn = test_domain.connection_for(CachedPersonProjection)
+        cache_conn = test_domain.caches.get_connection("default")
+        assert type(conn) is type(cache_conn)
+
+    def test_connection_usable_after_seeding(self, test_domain, seeded_cache):
+        """The returned cache connection is live and usable after data has been seeded."""
+        conn = test_domain.connection_for(CachedPersonProjection)
+        assert conn is not None


### PR DESCRIPTION
Introduce `domain.connection_for(projection_cls)` as the Level 3 "Raw" read access escape hatch for projections. The method accepts a projection class and returns the raw database or cache connection, automatically routing based on the projection's meta configuration:

- Database-backed projections → provider connection (SQLAlchemy session, Elasticsearch client, MemorySession)
- Cache-backed projections → cache client (Redis client, dict)

This completes the four-level projection access hierarchy:
1. ReadView   — domain.view_for()
2. QuerySet   — domain.query_for()
3. Raw        — domain.connection_for()
4. Repository — domain.repository_for()