### PR TITLE
DomainValidator changes

### DIFF
--- a/src/protean/domain/__init__.py
+++ b/src/protean/domain/__init__.py
@@ -531,46 +531,6 @@ class Domain:
         # Initialize adapters after loading domain
         self._initialize()
 
-        # Validate outbox / subscription-type consistency
-        subscription_type = self.config.get("server", {}).get(
-            "default_subscription_type", "event_store"
-        )
-        if (
-            self.config.get("enable_outbox", False)
-            and subscription_type == "event_store"
-        ):
-            raise ConfigurationError(
-                "Configuration conflict: 'enable_outbox' is True but "
-                "'server.default_subscription_type' is 'event_store'. "
-                "When outbox is enabled, subscription type must be 'stream' "
-                "so that subscriptions read from the broker where the outbox publishes. "
-                "Either set server.default_subscription_type = 'stream' or remove enable_outbox."
-            )
-
-        # Validate priority lanes configuration
-        lanes_config = self.config.get("server", {}).get("priority_lanes", {})
-        if lanes_config:
-            enabled = lanes_config.get("enabled", False)
-            if not isinstance(enabled, bool):
-                raise ConfigurationError(
-                    f"server.priority_lanes.enabled must be a bool, "
-                    f"got {type(enabled).__name__}: {enabled!r}"
-                )
-
-            threshold = lanes_config.get("threshold", 0)
-            if not isinstance(threshold, (int, float)) or isinstance(threshold, bool):
-                raise ConfigurationError(
-                    f"server.priority_lanes.threshold must be an integer, "
-                    f"got {type(threshold).__name__}: {threshold!r}"
-                )
-
-            suffix = lanes_config.get("backfill_suffix", "backfill")
-            if not isinstance(suffix, str) or not suffix.strip():
-                raise ConfigurationError(
-                    f"server.priority_lanes.backfill_suffix must be a non-empty string, "
-                    f"got {type(suffix).__name__}: {suffix!r}"
-                )
-
         # Initialize outbox DAOs for all providers
         if self.has_outbox:
             self._initialize_outbox()

--- a/src/protean/domain/validation.py
+++ b/src/protean/domain/validation.py
@@ -114,6 +114,9 @@ class DomainValidator:
         Called just before the domain is activated.  Each private method
         is responsible for one category of validation, making it easier
         to test and extend.
+
+        Raises on the first error encountered (fail-fast behavior used
+        by ``Domain.init()``).
         """
         self._validate_identity_config()
         self._validate_association_fields()
@@ -122,6 +125,54 @@ class DomainValidator:
         self._validate_projector_associations()
         self._validate_query_associations()
         self._validate_query_handler_associations()
+        self._validate_outbox_subscription_consistency()
+        self._validate_priority_lanes_config()
+        self._warn_unhandled_commands()
+        self._warn_missing_apply_handlers()
+        self._warn_published_events_without_external_brokers()
+
+    def validate_all(self) -> None:
+        """Run all domain validation checks, collecting every issue.
+
+        Unlike :meth:`validate`, this method does **not** abort on the
+        first error.  Each validation is wrapped in a try/except so that
+        all errors are captured in :attr:`errors` and all warnings in
+        :attr:`warnings`.  This is the entry point used by
+        ``Domain.check()`` and the ``protean check`` CLI.
+        """
+        self.reset()
+
+        validators = [
+            self._validate_identity_config,
+            self._validate_association_fields,
+            self._validate_event_sourced_aggregates,
+            self._validate_entity_providers,
+            self._validate_projector_associations,
+            self._validate_query_associations,
+            self._validate_query_handler_associations,
+            self._validate_outbox_subscription_consistency,
+            self._validate_priority_lanes_config,
+        ]
+
+        for validator_fn in validators:
+            try:
+                validator_fn()
+            except (ConfigurationError, IncorrectUsageError) as exc:
+                raw = exc.args[0] if exc.args else str(exc)
+                # Some validators pass a dict (e.g. {"element": "..."})
+                message = (
+                    raw.get("element", str(raw)) if isinstance(raw, dict) else str(raw)
+                )
+                self._errors.append(
+                    {
+                        "code": type(exc).__name__,
+                        "element": validator_fn.__name__,
+                        "level": "error",
+                        "message": message,
+                    }
+                )
+
+        # Warning methods never raise — they always collect
         self._warn_unhandled_commands()
         self._warn_missing_apply_handlers()
         self._warn_published_events_without_external_brokers()
@@ -260,6 +311,51 @@ class DomainValidator:
                         f"`{qh_record.cls.meta_.part_of.__name__}` is not a Projection, "
                         f"or is not registered in domain {self._domain.name}"
                     )
+
+    def _validate_outbox_subscription_consistency(self) -> None:
+        """Check that outbox and subscription type config are compatible."""
+        domain = self._domain
+        subscription_type = domain.config.get("server", {}).get(
+            "default_subscription_type", "event_store"
+        )
+        if (
+            domain.config.get("enable_outbox", False)
+            and subscription_type == "event_store"
+        ):
+            raise ConfigurationError(
+                "Configuration conflict: 'enable_outbox' is True but "
+                "'server.default_subscription_type' is 'event_store'. "
+                "When outbox is enabled, subscription type must be 'stream' "
+                "so that subscriptions read from the broker where the outbox publishes. "
+                "Either set server.default_subscription_type = 'stream' or remove enable_outbox."
+            )
+
+    def _validate_priority_lanes_config(self) -> None:
+        """Check that priority lanes configuration values are well-typed."""
+        lanes_config = self._domain.config.get("server", {}).get("priority_lanes", {})
+        if not lanes_config:
+            return
+
+        enabled = lanes_config.get("enabled", False)
+        if not isinstance(enabled, bool):
+            raise ConfigurationError(
+                f"server.priority_lanes.enabled must be a bool, "
+                f"got {type(enabled).__name__}: {enabled!r}"
+            )
+
+        threshold = lanes_config.get("threshold", 0)
+        if not isinstance(threshold, (int, float)) or isinstance(threshold, bool):
+            raise ConfigurationError(
+                f"server.priority_lanes.threshold must be an integer, "
+                f"got {type(threshold).__name__}: {threshold!r}"
+            )
+
+        suffix = lanes_config.get("backfill_suffix", "backfill")
+        if not isinstance(suffix, str) or not suffix.strip():
+            raise ConfigurationError(
+                f"server.priority_lanes.backfill_suffix must be a non-empty string, "
+                f"got {type(suffix).__name__}: {suffix!r}"
+            )
 
     def _warn_unhandled_commands(self) -> None:
         """Warn about registered Commands that have no handler."""

--- a/tests/domain/test_domain_validation.py
+++ b/tests/domain/test_domain_validation.py
@@ -660,3 +660,198 @@ class TestReset:
         test_domain._validator.reset()
         assert test_domain._validator.warnings == []
         assert test_domain._validator.errors == []
+
+
+# ─── Config validations (extracted from Domain.init()) ───────────────
+
+
+class TestValidateOutboxSubscriptionConsistency:
+    """Validate that outbox + event_store subscription type is rejected."""
+
+    @pytest.mark.no_test_domain
+    def test_outbox_with_event_store_subscription_raises_error(self):
+        domain = Domain(__name__, "TestOutbox")
+        domain.config["enable_outbox"] = True
+        domain.config["server"] = {"default_subscription_type": "event_store"}
+
+        domain.register(Account)
+
+        with pytest.raises(ConfigurationError, match="Configuration conflict"):
+            domain.init(traverse=False)
+
+    @pytest.mark.no_test_domain
+    def test_outbox_with_stream_subscription_passes(self):
+        domain = Domain(__name__, "TestOutbox")
+        domain.config["enable_outbox"] = True
+        domain.config["server"] = {"default_subscription_type": "stream"}
+
+        domain.register(Account)
+        domain.init(traverse=False)  # Should not raise
+
+    def test_no_outbox_passes(self, test_domain):
+        test_domain.register(Account)
+        test_domain.init(traverse=False)  # Should not raise
+
+
+class TestValidatePriorityLanesConfig:
+    """Validate priority lanes configuration type checks."""
+
+    @pytest.mark.no_test_domain
+    def test_enabled_must_be_bool(self):
+        domain = Domain(__name__, "TestLanes")
+        domain.config["server"] = {"priority_lanes": {"enabled": "yes"}}
+
+        domain.register(Account)
+
+        with pytest.raises(ConfigurationError, match="must be a bool"):
+            domain.init(traverse=False)
+
+    @pytest.mark.no_test_domain
+    def test_threshold_must_be_numeric(self):
+        domain = Domain(__name__, "TestLanes")
+        domain.config["server"] = {
+            "priority_lanes": {"enabled": True, "threshold": "high"}
+        }
+
+        domain.register(Account)
+
+        with pytest.raises(ConfigurationError, match="must be an integer"):
+            domain.init(traverse=False)
+
+    @pytest.mark.no_test_domain
+    def test_backfill_suffix_must_be_nonempty_string(self):
+        domain = Domain(__name__, "TestLanes")
+        domain.config["server"] = {
+            "priority_lanes": {"enabled": True, "threshold": 100, "backfill_suffix": ""}
+        }
+
+        domain.register(Account)
+
+        with pytest.raises(ConfigurationError, match="non-empty string"):
+            domain.init(traverse=False)
+
+    @pytest.mark.no_test_domain
+    def test_valid_priority_lanes_config_passes(self):
+        domain = Domain(__name__, "TestLanes")
+        domain.config["server"] = {
+            "priority_lanes": {
+                "enabled": True,
+                "threshold": 100,
+                "backfill_suffix": "backfill",
+            }
+        }
+
+        domain.register(Account)
+        domain.init(traverse=False)  # Should not raise
+
+
+# ─── validate_all() ──────────────────────────────────────────────────
+
+
+class TestValidateAll:
+    """Verify that validate_all() collects all errors without aborting."""
+
+    @pytest.mark.no_test_domain
+    def test_collects_multiple_errors(self):
+        """Multiple broken elements → validate_all() collects all errors."""
+        domain = Domain(__name__, "TestMultiError")
+        domain.config["identity_strategy"] = "function"
+        # No identity function → error from _validate_identity_config
+        domain.config["enable_outbox"] = True
+        domain.config["server"] = {"default_subscription_type": "event_store"}
+        # outbox + event_store → error from _validate_outbox_subscription_consistency
+
+        domain.register(Account)
+        # Run the init steps that precede validation
+        domain._resolve_references()
+        domain._validator.check_unresolved_references()
+        domain._assign_aggregate_clusters()
+        domain._set_aggregate_cluster_options()
+        domain._generate_fact_event_classes()
+        domain._set_and_record_event_and_command_type()
+        domain._build_upcaster_chains()
+        domain._setup_command_handlers()
+        domain._setup_event_handlers()
+        domain._setup_projectors()
+        domain._setup_process_managers()
+        domain._set_query_type()
+        domain._setup_query_handlers()
+
+        domain._validator.validate_all()
+
+        errors = domain._validator.errors
+        assert len(errors) >= 2
+        codes = {e["code"] for e in errors}
+        assert "ConfigurationError" in codes
+
+    @pytest.mark.no_test_domain
+    def test_collects_warnings_alongside_errors(self):
+        """validate_all() collects both errors and warnings."""
+        domain = Domain(__name__, "TestMixed")
+        domain.config["identity_strategy"] = "function"
+        # No identity function → error
+
+        domain.register(Account)
+        domain.register(CreateAccount, part_of=Account)
+        # Unhandled command → warning
+
+        domain._resolve_references()
+        domain._validator.check_unresolved_references()
+        domain._assign_aggregate_clusters()
+        domain._set_aggregate_cluster_options()
+        domain._generate_fact_event_classes()
+        domain._set_and_record_event_and_command_type()
+        domain._build_upcaster_chains()
+        domain._setup_command_handlers()
+        domain._setup_event_handlers()
+        domain._setup_projectors()
+        domain._setup_process_managers()
+        domain._set_query_type()
+        domain._setup_query_handlers()
+
+        domain._validator.validate_all()
+
+        assert len(domain._validator.errors) >= 1
+        assert len(domain._validator.warnings) >= 1
+        assert domain._validator.warnings[0]["code"] == "UNUSED_COMMAND"
+
+    def test_validate_still_raises_on_first_error(self, test_domain):
+        """validate() (not validate_all) still raises on first error."""
+        test_domain.config["identity_strategy"] = "function"
+        # No identity function set
+
+        test_domain.register(Account)
+
+        with pytest.raises(ConfigurationError, match="no Identity Function"):
+            test_domain.init(traverse=False)
+
+    def test_clean_domain_has_no_errors(self, test_domain):
+        """A valid domain has empty errors after validate_all()."""
+
+        class Handler(BaseCommandHandler):
+            @handle(CreateAccount)
+            def create(self, command: CreateAccount) -> None:
+                pass
+
+        test_domain.register(Account)
+        test_domain.register(CreateAccount, part_of=Account)
+        test_domain.register(Handler, part_of=Account)
+        test_domain.init(traverse=False)
+
+        test_domain._validator.validate_all()
+        assert test_domain._validator.errors == []
+        assert test_domain._validator.warnings == []
+
+    def test_validate_all_resets_before_collecting(self, test_domain):
+        """validate_all() clears prior state before collecting."""
+        test_domain.register(Account)
+        test_domain.register(CreateAccount, part_of=Account)
+        test_domain.init(traverse=False)
+
+        # First call collects a warning
+        test_domain._validator.validate_all()
+        assert len(test_domain._validator.warnings) == 1
+
+        # Second call should reset and re-collect (not double)
+        test_domain._validator.validate_all()
+        assert len(test_domain._validator.warnings) == 1


### PR DESCRIPTION
- **Structured warning collection**: `DomainValidator` now collects warnings as structured dicts (`{code, element, level, message}`) matching the IR diagnostic format, accessible via the `warnings` property. All 3 `_warn_*` methods collect AND continue logging for backward compat. Codes: `UNUSED_COMMAND`, `ES_EVENT_MISSING_APPLY`, `PUBLISHED_NO_EXTERNAL_BROKER`.
- **Structured error collection**: Added `_errors` list, `errors` property, and `reset()` method to clear both collections.
- **Config validation extraction**: Moved outbox/subscription-type consistency check and priority lanes config validation from inline in `Domain.init()` into DomainValidator methods (`_validate_outbox_subscription_consistency`, `_validate_priority_lanes_config`).
- **`validate_all()` method**: Runs every validation wrapped in try/except, collecting all errors and warnings instead of aborting on the first. This is the entry point for the upcoming `Domain.check()` and `protean check` CLI.

Closes #703
