### PR TITLE
Domain.check() and `protean check` CLI command

### DIFF
--- a/src/protean/cli/__init__.py
+++ b/src/protean/cli/__init__.py
@@ -21,6 +21,7 @@ import typer
 from rich import print
 from typing_extensions import Annotated
 
+from protean.cli.check import check
 from protean.cli.database import app as db_app
 from protean.cli.dlq import app as dlq_app
 from protean.cli.docs import app as docs_app
@@ -45,6 +46,7 @@ logger = get_logger(__name__)
 #   `no_args_is_help=True` will show the help message when no arguments are passed
 app = typer.Typer(no_args_is_help=True)
 
+app.command()(check)
 app.command()(new)
 app.command()(observatory)
 app.command()(shell)

--- a/src/protean/cli/check.py
+++ b/src/protean/cli/check.py
@@ -1,0 +1,126 @@
+"""CLI command for ``protean check`` — domain health validation.
+
+Usage::
+
+    # Rich output (default)
+    protean check --domain=my_app
+
+    # JSON output (CI-friendly)
+    protean check --domain=my_app --format=json
+
+Exit codes:
+    0 — clean (no errors, warnings, or diagnostics)
+    1 — errors found
+    2 — warnings or diagnostics only (no errors)
+"""
+
+import json
+
+import typer
+from rich import print
+from rich.console import Console
+from typing_extensions import Annotated
+
+from protean.exceptions import NoDomainException
+from protean.utils.domain_discovery import derive_domain
+from protean.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+_CONSOLE = Console()
+
+
+def check(
+    domain: Annotated[
+        str,
+        typer.Option(
+            "--domain",
+            "-d",
+            help="Path to the domain module (e.g. 'my_app.domain')",
+        ),
+    ] = ".",
+    format: Annotated[
+        str,
+        typer.Option(
+            "--format",
+            "-f",
+            help="Output format: 'rich' (default) or 'json'",
+        ),
+    ] = "rich",
+) -> None:
+    """Validate a Protean domain and report errors, warnings, and diagnostics."""
+    try:
+        derived_domain = derive_domain(domain)
+    except NoDomainException as exc:
+        msg = f"Error loading Protean domain: {exc.args[0]}"
+        print(f"[red]{msg}[/red]")
+        logger.error(msg)
+        raise typer.Exit(code=1)
+
+    assert derived_domain is not None
+
+    result = derived_domain.check()
+
+    if format == "json":
+        typer.echo(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        _print_rich(result)
+
+    # Exit codes: 0=clean, 1=errors, 2=warnings/diagnostics only
+    if result["counts"]["errors"] > 0:
+        raise typer.Exit(code=1)
+    elif result["counts"]["warnings"] > 0 or result["counts"]["diagnostics"] > 0:
+        raise typer.Exit(code=2)
+
+
+def _print_rich(result: dict) -> None:
+    """Print a rich-formatted check report to the terminal."""
+    domain_name = result["domain"]
+    status = result["status"]
+    counts = result["counts"]
+
+    # Status line
+    status_style = {
+        "pass": "[bold green]PASS[/bold green]",
+        "warn": "[bold yellow]WARN[/bold yellow]",
+        "fail": "[bold red]FAIL[/bold red]",
+    }
+    print(f"\n  Domain: [bold]{domain_name}[/bold]  {status_style.get(status, status)}")
+
+    # Counts summary
+    parts = []
+    if counts["errors"]:
+        parts.append(f"[red]{counts['errors']} error(s)[/red]")
+    if counts["warnings"]:
+        parts.append(f"[yellow]{counts['warnings']} warning(s)[/yellow]")
+    if counts["diagnostics"]:
+        parts.append(f"[cyan]{counts['diagnostics']} diagnostic(s)[/cyan]")
+    if parts:
+        print(f"  {', '.join(parts)}")
+
+    # Errors
+    if result["errors"]:
+        print(f"\n  [bold red]Errors ({counts['errors']}):[/bold red]")
+        for err in result["errors"]:
+            print(f"    [red]✗[/red] {err['message']}")
+
+    # Warnings
+    if result["warnings"]:
+        print(f"\n  [bold yellow]Warnings ({counts['warnings']}):[/bold yellow]")
+        for warn in result["warnings"]:
+            code = warn.get("code", "")
+            prefix = f"[dim]{code}:[/dim] " if code else ""
+            print(f"    [yellow]![/yellow] {prefix}{warn['message']}")
+
+    # Diagnostics (from IR)
+    if result["diagnostics"]:
+        print(f"\n  [bold cyan]Diagnostics ({counts['diagnostics']}):[/bold cyan]")
+        for diag in result["diagnostics"]:
+            code = diag.get("code", "")
+            prefix = f"[dim]{code}:[/dim] " if code else ""
+            print(f"    [cyan]·[/cyan] {prefix}{diag['message']}")
+
+    if status == "pass":
+        print("\n  [green]All checks passed.[/green]")
+
+    print()

--- a/src/protean/domain/__init__.py
+++ b/src/protean/domain/__init__.py
@@ -460,27 +460,18 @@ class Domain:
         """
         return underscore(parameterize(transliterate(self.name)))
 
-    def init(self, traverse=True):  # noqa: C901
-        """Parse the domain folder, and attach elements dynamically to the domain.
+    def _prepare(self, traverse: bool = True, validate: bool = True) -> None:
+        """Resolve references, wire handlers, and optionally validate.
 
-        Protean parses all files in the domain file's folder, as well as under it,
-        to load elements. So, all domain files are to be nested under the file contain
-        the domain definition.
+        This is the shared preparation sequence used by both :meth:`init`
+        (which validates fail-fast and initializes adapters) and :meth:`check`
+        (which skips fail-fast validation and uses ``validate_all()`` instead).
 
-        One can use the `traverse` flag to control this functionality, `True` by default.
-
-        When enabled, Protean is responsible for loading domain elements and ensuring
-        all functionality is activated.
-
-        The developer is responsible for activating functionality manually when
-        autoloading is disabled. Element activation can be done by importing them
-        in central areas of domain execution, like Application Services.
-
-        For example, asynchronous aspects of a domain like its Subscribers and
-        Event Handlers should be imported in their relevant Application Services
-        and Aggregates.
-
-        This method bubbles up circular import issues, if present, in the domain code.
+        Args:
+            traverse: Whether to auto-discover domain elements from files.
+            validate: Whether to run fail-fast validation at the end.
+                Set to ``False`` when the caller will run ``validate_all()``
+                separately (e.g. :meth:`check`).
         """
         if traverse is True:
             self._traverse()
@@ -525,8 +516,33 @@ class Domain:
         # Parse and setup handler methods in Query Handlers
         self._setup_query_handlers()
 
-        # Run Validations
-        self._validate_domain()
+        # Run fail-fast validations (skipped by check())
+        if validate:
+            self._validate_domain()
+
+    def init(self, traverse=True):  # noqa: C901
+        """Parse the domain folder, and attach elements dynamically to the domain.
+
+        Protean parses all files in the domain file's folder, as well as under it,
+        to load elements. So, all domain files are to be nested under the file contain
+        the domain definition.
+
+        One can use the `traverse` flag to control this functionality, `True` by default.
+
+        When enabled, Protean is responsible for loading domain elements and ensuring
+        all functionality is activated.
+
+        The developer is responsible for activating functionality manually when
+        autoloading is disabled. Element activation can be done by importing them
+        in central areas of domain execution, like Application Services.
+
+        For example, asynchronous aspects of a domain like its Subscribers and
+        Event Handlers should be imported in their relevant Application Services
+        and Aggregates.
+
+        This method bubbles up circular import issues, if present, in the domain code.
+        """
+        self._prepare(traverse=traverse)
 
         # Initialize adapters after loading domain
         self._initialize()
@@ -534,6 +550,72 @@ class Domain:
         # Initialize outbox DAOs for all providers
         if self.has_outbox:
             self._initialize_outbox()
+
+    def check(self, traverse: bool = True) -> dict[str, Any]:
+        """Validate the domain and return a structured diagnostic report.
+
+        Unlike :meth:`init`, this method does **not** initialize adapters —
+        it only resolves references, wires handlers, and runs every validation
+        check (collecting all issues instead of failing on the first one).
+
+        If no fatal errors are found, the IR is also built so that IR-level
+        diagnostics (e.g. ``UNHANDLED_EVENT``) can be included.
+
+        Returns a dict with the following structure::
+
+            {
+                "domain": "<domain name>",
+                "status": "pass" | "warn" | "fail",
+                "errors": [...],       # from validate_all()
+                "warnings": [...],     # from validate_all()
+                "diagnostics": [...],  # from IR builder (if no errors)
+                "counts": {
+                    "errors": int,
+                    "warnings": int,
+                    "diagnostics": int,
+                },
+            }
+        """
+        self._prepare(traverse=traverse, validate=False)
+
+        # Run the collect-all validator (does not raise)
+        self._validator.validate_all()
+
+        errors = self._validator.errors
+        warnings = self._validator.warnings
+        diagnostics: list[dict[str, str]] = []
+
+        # Build IR for additional diagnostics only if no fatal errors
+        if not errors:
+            try:
+                ir = self.to_ir()
+                diagnostics = ir.get("diagnostics", [])
+            except Exception:
+                pass
+
+        total_errors = len(errors)
+        total_warnings = len(warnings)
+        total_diagnostics = len(diagnostics)
+
+        if total_errors > 0:
+            status = "fail"
+        elif total_warnings > 0 or total_diagnostics > 0:
+            status = "warn"
+        else:
+            status = "pass"
+
+        return {
+            "domain": self.name,
+            "status": status,
+            "errors": errors,
+            "warnings": warnings,
+            "diagnostics": diagnostics,
+            "counts": {
+                "errors": total_errors,
+                "warnings": total_warnings,
+                "diagnostics": total_diagnostics,
+            },
+        }
 
     def _traverse(self):
         # Standard Library Imports

--- a/tests/cli/test_check.py
+++ b/tests/cli/test_check.py
@@ -1,0 +1,81 @@
+"""Tests for the ``protean check`` CLI command.
+
+Covers exit codes, output formats, and error handling.
+"""
+
+import json
+
+import pytest
+
+from typer.testing import CliRunner
+
+from protean.cli import app
+
+runner = CliRunner()
+
+
+@pytest.mark.no_test_domain
+class TestCheckCleanDomain:
+    """A clean domain exits 0 with PASS status."""
+
+    def test_rich_output_exit_code_0(self):
+        result = runner.invoke(
+            app,
+            ["check", "-d", "tests/support/domains/test19/domain19.py:domain"],
+        )
+        assert result.exit_code == 0
+        assert "PASS" in result.output
+
+    def test_json_output_exit_code_0(self):
+        result = runner.invoke(
+            app,
+            [
+                "check",
+                "-d",
+                "tests/support/domains/test19/domain19.py:domain",
+                "-f",
+                "json",
+            ],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["status"] == "pass"
+        assert data["counts"]["errors"] == 0
+
+
+@pytest.mark.no_test_domain
+class TestCheckDomainLoadFailure:
+    """Invalid domain path produces an error and non-zero exit."""
+
+    def test_bad_domain_path(self):
+        result = runner.invoke(app, ["check", "-d", "nonexistent.module"])
+        assert result.exit_code != 0
+        assert "Error" in result.output
+
+
+@pytest.mark.no_test_domain
+class TestCheckJsonStructure:
+    """JSON output has the expected structure."""
+
+    def test_json_has_expected_keys(self):
+        result = runner.invoke(
+            app,
+            [
+                "check",
+                "-d",
+                "tests/support/domains/test19/domain19.py:domain",
+                "-f",
+                "json",
+            ],
+        )
+        data = json.loads(result.output)
+        expected_keys = {
+            "domain",
+            "status",
+            "errors",
+            "warnings",
+            "diagnostics",
+            "counts",
+        }
+        assert set(data.keys()) == expected_keys
+        assert set(data["counts"].keys()) == {"errors", "warnings", "diagnostics"}

--- a/tests/domain/test_domain_check.py
+++ b/tests/domain/test_domain_check.py
@@ -1,0 +1,224 @@
+"""Tests for Domain.check() — the structured diagnostic report method.
+
+Domain.check() runs all init steps (via _prepare()) and all validation
+checks (via validate_all()), then builds the IR for additional diagnostics.
+It returns a structured dict with errors, warnings, diagnostics, and counts.
+"""
+
+import pytest
+
+from protean.core.aggregate import BaseAggregate
+from protean.core.command import BaseCommand
+from protean.core.command_handler import BaseCommandHandler
+from protean.core.entity import BaseEntity
+from protean.core.event import BaseEvent
+from protean.domain import Domain
+from protean.fields import HasOne, String
+from protean.utils.mixins import handle
+
+
+# ─── Element definitions ────────────────────────────────────────────────
+
+
+class Order(BaseAggregate):
+    name: String(required=True)
+
+
+class OrderPlaced(BaseEvent):
+    name: String(required=True)
+
+
+class PlaceOrder(BaseCommand):
+    name: String(required=True)
+
+
+class PlaceOrderHandler(BaseCommandHandler):
+    @handle(PlaceOrder)
+    def handle_place_order(self, command):
+        pass
+
+
+# ─── Tests ──────────────────────────────────────────────────────────────
+
+
+class TestDomainCheckClean:
+    """A fully wired domain returns status=pass with no issues."""
+
+    @pytest.mark.no_test_domain
+    def test_clean_domain_returns_pass(self):
+        domain = Domain(name="CleanDomain", root_path=__file__)
+        domain.register(Order)
+        domain.register(PlaceOrder, part_of=Order)
+        domain.register(PlaceOrderHandler, part_of=Order)
+
+        result = domain.check(traverse=False)
+
+        assert result["domain"] == "CleanDomain"
+        assert result["status"] == "pass"
+        assert result["errors"] == []
+        assert result["warnings"] == []
+        assert result["counts"]["errors"] == 0
+        assert result["counts"]["warnings"] == 0
+
+    @pytest.mark.no_test_domain
+    def test_check_returns_expected_keys(self):
+        domain = Domain(name="KeyCheck", root_path=__file__)
+        domain.register(Order)
+        result = domain.check(traverse=False)
+
+        expected_keys = {
+            "domain",
+            "status",
+            "errors",
+            "warnings",
+            "diagnostics",
+            "counts",
+        }
+        assert set(result.keys()) == expected_keys
+        assert set(result["counts"].keys()) == {"errors", "warnings", "diagnostics"}
+
+
+class TestDomainCheckWarnings:
+    """Domains with warnings but no errors return status=warn."""
+
+    @pytest.mark.no_test_domain
+    def test_unused_command_produces_warning(self):
+        domain = Domain(name="WarnDomain", root_path=__file__)
+        domain.register(Order)
+        domain.register(PlaceOrder, part_of=Order)
+        # No handler registered — command is unused
+
+        result = domain.check(traverse=False)
+
+        assert result["status"] == "warn"
+        assert result["errors"] == []
+        assert result["counts"]["warnings"] > 0
+
+        codes = [w["code"] for w in result["warnings"]]
+        assert "UNUSED_COMMAND" in codes
+
+    @pytest.mark.no_test_domain
+    def test_es_event_missing_apply_produces_warning(self):
+        class ESAggregate(BaseAggregate):
+            name: String(required=True)
+
+        class ESEvent(BaseEvent):
+            name: String(required=True)
+
+        domain = Domain(name="ESWarnDomain", root_path=__file__)
+        domain.register(ESAggregate, is_event_sourced=True)
+        domain.register(ESEvent, part_of=ESAggregate)
+
+        result = domain.check(traverse=False)
+
+        assert result["status"] == "warn"
+        codes = [w["code"] for w in result["warnings"]]
+        assert "ES_EVENT_MISSING_APPLY" in codes
+
+
+class TestDomainCheckErrors:
+    """Domains with structural errors return status=fail."""
+
+    @pytest.mark.no_test_domain
+    def test_identity_strategy_error(self):
+        domain = Domain(name="ErrDomain", root_path=__file__)
+        domain.config["identity_strategy"] = "function"
+        domain.register(Order)
+
+        result = domain.check(traverse=False)
+
+        assert result["status"] == "fail"
+        assert result["counts"]["errors"] > 0
+        assert any("Identity Strategy" in e["message"] for e in result["errors"])
+
+    @pytest.mark.no_test_domain
+    def test_cross_aggregate_has_one_error(self):
+        class Inventory(BaseAggregate):
+            name: String()
+
+        class InventoryItem(BaseEntity):
+            sku: String()
+
+        class BadAggregate(BaseAggregate):
+            name: String()
+            item: HasOne("InventoryItem")
+
+        domain = Domain(name="CrossAggDomain", root_path=__file__)
+        domain.register(Inventory)
+        domain.register(InventoryItem, part_of=Inventory)
+        domain.register(BadAggregate)
+
+        result = domain.check(traverse=False)
+
+        assert result["status"] == "fail"
+        assert result["counts"]["errors"] > 0
+
+    @pytest.mark.no_test_domain
+    def test_errors_and_warnings_both_collected(self):
+        """When errors and warnings coexist, status is fail and both are populated."""
+        domain = Domain(name="MixedDomain", root_path=__file__)
+        domain.config["identity_strategy"] = "function"
+        domain.register(Order)
+        domain.register(PlaceOrder, part_of=Order)
+        # No handler → warning; identity_strategy=function without function → error
+
+        result = domain.check(traverse=False)
+
+        assert result["status"] == "fail"
+        assert result["counts"]["errors"] > 0
+        assert result["counts"]["warnings"] > 0
+
+
+class TestDomainCheckDiagnostics:
+    """IR diagnostics are included when there are no fatal errors."""
+
+    @pytest.mark.no_test_domain
+    def test_diagnostics_included_when_no_errors(self):
+        domain = Domain(name="DiagDomain", root_path=__file__)
+        domain.register(Order)
+        domain.register(PlaceOrder, part_of=Order)
+        # Unused command will appear in both warnings and IR diagnostics
+
+        result = domain.check(traverse=False)
+
+        assert result["status"] == "warn"
+        # Diagnostics should be a list (possibly empty depending on IR builder)
+        assert isinstance(result["diagnostics"], list)
+
+    @pytest.mark.no_test_domain
+    def test_diagnostics_empty_when_errors_present(self):
+        domain = Domain(name="ErrNoDiag", root_path=__file__)
+        domain.config["identity_strategy"] = "function"
+        domain.register(Order)
+
+        result = domain.check(traverse=False)
+
+        assert result["status"] == "fail"
+        assert result["diagnostics"] == []
+        assert result["counts"]["diagnostics"] == 0
+
+
+class TestPrepareRefactoring:
+    """Verify that init() still works correctly after the _prepare() extraction."""
+
+    @pytest.mark.no_test_domain
+    def test_init_still_works(self):
+        """init() delegates to _prepare() and then initializes adapters."""
+        domain = Domain(name="InitTest", root_path=__file__)
+        domain.register(Order)
+        domain.register(OrderPlaced, part_of=Order)
+        domain.register(PlaceOrder, part_of=Order)
+        domain.register(PlaceOrderHandler, part_of=Order)
+
+        # Should not raise
+        domain.init(traverse=False)
+
+    @pytest.mark.no_test_domain
+    def test_init_still_raises_on_error(self):
+        """init() should still fail fast on the first validation error."""
+        domain = Domain(name="InitErrTest", root_path=__file__)
+        domain.config["identity_strategy"] = "function"
+        domain.register(Order)
+
+        with pytest.raises(Exception):
+            domain.init(traverse=False)


### PR DESCRIPTION
Extract shared init steps into `Domain._prepare()` so both `init()` and the new `check()` method can reuse the resolution/wiring pipeline without duplicating logic. `init()` continues to initialize adapters after _prepare(); check() skips adapters and runs validate_all() to collect all errors and warnings instead of failing fast.

`Domain.check()` builds the IR when no fatal errors are present, merging IR-level diagnostics (`UNHANDLED_EVENT`, `UNUSED_COMMAND`, etc.) into the structured report alongside validator errors and warnings. Returns a dict with domain name, status (pass/warn/fail), errors, warnings, diagnostics, and counts.

The protean check CLI command exposes this as a top-level command with rich (default) and JSON output formats, and CI-friendly exit codes: 0 = clean, 1 = errors, 2 = warnings/diagnostics only.

Closes #704