### PR TITLE
Add description, version option, and repository database to IR

### DIFF
--- a/src/protean/core/command.py
+++ b/src/protean/core/command.py
@@ -44,6 +44,7 @@ class BaseCommand(BaseMessageType):
     | Option | Type | Description |
     |--------|------|-------------|
     | ``part_of`` | ``type`` | The aggregate class this command targets. Required. |
+    | ``version`` | ``int`` | Message version number (alternative to ``__version__`` class attribute). Default ``1``. |
     """
 
     element_type: ClassVar[str] = DomainObjects.COMMAND

--- a/src/protean/core/event.py
+++ b/src/protean/core/event.py
@@ -48,6 +48,7 @@ class BaseEvent(BaseMessageType):
     |--------|------|-------------|
     | ``part_of`` | ``type`` | The aggregate class that raises this event. Required. |
     | ``published`` | ``bool`` | Whether this event is part of the bounded context's published language. Default ``False``. |
+    | ``version`` | ``int`` | Message version number (alternative to ``__version__`` class attribute). Default ``1``. |
     """
 
     element_type: ClassVar[str] = DomainObjects.EVENT

--- a/src/protean/ir/builder.py
+++ b/src/protean/ir/builder.py
@@ -395,6 +395,11 @@ class IRBuilder:
         from protean.utils.reflection import _ID_FIELD_NAME
 
         entry: dict[str, Any] = {}
+
+        doc = (cls.__doc__ or "").strip()
+        if doc:
+            entry["description"] = doc
+
         entry["element_type"] = "ENTITY"
         entry["fields"] = self._extract_fields(cls)
         entry["fqn"] = fqn(cls)
@@ -451,6 +456,11 @@ class IRBuilder:
         entry: dict[str, Any] = {}
         entry["__type__"] = getattr(cls, "__type__", "")
         entry["__version__"] = getattr(cls, "__version__", 1)
+
+        doc = (cls.__doc__ or "").strip()
+        if doc:
+            entry["description"] = doc
+
         entry["element_type"] = "COMMAND"
         entry["fields"] = self._extract_fields(cls)
         entry["fqn"] = fqn(cls)
@@ -473,6 +483,10 @@ class IRBuilder:
 
         if record.auto_generated:
             entry["auto_generated"] = True
+
+        doc = (cls.__doc__ or "").strip()
+        if doc:
+            entry["description"] = doc
 
         entry["element_type"] = "EVENT"
         entry["fields"] = self._extract_fields(cls)
@@ -516,6 +530,11 @@ class IRBuilder:
         from protean.utils import fqn
 
         entry: dict[str, Any] = {}
+
+        doc = (cls.__doc__ or "").strip()
+        if doc:
+            entry["description"] = doc
+
         entry["element_type"] = "COMMAND_HANDLER"
         entry["fqn"] = fqn(cls)
         entry["handlers"] = self._extract_handler_map(cls)
@@ -536,6 +555,11 @@ class IRBuilder:
         from protean.utils import fqn
 
         entry: dict[str, Any] = {}
+
+        doc = (cls.__doc__ or "").strip()
+        if doc:
+            entry["description"] = doc
+
         entry["element_type"] = "EVENT_HANDLER"
         entry["fqn"] = fqn(cls)
         entry["handlers"] = self._extract_handler_map(cls)
@@ -557,6 +581,11 @@ class IRBuilder:
         from protean.utils import fqn
 
         entry: dict[str, Any] = {}
+
+        doc = (cls.__doc__ or "").strip()
+        if doc:
+            entry["description"] = doc
+
         entry["element_type"] = "APPLICATION_SERVICE"
         entry["fqn"] = fqn(cls)
         entry["module"] = cls.__module__
@@ -573,6 +602,16 @@ class IRBuilder:
         from protean.utils import fqn
 
         entry: dict[str, Any] = {}
+
+        doc = (cls.__doc__ or "").strip()
+        if doc:
+            entry["description"] = doc
+
+        # Sparse: omit database when default "ALL"
+        database = getattr(cls.meta_, "database", "ALL")
+        if database != "ALL":
+            entry["database"] = database
+
         entry["element_type"] = "REPOSITORY"
         entry["fqn"] = fqn(cls)
         entry["module"] = cls.__module__
@@ -593,6 +632,10 @@ class IRBuilder:
         database = getattr(cls.meta_, "database", None)
         if database is not None:
             entry["database"] = database
+
+        doc = (cls.__doc__ or "").strip()
+        if doc:
+            entry["description"] = doc
 
         entry["element_type"] = "DATABASE_MODEL"
         entry["fqn"] = fqn(cls)
@@ -619,6 +662,11 @@ class IRBuilder:
         from protean.utils.reflection import _ID_FIELD_NAME
 
         entry: dict[str, Any] = {}
+
+        doc = (cls.__doc__ or "").strip()
+        if doc:
+            entry["description"] = doc
+
         entry["element_type"] = "PROJECTION"
         entry["fields"] = self._extract_fields(cls)
         entry["fqn"] = fqn(cls)
@@ -650,6 +698,10 @@ class IRBuilder:
         aggregates = getattr(cls.meta_, "aggregates", [])
         entry["aggregates"] = sorted(fqn(a) for a in aggregates) if aggregates else []
 
+        doc = (cls.__doc__ or "").strip()
+        if doc:
+            entry["description"] = doc
+
         entry["element_type"] = "PROJECTOR"
         entry["fqn"] = fqn(cls)
         entry["handlers"] = self._extract_handler_map(cls)
@@ -671,6 +723,11 @@ class IRBuilder:
 
         entry: dict[str, Any] = {}
         entry["__type__"] = getattr(cls, "__type__", "")
+
+        doc = (cls.__doc__ or "").strip()
+        if doc:
+            entry["description"] = doc
+
         entry["element_type"] = "QUERY"
         entry["fields"] = self._extract_fields(cls)
         entry["fqn"] = fqn(cls)
@@ -688,6 +745,11 @@ class IRBuilder:
         from protean.utils import fqn
 
         entry: dict[str, Any] = {}
+
+        doc = (cls.__doc__ or "").strip()
+        if doc:
+            entry["description"] = doc
+
         entry["element_type"] = "QUERY_HANDLER"
         entry["fqn"] = fqn(cls)
         entry["handlers"] = self._extract_handler_map(cls)
@@ -767,6 +829,11 @@ class IRBuilder:
         from protean.utils import fqn
 
         entry: dict[str, Any] = {}
+
+        doc = (cls.__doc__ or "").strip()
+        if doc:
+            entry["description"] = doc
+
         entry["element_type"] = "DOMAIN_SERVICE"
         entry["fqn"] = fqn(cls)
         entry["invariants"] = self._extract_invariants(cls)
@@ -788,6 +855,11 @@ class IRBuilder:
         from protean.utils.reflection import _ID_FIELD_NAME
 
         entry: dict[str, Any] = {}
+
+        doc = (cls.__doc__ or "").strip()
+        if doc:
+            entry["description"] = doc
+
         entry["element_type"] = "PROCESS_MANAGER"
         entry["fields"] = self._extract_fields(cls)
         entry["fqn"] = fqn(cls)
@@ -834,6 +906,11 @@ class IRBuilder:
 
         entry: dict[str, Any] = {}
         entry["broker"] = getattr(cls.meta_, "broker", "default")
+
+        doc = (cls.__doc__ or "").strip()
+        if doc:
+            entry["description"] = doc
+
         entry["element_type"] = "SUBSCRIBER"
         entry["fqn"] = fqn(cls)
         entry["module"] = cls.__module__

--- a/src/protean/ir/schema/v0.1.0/schema.json
+++ b/src/protean/ir/schema/v0.1.0/schema.json
@@ -564,7 +564,8 @@
           "type": "object",
           "properties": {
             "element_type": { "const": "REPOSITORY" },
-            "part_of": { "type": "string", "minLength": 1 }
+            "part_of": { "type": "string", "minLength": 1 },
+            "database": { "type": "string", "minLength": 1 }
           },
           "required": ["part_of"]
         }

--- a/src/protean/utils/eventing.py
+++ b/src/protean/utils/eventing.py
@@ -250,13 +250,30 @@ class BaseMessageType(BaseModel, OptionsMixin):
             ("part_of", None),
             ("is_fact_event", False),
             ("published", False),
+            ("version", None),
         ]
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
 
-        # Use explicit version if specified, else default to 1
-        if not hasattr(cls, "__version__"):
+        # Resolve version: decorator option `version=N` sets __version__
+        meta_version = getattr(getattr(cls, "meta_", None), "version", None)
+        has_class_version = "__version__" in cls.__dict__
+
+        if meta_version is not None and has_class_version:
+            raise IncorrectUsageError(
+                f"`{cls.__name__}` sets both `version` option and "
+                f"`__version__` class attribute. Use one or the other."
+            )
+
+        if meta_version is not None:
+            if not isinstance(meta_version, int) or meta_version < 1:
+                raise IncorrectUsageError(
+                    f"`{cls.__name__}` `version` option must be a positive "
+                    f"integer, got `{meta_version!r}`"
+                )
+            cls.__version__ = meta_version
+        elif not hasattr(cls, "__version__"):
             cls.__version__ = 1
         elif not isinstance(cls.__version__, int) or cls.__version__ < 1:
             raise IncorrectUsageError(

--- a/tests/ir/elements.py
+++ b/tests/ir/elements.py
@@ -551,3 +551,123 @@ def build_integration_domain() -> Domain:
 
     domain.init(traverse=False)
     return domain
+
+
+def build_description_test_domain() -> Domain:
+    """Build a domain where every element type has a docstring."""
+    from protean.utils.mixins import read
+
+    domain = Domain(name="DescriptionTest", root_path=".")
+
+    @domain.value_object
+    class Address:
+        """A postal address."""
+
+        street = String(max_length=255, required=True)
+        city = String(max_length=100, required=True)
+
+    @domain.entity(part_of="Order")
+    class LineItem:
+        """A single item within an order."""
+
+        product_name = String(max_length=200, required=True)
+        quantity = Integer(min_value=1, required=True)
+
+    @domain.command(part_of="Order")
+    class PlaceOrder:
+        """Request to place a new order."""
+
+        customer_name = String(max_length=100, required=True)
+
+    @domain.event(part_of="Order")
+    class OrderPlaced:
+        """Emitted when an order is successfully placed."""
+
+        order_id = Identifier(required=True)
+
+    @domain.aggregate
+    class Order:
+        """An order placed by a customer."""
+
+        customer_name = String(max_length=100, required=True)
+        address = VOField(Address)
+        items = HasMany(LineItem)
+
+    @domain.command_handler(part_of=Order)
+    class OrderCommandHandler:
+        """Handles order commands."""
+
+        @handle(PlaceOrder)
+        def handle_place(self, command):
+            pass
+
+    @domain.event_handler(part_of=Order)
+    class OrderEventHandler:
+        """Reacts to order events."""
+
+        @handle(OrderPlaced)
+        def on_placed(self, event):
+            pass
+
+    @domain.application_service(part_of=Order)
+    class OrderService:
+        """Application service for order use cases."""
+
+        pass
+
+    @domain.repository(part_of=Order)
+    class OrderRepository:
+        """Custom repository for orders."""
+
+        pass
+
+    @domain.aggregate
+    class Payment:
+        """A payment for an order."""
+
+        amount = Float(default=0.0)
+
+    @domain.domain_service(part_of=[Order, Payment])
+    class OrderValidator:
+        """Validates orders across business rules."""
+
+        pass
+
+    @domain.subscriber(broker="default", stream="ext_payments")
+    class PaymentSubscriber:
+        """Consumes external payment events."""
+
+        def __call__(self, payload):
+            pass
+
+    @domain.projection
+    class OrderSummary:
+        """Read-optimized order summary."""
+
+        order_id = Identifier(identifier=True)
+        customer_name = String(max_length=100)
+
+    @domain.projector(projector_for=OrderSummary, aggregates=[Order])
+    class OrderSummaryProjector:
+        """Projects order events into OrderSummary."""
+
+        @handle(OrderPlaced)
+        def on_placed(self, event):
+            pass
+
+    @domain.query(part_of=OrderSummary)
+    class GetOrderSummary:
+        """Query to fetch an order summary."""
+
+        order_id = Identifier(required=True)
+
+    @domain.query_handler(part_of=OrderSummary)
+    class OrderSummaryQueryHandler:
+        """Handles order summary queries."""
+
+        @read(GetOrderSummary)
+        def by_order(self, query):
+            pass
+
+    domain.init(traverse=False)
+    return domain

--- a/tests/ir/test_command_event_extraction.py
+++ b/tests/ir/test_command_event_extraction.py
@@ -133,3 +133,119 @@ class TestFactEvent:
                 assert evt.get("auto_generated") is True
                 return
         pytest.fail("No fact event found")
+
+
+@pytest.mark.no_test_domain
+class TestVersionOption:
+    """Verify that the `version` decorator option sets __version__ on events and commands."""
+
+    def test_event_version_via_option(self):
+        """Events can set version via decorator option."""
+        from protean import Domain
+        from protean.fields.simple import Identifier, String
+        from protean.ir.builder import IRBuilder
+
+        domain = Domain(name="VersionTest", root_path=".")
+
+        @domain.event(part_of="Order", version=3)
+        class OrderPlaced:
+            order_id = Identifier(required=True)
+
+        @domain.aggregate
+        class Order:
+            name = String(max_length=100)
+
+        domain.init(traverse=False)
+        ir = IRBuilder(domain).build()
+
+        for cluster in ir["clusters"].values():
+            for evt in cluster["events"].values():
+                if evt["name"] == "OrderPlaced":
+                    assert evt["__version__"] == 3
+                    return
+        pytest.fail("OrderPlaced not found")
+
+    def test_command_version_via_option(self):
+        """Commands can set version via decorator option."""
+        from protean import Domain
+        from protean.fields.simple import String
+        from protean.ir.builder import IRBuilder
+
+        domain = Domain(name="VersionTest", root_path=".")
+
+        @domain.command(part_of="Order", version=2)
+        class PlaceOrder:
+            customer_name = String(max_length=100, required=True)
+
+        @domain.aggregate
+        class Order:
+            name = String(max_length=100)
+
+        domain.init(traverse=False)
+        ir = IRBuilder(domain).build()
+
+        for cluster in ir["clusters"].values():
+            for cmd in cluster["commands"].values():
+                if cmd["name"] == "PlaceOrder":
+                    assert cmd["__version__"] == 2
+                    return
+        pytest.fail("PlaceOrder not found")
+
+    def test_version_option_default_is_1(self):
+        """Without explicit version, __version__ defaults to 1."""
+        from protean import Domain
+        from protean.fields.simple import Identifier, String
+        from protean.ir.builder import IRBuilder
+
+        domain = Domain(name="VersionTest", root_path=".")
+
+        @domain.event(part_of="Order")
+        class OrderPlaced:
+            order_id = Identifier(required=True)
+
+        @domain.aggregate
+        class Order:
+            name = String(max_length=100)
+
+        domain.init(traverse=False)
+        ir = IRBuilder(domain).build()
+
+        for cluster in ir["clusters"].values():
+            for evt in cluster["events"].values():
+                if evt["name"] == "OrderPlaced":
+                    assert evt["__version__"] == 1
+                    return
+        pytest.fail("OrderPlaced not found")
+
+    def test_version_option_rejects_non_positive(self):
+        """Non-positive version raises IncorrectUsageError."""
+        import pytest as _pytest
+
+        from protean import Domain
+        from protean.exceptions import IncorrectUsageError
+        from protean.fields.simple import Identifier
+
+        domain = Domain(name="VersionTest", root_path=".")
+
+        with _pytest.raises(IncorrectUsageError, match="positive integer"):
+
+            @domain.event(part_of="Order", version=0)
+            class OrderPlaced:
+                order_id = Identifier(required=True)
+
+    def test_version_option_conflicts_with_class_version(self):
+        """Setting both version option and __version__ class attribute raises error."""
+        import pytest as _pytest
+
+        from protean import Domain
+        from protean.exceptions import IncorrectUsageError
+        from protean.fields.simple import Identifier
+
+        domain = Domain(name="VersionTest", root_path=".")
+
+        with _pytest.raises(IncorrectUsageError, match="both"):
+
+            @domain.event(part_of="Order", version=2)
+            class OrderPlaced:
+                __version__ = 3
+                order_id = Identifier(required=True)

--- a/tests/ir/test_description_extraction.py
+++ b/tests/ir/test_description_extraction.py
@@ -1,0 +1,132 @@
+"""Tests for description (docstring) extraction across all domain element types."""
+
+import pytest
+
+from protean.ir.builder import IRBuilder
+
+from .elements import build_description_test_domain
+
+
+@pytest.fixture
+def desc_ir():
+    """Return the full IR for the description test domain."""
+    domain = build_description_test_domain()
+    return IRBuilder(domain).build()
+
+
+@pytest.fixture
+def order_cluster(desc_ir):
+    """Return the Order aggregate's cluster."""
+    for cluster in desc_ir["clusters"].values():
+        if cluster["aggregate"]["name"] == "Order":
+            return cluster
+    pytest.fail("Order cluster not found")
+
+
+@pytest.mark.no_test_domain
+class TestClusterElementDescriptions:
+    """Verify description is captured for elements within aggregate clusters."""
+
+    def test_aggregate_description(self, order_cluster):
+        assert (
+            order_cluster["aggregate"]["description"]
+            == "An order placed by a customer."
+        )
+
+    def test_entity_description(self, order_cluster):
+        entity = next(iter(order_cluster["entities"].values()))
+        assert entity["description"] == "A single item within an order."
+
+    def test_value_object_description(self, order_cluster):
+        vo = next(iter(order_cluster["value_objects"].values()))
+        assert vo["description"] == "A postal address."
+
+    def test_command_description(self, order_cluster):
+        cmd = next(iter(order_cluster["commands"].values()))
+        assert cmd["description"] == "Request to place a new order."
+
+    def test_event_description(self, order_cluster):
+        # Find the user-defined event (not fact events)
+        for evt in order_cluster["events"].values():
+            if evt["name"] == "OrderPlaced":
+                assert (
+                    evt["description"]
+                    == "Emitted when an order is successfully placed."
+                )
+                return
+        pytest.fail("OrderPlaced event not found")
+
+    def test_command_handler_description(self, order_cluster):
+        ch = next(iter(order_cluster["command_handlers"].values()))
+        assert ch["description"] == "Handles order commands."
+
+    def test_event_handler_description(self, order_cluster):
+        eh = next(iter(order_cluster["event_handlers"].values()))
+        assert eh["description"] == "Reacts to order events."
+
+    def test_application_service_description(self, order_cluster):
+        svc = next(iter(order_cluster["application_services"].values()))
+        assert svc["description"] == "Application service for order use cases."
+
+    def test_repository_description(self, order_cluster):
+        repo = next(iter(order_cluster["repositories"].values()))
+        assert repo["description"] == "Custom repository for orders."
+
+
+@pytest.mark.no_test_domain
+class TestFlowElementDescriptions:
+    """Verify description is captured for flow elements (domain services, subscribers)."""
+
+    def test_domain_service_description(self, desc_ir):
+        ds = next(iter(desc_ir["flows"]["domain_services"].values()))
+        assert ds["description"] == "Validates orders across business rules."
+
+    def test_subscriber_description(self, desc_ir):
+        sub = next(iter(desc_ir["flows"]["subscribers"].values()))
+        assert sub["description"] == "Consumes external payment events."
+
+
+@pytest.mark.no_test_domain
+class TestProjectionElementDescriptions:
+    """Verify description is captured for projection-related elements."""
+
+    def test_projection_description(self, desc_ir):
+        proj_group = next(iter(desc_ir["projections"].values()))
+        assert (
+            proj_group["projection"]["description"] == "Read-optimized order summary."
+        )
+
+    def test_projector_description(self, desc_ir):
+        proj_group = next(iter(desc_ir["projections"].values()))
+        projector = next(iter(proj_group["projectors"].values()))
+        assert projector["description"] == "Projects order events into OrderSummary."
+
+    def test_query_description(self, desc_ir):
+        proj_group = next(iter(desc_ir["projections"].values()))
+        query = next(iter(proj_group["queries"].values()))
+        assert query["description"] == "Query to fetch an order summary."
+
+    def test_query_handler_description(self, desc_ir):
+        proj_group = next(iter(desc_ir["projections"].values()))
+        qh = next(iter(proj_group["query_handlers"].values()))
+        assert qh["description"] == "Handles order summary queries."
+
+
+@pytest.mark.no_test_domain
+class TestDescriptionOmittedWhenEmpty:
+    """Verify description is omitted (sparse) when element has no docstring."""
+
+    def test_no_description_when_no_docstring(self):
+        """Elements without docstrings should not have a description key."""
+        from .elements import build_command_event_test_domain
+
+        domain = build_command_event_test_domain()
+        ir = IRBuilder(domain).build()
+
+        # PlaceOrder in this domain has no docstring
+        for cluster in ir["clusters"].values():
+            for cmd in cluster["commands"].values():
+                if cmd["name"] == "PlaceOrder":
+                    assert "description" not in cmd
+                    return
+        pytest.fail("PlaceOrder command not found")

--- a/tests/ir/test_handler_extraction.py
+++ b/tests/ir/test_handler_extraction.py
@@ -151,3 +151,39 @@ class TestRepositoryExtraction:
         for repo in account_cluster["repositories"].values():
             keys = list(repo.keys())
             assert keys == sorted(keys)
+
+    def test_database_omitted_when_default(self, account_cluster):
+        """Repositories with default database='ALL' should not have a database key."""
+        for repo in account_cluster["repositories"].values():
+            assert "database" not in repo
+
+
+@pytest.mark.no_test_domain
+class TestRepositoryDatabaseOption:
+    """Verify repository database option is captured in IR."""
+
+    def test_non_default_database_captured(self):
+        """Repository with explicit database option should have it in IR."""
+        from protean import Domain
+        from protean.fields.simple import String
+        from protean.ir.builder import IRBuilder
+
+        domain = Domain(name="RepoDbTest", root_path=".")
+
+        @domain.aggregate
+        class Order:
+            name = String(max_length=100)
+
+        @domain.repository(part_of=Order, database="memory")
+        class OrderMemoryRepository:
+            pass
+
+        domain.init(traverse=False)
+        ir = IRBuilder(domain).build()
+
+        for cluster in ir["clusters"].values():
+            for repo in cluster["repositories"].values():
+                if repo["name"] == "OrderMemoryRepository":
+                    assert repo["database"] == "memory"
+                    return
+        pytest.fail("OrderMemoryRepository not found")


### PR DESCRIPTION
- Extract docstrings as `description` on all 15 element extractors (sparse: omitted when empty)
- Add `version` decorator option for events and commands as alternative to `__version__` class attribute, with validation and conflict detection
- Capture repository `database` option in IR (sparse: omitted when default "ALL")
- Update JSON schema with repository `database` property

Closes #705