### PR TITLE
Enrich contracts with language-neutral keys, version, and field schemas

### DIFF
--- a/src/protean/cli/ir.py
+++ b/src/protean/cli/ir.py
@@ -242,12 +242,10 @@ def _print_diff_text(result: dict[str, Any]) -> None:
         print("\n[bold]Contracts[/bold]")
         for evt in contract_added:
             print(
-                f"  [green]+ published event: {evt.get('__type__', evt.get('fqn'))}[/green]"
+                f"  [green]+ published event: {evt.get('type', evt.get('fqn'))}[/green]"
             )
         for evt in contract_removed:
-            print(
-                f"  [red]- published event: {evt.get('__type__', evt.get('fqn'))}[/red]"
-            )
+            print(f"  [red]- published event: {evt.get('type', evt.get('fqn'))}[/red]")
 
     # Diagnostics
     diagnostics = result.get("diagnostics", {})

--- a/src/protean/ir/builder.py
+++ b/src/protean/ir/builder.py
@@ -1149,24 +1149,32 @@ class IRBuilder:
     # Contracts
     # ------------------------------------------------------------------
 
-    def _build_contracts(self) -> dict[str, list[dict[str, str]]]:
-        """Build contracts section — published events sorted by __type__."""
+    def _build_contracts(self) -> dict[str, list[dict[str, Any]]]:
+        """Build contracts section — published events with language-neutral keys.
+
+        Contract entries use ``type`` (not ``__type__``), ``version`` (not
+        ``__version__``), and include field schemas so that downstream
+        consumers (schema generators, contract checkers) have everything
+        they need without reaching into element-level IR.
+        """
         from protean.utils import fqn
 
         registry = self._domain._domain_registry
-        published_events: list[dict[str, str]] = []
+        published_events: list[dict[str, Any]] = []
 
         for record in registry._elements.get("EVENT", {}).values():
             cls = record.cls
             if getattr(cls.meta_, "published", False):
                 published_events.append(
                     {
-                        "__type__": getattr(cls, "__type__", ""),
+                        "fields": self._extract_fields(cls),
                         "fqn": fqn(cls),
+                        "type": getattr(cls, "__type__", ""),
+                        "version": getattr(cls, "__version__", 1),
                     }
                 )
 
-        return {"events": sorted(published_events, key=lambda e: e.get("__type__", ""))}
+        return {"events": sorted(published_events, key=lambda e: e.get("type", ""))}
 
     # ------------------------------------------------------------------
     # Diagnostics

--- a/src/protean/ir/diff.py
+++ b/src/protean/ir/diff.py
@@ -41,8 +41,6 @@ def diff_ir(left: dict[str, Any], right: dict[str, Any]) -> dict[str, Any]:
     result["contracts"] = _diff_contracts(
         left.get("contracts", {}),
         right.get("contracts", {}),
-        left,
-        right,
     )
     result["diagnostics"] = _diff_diagnostics(
         left.get("diagnostics", []),
@@ -371,10 +369,12 @@ def _diff_flows(
 def _diff_contracts(
     left_contracts: dict[str, Any],
     right_contracts: dict[str, Any],
-    left_ir: dict[str, Any],
-    right_ir: dict[str, Any],
 ) -> dict[str, Any]:
-    """Diff the contracts section and detect breaking changes."""
+    """Diff the contracts section and detect breaking changes.
+
+    Contract entries use language-neutral keys: ``type`` (not ``__type__``),
+    ``version``, ``fields``, and ``fqn``.
+    """
     left_events = left_contracts.get("events", [])
     right_events = right_contracts.get("events", [])
 
@@ -391,59 +391,54 @@ def _diff_contracts(
 
     # Removed published events are breaking
     for event in removed:
+        event_label = event.get("type", event["fqn"])
         breaking.append(
             {
                 "type": "contract_event_removed",
-                "event": event.get("__type__", ""),
+                "event": event_label,
                 "fqn": event["fqn"],
-                "message": (
-                    f"Published event '{event.get('__type__', event['fqn'])}' "
-                    f"was removed"
-                ),
+                "message": f"Published event '{event_label}' was removed",
             }
         )
 
-    # Check events present in both for __type__ changes and field changes
-    for fqn in sorted(left_fqns & right_fqns):
-        left_evt = left_by_fqn[fqn]
-        right_evt = right_by_fqn[fqn]
+    # Check events present in both for type/version/field changes
+    for event_fqn in sorted(left_fqns & right_fqns):
+        left_evt = left_by_fqn[event_fqn]
+        right_evt = right_by_fqn[event_fqn]
 
-        # __type__ change is breaking
-        left_type = left_evt.get("__type__", "")
-        right_type = right_evt.get("__type__", "")
+        # type string change is breaking
+        left_type = left_evt.get("type", "")
+        right_type = right_evt.get("type", "")
         if left_type != right_type:
             breaking.append(
                 {
                     "type": "contract_type_changed",
-                    "fqn": fqn,
+                    "fqn": event_fqn,
                     "left": left_type,
                     "right": right_type,
                     "message": (
-                        f"__type__ changed for published event: "
+                        f"type changed for published event: "
                         f"'{left_type}' → '{right_type}'"
                     ),
                 }
             )
 
-        # Field-level changes on published events
-        left_event_def = _find_event_in_ir(left_ir, fqn)
-        right_event_def = _find_event_in_ir(right_ir, fqn)
-        if left_event_def and right_event_def:
-            left_fields = left_event_def.get("fields", {})
-            right_fields = right_event_def.get("fields", {})
-            removed_fields = set(left_fields.keys()) - set(right_fields.keys())
-            for field_name in sorted(removed_fields):
-                breaking.append(
-                    {
-                        "type": "contract_field_removed",
-                        "fqn": fqn,
-                        "field": field_name,
-                        "message": (
-                            f"Field '{field_name}' removed from published event "
-                            f"'{left_type}'"
-                        ),
-                    }
-                )
+        # Field-level changes — fields are embedded in contract entries
+        left_fields = left_evt.get("fields", {})
+        right_fields = right_evt.get("fields", {})
+        removed_fields = set(left_fields.keys()) - set(right_fields.keys())
+        for field_name in sorted(removed_fields):
+            breaking.append(
+                {
+                    "type": "contract_field_removed",
+                    "fqn": event_fqn,
+                    "field": field_name,
+                    "message": (
+                        f"Field '{field_name}' removed from published event "
+                        f"'{left_type}'"
+                    ),
+                }
+            )
 
     result: dict[str, Any] = {}
     if added:
@@ -454,15 +449,6 @@ def _diff_contracts(
         result["breaking_changes"] = breaking
 
     return result
-
-
-def _find_event_in_ir(ir: dict[str, Any], event_fqn: str) -> dict[str, Any] | None:
-    """Look up an event definition by FQN in the clusters section."""
-    for cluster in ir.get("clusters", {}).values():
-        events = cluster.get("events", {})
-        if event_fqn in events:
-            return events[event_fqn]
-    return None
 
 
 def _diff_diagnostics(

--- a/src/protean/ir/examples/fidelis-ir.json
+++ b/src/protean/ir/examples/fidelis-ir.json
@@ -339,16 +339,73 @@
   "contracts": {
     "events": [
       {
-        "__type__": "Fidelis.AccountOpened.v1",
-        "fqn": "banking.accounts.AccountOpened"
+        "fields": {
+          "account_id": {
+            "kind": "identifier",
+            "required": true,
+            "type": "Identifier"
+          },
+          "account_number": {
+            "kind": "standard",
+            "required": true,
+            "type": "String"
+          },
+          "holder_name": {
+            "kind": "standard",
+            "required": true,
+            "type": "String"
+          },
+          "opening_deposit": {
+            "kind": "standard",
+            "required": true,
+            "type": "Float"
+          }
+        },
+        "fqn": "banking.accounts.AccountOpened",
+        "type": "Fidelis.AccountOpened.v1",
+        "version": 1
       },
       {
-        "__type__": "Fidelis.DepositMade.v1",
-        "fqn": "banking.accounts.DepositMade"
+        "fields": {
+          "account_id": {
+            "kind": "identifier",
+            "required": true,
+            "type": "Identifier"
+          },
+          "amount": {
+            "kind": "standard",
+            "required": true,
+            "type": "Float"
+          },
+          "reference": {
+            "kind": "standard",
+            "type": "String"
+          }
+        },
+        "fqn": "banking.accounts.DepositMade",
+        "type": "Fidelis.DepositMade.v1",
+        "version": 1
       },
       {
-        "__type__": "Fidelis.WithdrawalMade.v1",
-        "fqn": "banking.accounts.WithdrawalMade"
+        "fields": {
+          "account_id": {
+            "kind": "identifier",
+            "required": true,
+            "type": "Identifier"
+          },
+          "amount": {
+            "kind": "standard",
+            "required": true,
+            "type": "Float"
+          },
+          "reference": {
+            "kind": "standard",
+            "type": "String"
+          }
+        },
+        "fqn": "banking.accounts.WithdrawalMade",
+        "type": "Fidelis.WithdrawalMade.v1",
+        "version": 1
       }
     ]
   },

--- a/src/protean/ir/examples/ordering-ir.json
+++ b/src/protean/ir/examples/ordering-ir.json
@@ -476,16 +476,64 @@
   "contracts": {
     "events": [
       {
-        "__type__": "Ordering.OrderCancelled.v1",
-        "fqn": "ecommerce.ordering.OrderCancelled"
+        "fields": {
+          "order_id": {
+            "kind": "identifier",
+            "required": true,
+            "type": "Identifier"
+          },
+          "reason": {
+            "kind": "standard",
+            "type": "String"
+          }
+        },
+        "fqn": "ecommerce.ordering.OrderCancelled",
+        "type": "Ordering.OrderCancelled.v1",
+        "version": 1
       },
       {
-        "__type__": "Ordering.OrderPlaced.v1",
-        "fqn": "ecommerce.ordering.OrderPlaced"
+        "fields": {
+          "customer_name": {
+            "kind": "standard",
+            "required": true,
+            "type": "String"
+          },
+          "order_id": {
+            "kind": "identifier",
+            "required": true,
+            "type": "Identifier"
+          },
+          "total_amount": {
+            "kind": "standard",
+            "required": true,
+            "type": "Float"
+          }
+        },
+        "fqn": "ecommerce.ordering.OrderPlaced",
+        "type": "Ordering.OrderPlaced.v1",
+        "version": 1
       },
       {
-        "__type__": "Ordering.PaymentConfirmed.v1",
-        "fqn": "ecommerce.payments.PaymentConfirmed"
+        "fields": {
+          "amount": {
+            "kind": "standard",
+            "required": true,
+            "type": "Float"
+          },
+          "order_id": {
+            "kind": "identifier",
+            "required": true,
+            "type": "Identifier"
+          },
+          "payment_id": {
+            "kind": "identifier",
+            "required": true,
+            "type": "Identifier"
+          }
+        },
+        "fqn": "ecommerce.payments.PaymentConfirmed",
+        "type": "Ordering.PaymentConfirmed.v1",
+        "version": 1
       }
     ]
   },

--- a/src/protean/ir/schema/v0.1.0/schema.json
+++ b/src/protean/ir/schema/v0.1.0/schema.json
@@ -781,10 +781,16 @@
           "items": {
             "type": "object",
             "properties": {
-              "__type__": { "type": "string", "minLength": 1 },
-              "fqn": { "type": "string", "minLength": 1 }
+              "fields": {
+                "type": "object",
+                "description": "Field schemas for the published event",
+                "additionalProperties": { "$ref": "#/$defs/field" }
+              },
+              "fqn": { "type": "string", "minLength": 1 },
+              "type": { "type": "string", "minLength": 1 },
+              "version": { "type": "integer", "minimum": 1 }
             },
-            "required": ["__type__", "fqn"],
+            "required": ["fields", "fqn", "type", "version"],
             "additionalProperties": true
           }
         }

--- a/tests/ir/test_diff.py
+++ b/tests/ir/test_diff.py
@@ -318,27 +318,30 @@ class TestDiffOptions:
 
 
 class TestDiffContracts:
+    def _contract_event(
+        self,
+        type_str: str = "Test.OrderPlaced.v1",
+        fqn: str = "app.OrderPlaced",
+        version: int = 1,
+        fields: dict | None = None,
+    ) -> dict:
+        """Helper to build a contract event entry with language-neutral keys."""
+        return {
+            "fields": fields or {},
+            "fqn": fqn,
+            "type": type_str,
+            "version": version,
+        }
+
     def test_added_published_event(self):
         left = _minimal_ir()
-        right = _minimal_ir(
-            contracts={
-                "events": [
-                    {"__type__": "Test.OrderPlaced.v1", "fqn": "app.OrderPlaced"}
-                ]
-            }
-        )
+        right = _minimal_ir(contracts={"events": [self._contract_event()]})
         result = diff_ir(left, right)
         assert len(result["contracts"]["added"]) == 1
         assert result["summary"]["has_breaking_changes"] is False
 
     def test_removed_published_event_is_breaking(self):
-        left = _minimal_ir(
-            contracts={
-                "events": [
-                    {"__type__": "Test.OrderPlaced.v1", "fqn": "app.OrderPlaced"}
-                ]
-            }
-        )
+        left = _minimal_ir(contracts={"events": [self._contract_event()]})
         right = _minimal_ir()
         result = diff_ir(left, right)
         assert len(result["contracts"]["removed"]) == 1
@@ -347,19 +350,9 @@ class TestDiffContracts:
         assert breaking[0]["type"] == "contract_event_removed"
 
     def test_type_change_is_breaking(self):
-        left = _minimal_ir(
-            contracts={
-                "events": [
-                    {"__type__": "Test.OrderPlaced.v1", "fqn": "app.OrderPlaced"}
-                ]
-            }
-        )
+        left = _minimal_ir(contracts={"events": [self._contract_event()]})
         right = _minimal_ir(
-            contracts={
-                "events": [
-                    {"__type__": "Test.OrderPlaced.v2", "fqn": "app.OrderPlaced"}
-                ]
-            }
+            contracts={"events": [self._contract_event(type_str="Test.OrderPlaced.v2")]}
         )
         result = diff_ir(left, right)
         assert result["summary"]["has_breaking_changes"] is True
@@ -367,36 +360,17 @@ class TestDiffContracts:
         assert any(b["type"] == "contract_type_changed" for b in breaking)
 
     def test_removed_field_from_published_event_is_breaking(self):
-        event_with_field = _make_event(
-            "OrderPlaced",
-            "app.OrderPlaced",
-            fields={"amount": {"kind": "standard", "type": "Float"}},
-        )
-        event_without_field = _make_event("OrderPlaced", "app.OrderPlaced", fields={})
-
         left = _minimal_ir(
-            clusters={
-                "app.Order": _make_cluster(
-                    "Order", events={"app.OrderPlaced": event_with_field}
-                )
-            },
             contracts={
                 "events": [
-                    {"__type__": "Test.OrderPlaced.v1", "fqn": "app.OrderPlaced"}
+                    self._contract_event(
+                        fields={"amount": {"kind": "standard", "type": "Float"}}
+                    )
                 ]
             },
         )
         right = _minimal_ir(
-            clusters={
-                "app.Order": _make_cluster(
-                    "Order", events={"app.OrderPlaced": event_without_field}
-                )
-            },
-            contracts={
-                "events": [
-                    {"__type__": "Test.OrderPlaced.v1", "fqn": "app.OrderPlaced"}
-                ]
-            },
+            contracts={"events": [self._contract_event(fields={})]},
         )
         result = diff_ir(left, right)
         assert result["summary"]["has_breaking_changes"] is True
@@ -407,9 +381,7 @@ class TestDiffContracts:
         )
 
     def test_no_breaking_when_contracts_unchanged(self):
-        contract = {
-            "events": [{"__type__": "Test.OrderPlaced.v1", "fqn": "app.OrderPlaced"}]
-        }
+        contract = {"events": [self._contract_event()]}
         left = _minimal_ir(contracts=copy.deepcopy(contract))
         right = _minimal_ir(contracts=copy.deepcopy(contract))
         result = diff_ir(left, right)

--- a/tests/ir/test_elements_contracts_diagnostics.py
+++ b/tests/ir/test_elements_contracts_diagnostics.py
@@ -372,7 +372,24 @@ class TestPublishedContracts:
 
     def test_published_event_has_type(self):
         event = self.ir["contracts"]["events"][0]
-        assert "__type__" in event
+        assert "type" in event
+        assert event["type"].startswith("PublishedTest.")
+
+    def test_published_event_has_version(self):
+        event = self.ir["contracts"]["events"][0]
+        assert event["version"] == 1
+
+    def test_published_event_has_fields(self):
+        event = self.ir["contracts"]["events"][0]
+        assert "fields" in event
+        assert "account_id" in event["fields"]
+        assert "holder_name" in event["fields"]
+
+    def test_published_event_keys_are_language_neutral(self):
+        """Contract entries should not use Python-specific dunder keys."""
+        event = self.ir["contracts"]["events"][0]
+        assert "__type__" not in event
+        assert "__version__" not in event
 
     def test_unpublished_event_excluded(self):
         """AccountUpdated is not published and should not appear."""


### PR DESCRIPTION
Contract entries now use `type` (not `__type__`), `version` (not `__version__`), and include field schemas directly — making the contracts section self-contained and language-agnostic for downstream consumers.

- Rewrite `_build_contracts()` to emit `type`, `version`, and `fields`
- Simplify `_diff_contracts()` to read fields from contract entries directly instead of looking them up in clusters
- Update JSON schema, CLI diff output, and example IR files

Closes #706