### PR TITLE
CLI integration: protean docs generate

### DIFF
--- a/src/protean/cli/docs.py
+++ b/src/protean/cli/docs.py
@@ -69,7 +69,6 @@ def preview():
 # ---------------------------------------------------------------------------
 
 _VALID_TYPES = ("clusters", "events", "handlers", "catalog", "all")
-_DIAGRAM_TYPES = ("clusters", "events", "handlers")
 
 
 @app.command()
@@ -117,7 +116,7 @@ def generate(
         str,
         typer.Option(
             "--cluster",
-            help="Filter to a specific cluster FQN (for --type=clusters only)",
+            help="Filter to a specific cluster FQN (for --type=clusters or --type=all)",
         ),
     ] = "",
 ) -> None:
@@ -224,23 +223,24 @@ def _generate_clusters(
             return raw
         return mermaid_fence(raw, title="Aggregate Cluster")
 
-    # For --type=all or --type=clusters without --cluster,
-    # generate one diagram per cluster.
+    # For --type=all or --type=clusters without --cluster filter.
     clusters = ir_data.get("clusters", {})
+
+    if output_format == "mermaid":
+        # Raw Mermaid: emit a single combined classDiagram (multiple
+        # top-level classDiagram declarations are invalid Mermaid).
+        return generate_cluster_diagram(ir_data)
+
+    # Markdown: one fenced diagram per cluster for readability.
     if not clusters:
         raw = generate_cluster_diagram(ir_data)
-        if output_format == "mermaid":
-            return raw
         return mermaid_fence(raw, title="Aggregate Clusters")
 
     parts: list[str] = []
     for cfqn in sorted(clusters):
         raw = generate_cluster_diagram(ir_data, cluster_fqn=cfqn)
         cluster_name = cfqn.rsplit(".", 1)[-1] if "." in cfqn else cfqn
-        if output_format == "mermaid":
-            parts.append(raw)
-        else:
-            parts.append(mermaid_fence(raw, title=f"Cluster: {cluster_name}"))
+        parts.append(mermaid_fence(raw, title=f"Cluster: {cluster_name}"))
 
     return "\n\n".join(parts)
 

--- a/tests/cli/test_docs_generate.py
+++ b/tests/cli/test_docs_generate.py
@@ -664,11 +664,15 @@ class TestEmptyIR:
 
 
 class TestFullIntegration:
-    """Tests using the bundled ordering-ir.json example."""
+    """Tests using the bundled ordering-ir.json example.
+
+    The fixture asserts the file exists so a missing or moved example
+    causes a loud failure rather than a silent skip.
+    """
 
     @pytest.fixture()
     def ordering_ir_path(self) -> Path:
-        return (
+        path = (
             Path(__file__).resolve().parents[2]
             / "src"
             / "protean"
@@ -676,12 +680,11 @@ class TestFullIntegration:
             / "examples"
             / "ordering-ir.json"
         )
+        assert path.exists(), f"Bundled example IR not found at {path}"
+        return path
 
     def test_all_from_example(self, ordering_ir_path):
         """Full generation from the ordering example."""
-        if not ordering_ir_path.exists():
-            pytest.skip("ordering-ir.json not found")
-
         result = runner.invoke(
             app,
             ["generate", f"--ir={ordering_ir_path}"],
@@ -695,9 +698,6 @@ class TestFullIntegration:
 
     def test_mermaid_from_example(self, ordering_ir_path):
         """Mermaid output from the ordering example."""
-        if not ordering_ir_path.exists():
-            pytest.skip("ordering-ir.json not found")
-
         result = runner.invoke(
             app,
             [
@@ -713,9 +713,6 @@ class TestFullIntegration:
 
     def test_cluster_filter_from_example(self, ordering_ir_path):
         """Cluster filter with the ordering example."""
-        if not ordering_ir_path.exists():
-            pytest.skip("ordering-ir.json not found")
-
         result = runner.invoke(
             app,
             [
@@ -730,9 +727,6 @@ class TestFullIntegration:
 
     def test_file_output_from_example(self, ordering_ir_path, tmp_path):
         """Write full docs from ordering example to file."""
-        if not ordering_ir_path.exists():
-            pytest.skip("ordering-ir.json not found")
-
         out_file = tmp_path / "architecture.md"
         result = runner.invoke(
             app,


### PR DESCRIPTION
## Summary

- Add `generate` subcommand to `protean docs` CLI, wiring all four architecture generators into a single user-facing entry point
- Support `--domain` (live domain) and `--ir` (JSON file) as mutually exclusive IR sources
- Support `--type` to select generator: `clusters`, `events`, `handlers`, `catalog`, or `all` (default)
- Support `--format` for `markdown` (fenced Mermaid code blocks) or `mermaid` (raw diagram syntax)
- Support `--output` to write to a file instead of stdout, with automatic parent directory creation
- Support `--cluster` to filter cluster diagrams to a specific aggregate FQN
- Validate all option combinations (mutual exclusivity, format/type compatibility) with clear error messages
- 39 tests covering input validation, IR file/domain loading, all generator types, format modes, cluster filtering, file output, empty IR, and full integration with the ordering example

Closes #720