### PR TITLE
Add projection and invariant testing DSLs to protean.testing

### DIFF
--- a/src/protean/testing.py
+++ b/src/protean/testing.py
@@ -501,7 +501,14 @@ class EventSequence:
             ProjectionResult: Result object with ``.has()``, ``.found``,
             and ``.projection`` for assertions.
         """
+        from protean.exceptions import ObjectNotFoundError
         from protean.utils.globals import current_domain
+
+        if not identity:
+            raise ValueError(
+                "then() requires at least one keyword argument to identify "
+                "the projection record (e.g., id='u1')"
+            )
 
         domain = current_domain
 
@@ -512,18 +519,13 @@ class EventSequence:
                 handler_cls._handle(event)
 
         # Retrieve the projection
-        if not identity:
-            raise ValueError(
-                "then() requires at least one keyword argument to identify "
-                "the projection record (e.g., id='u1')"
-            )
 
         repo = domain.repository_for(projection_cls)
         identifier_value = next(iter(identity.values()))
 
         try:
             projection = repo.get(identifier_value)
-        except Exception:
+        except ObjectNotFoundError:
             projection = None
 
         return ProjectionResult(projection_cls, projection)
@@ -584,7 +586,12 @@ class ProjectionResult:
                 f"{self._projection_cls.__name__} projection not found"
             )
         for attr, expected_value in expected.items():
-            actual = getattr(self._projection, attr)
+            try:
+                actual = getattr(self._projection, attr)
+            except AttributeError:
+                raise AssertionError(
+                    f"{self._projection_cls.__name__} has no attribute '{attr}'"
+                ) from None
             if actual != expected_value:
                 raise AssertionError(
                     f"{self._projection_cls.__name__}.{attr}: "

--- a/tests/testing/test_given_projection.py
+++ b/tests/testing/test_given_projection.py
@@ -281,6 +281,16 @@ class TestProjectionResultAssertionFailures:
         with pytest.raises(AssertionError, match="expected 999"):
             result.has(balance=999)
 
+    def test_has_raises_on_unknown_attribute(self):
+        """has() raises AssertionError with context when attribute doesn't exist."""
+        uid = str(uuid4())
+        result = given(
+            Registered(user_id=uid, email="a@b.com", name="Alice"),
+        ).then(Balances, id=uid)
+
+        with pytest.raises(AssertionError, match="has no attribute 'balanec'"):
+            result.has(balanec=100)
+
 
 # ---------------------------------------------------------------------------
 # Tests: ProjectionResult — repr and private attrs

--- a/tests/testing/test_invariant_helpers.py
+++ b/tests/testing/test_invariant_helpers.py
@@ -11,7 +11,6 @@ import pytest
 from protean.core.aggregate import BaseAggregate
 from protean.core.domain_service import BaseDomainService
 from protean.core.entity import BaseEntity, invariant
-from protean.core.event import BaseEvent
 from protean.core.value_object import BaseValueObject
 from protean.exceptions import ValidationError
 from protean.fields import Float, HasMany, Identifier, Integer, String, ValueObject


### PR DESCRIPTION
## Summary

Extends the `protean.testing` module with two new testing DSLs: a projection testing pipeline and invariant assertion helpers. The `given()` function now polymorphically dispatches to different result types based on arguments, enabling fluent testing of both event-sourced aggregates and projections.

## Key Changes

- **Polymorphic `given()` function**: Now accepts either an aggregate class (existing behavior) or event instances (new). Returns `AggregateResult` for aggregate tests or `EventSequence` for projection tests.

- **EventSequence class**: Represents a sequence of domain events for projection testing. Provides `.then(ProjectionClass, id=...)` to process events through projector handlers and retrieve the resulting projection state.

- **ProjectionResult class**: Encapsulates the result of querying a projection after event processing. Features:
  - `.found` / `.not_found` properties to check existence
  - `.projection` property for direct access to the projection instance
  - `.has(**expected)` method for fluent attribute assertions with descriptive error messages
  - Attribute proxying to the underlying projection for convenient access (e.g., `result.balance`)

- **Invariant testing helpers**:
  - `assert_invalid(operation, message=None)`: Asserts that an operation raises `ValidationError`, optionally checking for a specific message. Returns the caught exception for further assertions.
  - `assert_valid(operation)`: Asserts that an operation completes without raising `ValidationError`. Returns the operation's result.

- **Updated module docstring**: Clarifies the three testing patterns now supported (event-sourcing, projections, invariants) with usage examples.

## Implementation Details

- Event processing in `EventSequence.then()` dispatches events to registered handlers via `domain.handlers_for(event)` and calls `_handle()` on each handler class.
- Projection retrieval uses the domain's repository pattern with the first identity keyword argument value.
- `ProjectionResult.__getattr__()` proxies attribute access while protecting private attributes and providing clear error messages when projections are not found.
- Validation error messages are flattened from nested dictionaries for flexible matching in `assert_invalid()`.
- Both new test helpers are designed for lambda-wrapped operations to defer execution until assertion time.

Closes #723 