### PR TITLE
Fix naive/aware datetime comparison in outbox retry logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fix `TypeError: can't compare offset-naive and offset-aware datetimes` in outbox retry logic. Database adapters may return timezone-naive datetimes for `next_retry_at` and `locked_until`, causing comparisons with `datetime.now(timezone.utc)` to crash and block all outbox processing. Added shared `ensure_utc_aware()` utility to normalize naive datetimes before comparison.
 - Fix flaky `test_mixed_error_scenarios` in `test_server_robustness.py`: increase Engine test_mode processing cycles from 3 to 10 so all subscription types (events, commands, broker messages) have enough time to be scheduled and process their messages under CI load
 - Bridge `correlation_id` from external broker messages to subscriber-triggered commands: `Engine.handle_broker_message()` now extracts `correlation_id` from the incoming message's `metadata.domain.correlation_id` (Protean external format) and sets it on the stub message context. When no correlation ID is present, a fresh UUID is auto-generated. This ensures the cross-service correlation chain is preserved through subscriber processing.
 - Preserve outer message context across nested `domain.process()` calls: `CommandProcessor.process()` now saves and restores the previous `g.message_in_context` instead of unconditionally clearing it. This fixes correlation ID loss when a subscriber dispatches multiple commands within a single handler invocation.

--- a/src/protean/server/outbox_processor.py
+++ b/src/protean/server/outbox_processor.py
@@ -352,10 +352,10 @@ class OutboxProcessor(BaseSubscription):
                         if hasattr(message, "created_at") and message.created_at:
                             import datetime
 
+                            from protean.utils import ensure_utc_aware
+
                             now = datetime.datetime.now(datetime.timezone.utc)
-                            created = message.created_at
-                            if created.tzinfo is None:
-                                created = created.replace(tzinfo=datetime.timezone.utc)
+                            created = ensure_utc_aware(message.created_at)
                             latency_s = (now - created).total_seconds()
                             if latency_s >= 0:
                                 metrics.outbox_latency.record(latency_s)

--- a/src/protean/utils/__init__.py
+++ b/src/protean/utils/__init__.py
@@ -50,6 +50,18 @@ class Cache(Enum):
     redis = "redis"
 
 
+def ensure_utc_aware(dt: datetime) -> datetime:
+    """Ensure a datetime is timezone-aware, assuming naive values are UTC.
+
+    Database adapters may return naive datetimes even when values were stored
+    as UTC-aware. This helper attaches UTC tzinfo to naive datetimes while
+    returning already-aware values unchanged.
+    """
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt
+
+
 class TypeMatcher:
     """Allow assertion on object type.
 

--- a/src/protean/utils/outbox.py
+++ b/src/protean/utils/outbox.py
@@ -8,22 +8,12 @@ from pydantic import Field
 from protean.core.aggregate import BaseAggregate
 from protean.core.repository import BaseRepository
 from protean.fields import Auto
+from protean.utils import ensure_utc_aware
 from protean.utils.eventing import Metadata
 from protean.utils.query import Q
 
 
 PAGE_SIZE = 50  # Default page size for fetching messages
-
-
-def _ensure_utc_aware(dt: datetime) -> datetime:
-    """Ensure a datetime is timezone-aware (UTC).
-
-    Database adapters may return naive datetimes even when values were stored
-    as UTC-aware. This normalizes them for safe comparison.
-    """
-    if dt.tzinfo is None:
-        return dt.replace(tzinfo=timezone.utc)
-    return dt
 
 
 class OutboxStatus(Enum):
@@ -162,7 +152,7 @@ class Outbox(BaseAggregate):
         # Check if enough time has passed for retry
         if self.next_retry_at:
             current_time = datetime.now(timezone.utc)
-            if current_time < _ensure_utc_aware(self.next_retry_at):
+            if current_time < ensure_utc_aware(self.next_retry_at):
                 return False, ProcessingResult.RETRY_NOT_DUE
 
         # Acquire lock and mark as processing
@@ -275,7 +265,7 @@ class Outbox(BaseAggregate):
         # Check if enough time has passed for retry
         if self.next_retry_at:
             current_time = datetime.now(timezone.utc)
-            if current_time < _ensure_utc_aware(self.next_retry_at):
+            if current_time < ensure_utc_aware(self.next_retry_at):
                 return False
 
         return True
@@ -285,7 +275,7 @@ class Outbox(BaseAggregate):
         """Check if message is currently locked for processing."""
         return bool(
             self.locked_until
-            and datetime.now(timezone.utc) < _ensure_utc_aware(self.locked_until)
+            and datetime.now(timezone.utc) < ensure_utc_aware(self.locked_until)
             and self.status == OutboxStatus.PROCESSING.value
         )
 

--- a/tests/outbox/test_outbox_aggregate.py
+++ b/tests/outbox/test_outbox_aggregate.py
@@ -734,14 +734,17 @@ class TestNaiveDatetimeHandling:
 
         assert sample_outbox._is_locked() is False
 
-    def test_is_ready_not_ready_when_locked_with_naive_datetime(self, sample_outbox):
-        """Test is_ready_for_processing returns False when locked with naive datetime."""
+    def test_start_processing_locked_with_naive_locked_until(self, sample_outbox):
+        """Test start_processing returns ALREADY_LOCKED with naive locked_until."""
         sample_outbox.status = OutboxStatus.PROCESSING.value
         sample_outbox.locked_until = datetime.now(timezone.utc).replace(
             tzinfo=None
         ) + timedelta(minutes=5)
 
-        assert sample_outbox.is_ready_for_processing() is False
+        success, result = sample_outbox.start_processing("worker-2")
+
+        assert success is False
+        assert result == ProcessingResult.ALREADY_LOCKED
 
 
 class TestEdgeCases:


### PR DESCRIPTION
Database adapters may return timezone-naive datetimes for next_retry_at and locked_until, while the comparison uses timezone-aware datetime.now(timezone.utc). This mismatch raises TypeError and blocks all outbox processing when any message has a non-null next_retry_at.