### PR TITLE
Add CLI logging control surface (--log-level, --log-format, --log-config)

### DIFF
--- a/changes/915.added.md
+++ b/changes/915.added.md
@@ -1,0 +1,1 @@
+Add global `--log-level`, `--log-format`, and `--log-config` CLI options that apply to every `protean` subcommand, and wrap all CLI commands with a structured exception handler that logs failures before exiting.

--- a/changes/915.changed.md
+++ b/changes/915.changed.md
@@ -1,0 +1,1 @@
+Deprecate `--debug` flag on `protean server` and `protean observatory` in favor of `--log-level DEBUG`. The flag still works but emits a `DeprecationWarning`; it will be removed in v0.17.0.

--- a/src/protean/cli/__init__.py
+++ b/src/protean/cli/__init__.py
@@ -15,12 +15,18 @@ Why does this file exist, and why not put this in __main__?
   Also see (1) from http://click.pocoo.org/5/setuptools/#setuptools-integration
 """
 
-from typing import Optional
+import json
+import warnings
+from pathlib import Path
+from typing import Any, Optional
 
 import typer
 from rich import print
 from typing_extensions import Annotated
 
+from protean.cli._helpers import CTX_LOG_CONFIGURED  # noqa: F401 — re-exported
+from protean.cli._helpers import cli_exception_handler  # noqa: F401 — re-exported
+from protean.cli._helpers import handle_cli_exceptions  # noqa: F401 — re-exported
 from protean.cli.check import check
 from protean.cli.database import app as db_app
 from protean.cli.dlq import app as dlq_app
@@ -31,8 +37,8 @@ from protean.cli.ir import app as ir_app
 from protean.cli.schema import app as schema_app
 from protean.cli.new import new
 from protean.cli.observatory import observatory
-from protean.cli.shell import shell
 from protean.cli.projection import app as projection_app
+from protean.cli.shell import shell
 from protean.cli.snapshot import app as snapshot_app
 from protean.cli.subscriptions import app as subscriptions_app
 from protean.cli.test import app as test_app
@@ -42,6 +48,7 @@ from protean.utils.domain_discovery import derive_domain
 from protean.utils.logging import configure_logging, get_logger
 
 logger = get_logger(__name__)
+
 
 # Create the Typer app
 #   `no_args_is_help=True` will show the help message when no arguments are passed
@@ -64,7 +71,11 @@ app.add_typer(subscriptions_app, name="subscriptions")
 app.add_typer(test_app, name="test")
 
 
-def version_callback(value: bool):
+_LOG_LEVELS = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+_LOG_FORMATS = ("auto", "console", "json")
+
+
+def version_callback(value: bool) -> None:
     if value:
         from protean import __version__
 
@@ -78,14 +89,67 @@ def main(
     version: Annotated[
         bool, typer.Option(help="Show version information", callback=version_callback)
     ] = False,
-):
-    """
-    Protean CLI
-    """
+    log_level: Annotated[
+        Optional[str],
+        typer.Option(
+            "--log-level",
+            help="Logging level: DEBUG, INFO, WARNING, ERROR, CRITICAL",
+        ),
+    ] = None,
+    log_format: Annotated[
+        Optional[str],
+        typer.Option(
+            "--log-format",
+            help="Logging output format: auto, console, json",
+        ),
+    ] = None,
+    log_config: Annotated[
+        Optional[Path],
+        typer.Option(
+            "--log-config",
+            help="Path to a JSON dictConfig file for logging",
+            exists=True,
+            readable=True,
+        ),
+    ] = None,
+) -> None:
+    """Protean CLI"""
+    # Resolve effective logging configuration per the documented precedence:
+    #   1. --log-config PATH  →  dictConfig
+    #   2. --log-level / --log-format  →  configure_logging(level=..., format=...)
+    #   3. Otherwise  →  defer to Domain.init() auto-configuration
+    ctx.ensure_object(dict)
+
+    if log_config is not None:
+        payload = json.loads(log_config.read_text())
+        configure_logging(dict_config=payload)
+        ctx.obj[CTX_LOG_CONFIGURED] = True
+    elif log_level is not None or log_format is not None:
+        kwargs: dict[str, Any] = {}
+        if log_level is not None:
+            upper = log_level.upper()
+            if upper not in _LOG_LEVELS:
+                print(
+                    f"Error: Invalid log level '{log_level}'. "
+                    f"Choose from: {', '.join(_LOG_LEVELS)}"
+                )
+                raise typer.Exit(code=2)
+            kwargs["level"] = upper
+        if log_format is not None:
+            if log_format not in _LOG_FORMATS:
+                print(
+                    f"Error: Invalid log format '{log_format}'. "
+                    f"Choose from: {', '.join(_LOG_FORMATS)}"
+                )
+                raise typer.Exit(code=2)
+            kwargs["format"] = log_format
+        configure_logging(**kwargs)
+        ctx.obj[CTX_LOG_CONFIGURED] = True
 
 
 @app.command()
 def server(
+    ctx: typer.Context,
     domain: Annotated[str, typer.Option()] = ".",
     test_mode: Annotated[Optional[bool], typer.Option()] = False,
     debug: Annotated[Optional[bool], typer.Option()] = False,
@@ -97,86 +161,96 @@ def server(
             help="Enable auto-reload on file changes (development only)",
         ),
     ] = False,
-):
+) -> None:
     """Run Async Background Server"""
-    # Configure logging based on debug flag
-    configure_logging(level="DEBUG" if debug else "INFO")
 
-    if workers < 1:
-        print("Error: --workers must be >= 1")
-        raise typer.Abort()
+    if debug:
+        warnings.warn(
+            "--debug is deprecated; use --log-level DEBUG. Will be removed in v0.17.0.",
+            DeprecationWarning,
+            stacklevel=1,
+        )
 
-    if reload and workers > 1:
-        print("Error: --reload cannot be combined with --workers > 1")
-        raise typer.Abort()
+    parent_obj = getattr(ctx, "obj", None) or {}
+    if not parent_obj.get(CTX_LOG_CONFIGURED):
+        configure_logging(level="DEBUG" if debug else "INFO")
 
-    if reload:
-        # Development path: outer Reloader watches source files and
-        # restarts the inner Engine process on change.
-        try:
-            from protean.server.reloader import Reloader
-        except ModuleNotFoundError as exc:
-            # Only translate the missing-watchfiles case into the
-            # install hint. Any other ModuleNotFoundError almost
-            # certainly indicates a real bug inside the reloader (or
-            # one of its imports) and must be re-raised so it isn't
-            # masked.
-            if exc.name != "watchfiles":
-                raise
-            msg = (
-                "Error: --reload requires the 'watchfiles' package. "
-                "Install it with 'pip install \"protean[dev]\"'."
-            )
-            print(msg)
-            logger.error("%s (%s)", msg, exc)
+    with cli_exception_handler("server"):
+        if workers < 1:
+            print("Error: --workers must be >= 1")
             raise typer.Abort()
 
-        reloader = Reloader(
-            domain_path=domain,
-            test_mode=test_mode,
-            debug=debug,
-        )
-        reloader.run()
+        if reload and workers > 1:
+            print("Error: --reload cannot be combined with --workers > 1")
+            raise typer.Abort()
 
-        if reloader.exit_code != 0:
-            raise typer.Exit(code=reloader.exit_code)
-        return
+        if reload:
+            # Development path: outer Reloader watches source files and
+            # restarts the inner Engine process on change.
+            try:
+                from protean.server.reloader import Reloader
+            except ModuleNotFoundError as exc:
+                # Only translate the missing-watchfiles case into the
+                # install hint. Any other ModuleNotFoundError almost
+                # certainly indicates a real bug inside the reloader (or
+                # one of its imports) and must be re-raised so it isn't
+                # masked.
+                if exc.name != "watchfiles":
+                    raise
+                msg = (
+                    "Error: --reload requires the 'watchfiles' package. "
+                    "Install it with 'pip install \"protean[dev]\"'."
+                )
+                print(msg)
+                logger.error("%s (%s)", msg, exc)
+                raise typer.Abort()
 
-    try:
-        derived_domain = derive_domain(domain)
-    except NoDomainException as exc:
-        msg = f"Error loading Protean domain: {exc.args[0]}"
-        print(msg)  # Required for tests to capture output
-        logger.error(msg)
+            reloader = Reloader(
+                domain_path=domain,
+                test_mode=test_mode,
+                debug=debug,
+            )
+            reloader.run()
 
-        raise typer.Abort()
+            if reloader.exit_code != 0:
+                raise typer.Exit(code=reloader.exit_code)
+            return
 
-    assert derived_domain is not None
+        try:
+            derived_domain = derive_domain(domain)
+        except NoDomainException as exc:
+            msg = f"Error loading Protean domain: {exc.args[0]}"
+            print(msg)  # Required for tests to capture output
+            logger.error(msg)
 
-    if workers == 1:
-        # Single-worker path: identical to previous behavior, zero overhead.
-        # Traverse and initialize domain — loads all aggregates, entities,
-        # services, and other domain elements.
-        derived_domain.init()
+            raise typer.Abort()
 
-        with derived_domain.domain_context():
-            engine = Engine(derived_domain, test_mode=test_mode, debug=debug)
-            engine.run()
+        assert derived_domain is not None
 
-        if engine.exit_code != 0:
-            raise typer.Exit(code=engine.exit_code)
-    else:
-        # Multi-worker path: Supervisor spawns N independent Engine processes.
-        # Each worker derives and initializes the domain independently.
-        from protean.server.supervisor import Supervisor
+        if workers == 1:
+            # Single-worker path: identical to previous behavior, zero overhead.
+            # Traverse and initialize domain — loads all aggregates, entities,
+            # services, and other domain elements.
+            derived_domain.init()
 
-        supervisor = Supervisor(
-            domain_path=domain,
-            num_workers=workers,
-            test_mode=test_mode,
-            debug=debug,
-        )
-        supervisor.run()
+            with derived_domain.domain_context():
+                engine = Engine(derived_domain, test_mode=test_mode, debug=debug)
+                engine.run()
 
-        if supervisor.exit_code != 0:
-            raise typer.Exit(code=supervisor.exit_code)
+            if engine.exit_code != 0:
+                raise typer.Exit(code=engine.exit_code)
+        else:
+            # Multi-worker path: Supervisor spawns N independent Engine processes.
+            # Each worker derives and initializes the domain independently.
+            from protean.server.supervisor import Supervisor
+
+            supervisor = Supervisor(
+                domain_path=domain,
+                num_workers=workers,
+                test_mode=test_mode,
+                debug=debug,
+            )
+            supervisor.run()
+
+            if supervisor.exit_code != 0:
+                raise typer.Exit(code=supervisor.exit_code)

--- a/src/protean/cli/__init__.py
+++ b/src/protean/cli/__init__.py
@@ -121,7 +121,14 @@ def main(
     ctx.ensure_object(dict)
 
     if log_config is not None:
-        payload = json.loads(log_config.read_text())
+        try:
+            payload = json.loads(log_config.read_text(encoding="utf-8"))
+        except OSError as exc:
+            print(f"Error: Unable to read log config '{log_config}': {exc}")
+            raise typer.Exit(code=2) from exc
+        except json.JSONDecodeError as exc:
+            print(f"Error: Invalid JSON in log config '{log_config}': {exc}")
+            raise typer.Exit(code=2) from exc
         configure_logging(dict_config=payload)
         ctx.obj[CTX_LOG_CONFIGURED] = True
     elif log_level is not None or log_format is not None:

--- a/src/protean/cli/_helpers.py
+++ b/src/protean/cli/_helpers.py
@@ -1,0 +1,61 @@
+"""Shared CLI helpers.
+
+This module exists separately to avoid circular imports — ``cli/__init__.py``
+imports every subcommand module, so subcommand modules cannot import from
+``cli/__init__.py`` directly.
+"""
+
+import functools
+import sys
+from contextlib import contextmanager
+from typing import Any, Callable, Iterator
+
+import typer
+
+from protean.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+# Key used to store CLI logging state in the Typer context.
+# Shared between cli/__init__.py (callback) and subcommands that have their
+# own logging setup (server, observatory) to avoid double-configuration.
+CTX_LOG_CONFIGURED = "_protean_log_configured"
+
+
+@contextmanager
+def cli_exception_handler(command: str) -> Iterator[None]:
+    """Context manager that logs unhandled exceptions from CLI commands.
+
+    Wraps the command body in ``try/except Exception``, logs the failure
+    with ``logger.exception`` for structured output, and re-raises so
+    Typer produces a non-zero exit code.
+    """
+    try:
+        yield
+    except (typer.Exit, typer.Abort, SystemExit, KeyboardInterrupt):
+        raise
+    except Exception:
+        logger.exception("cli.command_failed", command=command, argv=sys.argv)
+        raise
+
+
+def handle_cli_exceptions(command_name: str) -> Callable:
+    """Decorator that wraps a CLI command with structured exception logging.
+
+    Usage::
+
+        @app.command()
+        @handle_cli_exceptions("db setup")
+        def setup(...):
+            ...
+    """
+
+    def decorator(func: Callable) -> Callable:
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            with cli_exception_handler(command_name):
+                return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/src/protean/cli/check.py
+++ b/src/protean/cli/check.py
@@ -27,6 +27,7 @@ from rich import print
 from rich.console import Console
 from typing_extensions import Annotated
 
+from protean.cli._helpers import handle_cli_exceptions
 from protean.exceptions import NoDomainException
 from protean.utils.domain_discovery import derive_domain
 from protean.utils.logging import get_logger
@@ -39,6 +40,7 @@ _CONSOLE = Console()
 _LEVEL_ORDER = {"error": 0, "warning": 1, "info": 2}
 
 
+@handle_cli_exceptions("check")
 def check(
     domain: Annotated[
         str,

--- a/src/protean/cli/database.py
+++ b/src/protean/cli/database.py
@@ -4,6 +4,7 @@ import typer
 from rich import print
 from typing_extensions import Annotated
 
+from protean.cli._helpers import handle_cli_exceptions
 from protean.exceptions import ConfigurationError, NoDomainException
 from protean.utils.domain_discovery import derive_domain
 from protean.utils.logging import get_logger
@@ -19,6 +20,7 @@ def callback():
 
 
 @app.command()
+@handle_cli_exceptions("db setup")
 def setup(
     domain: Annotated[str, typer.Option(help="Domain module path")] = ".",
 ) -> None:
@@ -41,6 +43,7 @@ def setup(
 
 
 @app.command()
+@handle_cli_exceptions("db drop")
 def drop(
     domain: Annotated[str, typer.Option(help="Domain module path")] = ".",
     yes: Annotated[
@@ -71,6 +74,7 @@ def drop(
 
 
 @app.command()
+@handle_cli_exceptions("db truncate")
 def truncate(
     domain: Annotated[str, typer.Option(help="Domain module path")] = ".",
     yes: Annotated[
@@ -103,6 +107,7 @@ def truncate(
 
 
 @app.command(name="setup-outbox")
+@handle_cli_exceptions("db setup-outbox")
 def setup_outbox(
     domain: Annotated[str, typer.Option(help="Domain module path")] = ".",
 ) -> None:

--- a/src/protean/cli/dlq.py
+++ b/src/protean/cli/dlq.py
@@ -34,6 +34,7 @@ from rich import print
 from rich.table import Table
 from typing_extensions import Annotated
 
+from protean.cli._helpers import handle_cli_exceptions
 from protean.exceptions import NoDomainException
 from protean.port.broker import BrokerCapabilities
 from protean.utils.dlq import collect_dlq_streams, discover_subscriptions
@@ -126,6 +127,7 @@ def _format_time(raw: str | None) -> str:
 
 
 @app.command(name="list")
+@handle_cli_exceptions("dlq list")
 def list_dlq(
     domain: Annotated[str, typer.Option(help="Domain module path")] = ".",
     subscription: Annotated[
@@ -177,6 +179,7 @@ def list_dlq(
 
 
 @app.command()
+@handle_cli_exceptions("dlq inspect")
 def inspect(
     dlq_id: Annotated[str, typer.Argument(help="DLQ entry identifier")],
     domain: Annotated[str, typer.Option(help="Domain module path")] = ".",
@@ -218,6 +221,7 @@ def inspect(
 
 
 @app.command()
+@handle_cli_exceptions("dlq replay")
 def replay(
     dlq_id: Annotated[str, typer.Argument(help="DLQ entry identifier to replay")],
     domain: Annotated[str, typer.Option(help="Domain module path")] = ".",
@@ -248,6 +252,7 @@ def replay(
 
 
 @app.command(name="replay-all")
+@handle_cli_exceptions("dlq replay-all")
 def replay_all(
     subscription: Annotated[
         str,
@@ -279,6 +284,7 @@ def replay_all(
 
 
 @app.command()
+@handle_cli_exceptions("dlq purge")
 def purge(
     subscription: Annotated[
         str,

--- a/src/protean/cli/events.py
+++ b/src/protean/cli/events.py
@@ -35,6 +35,7 @@ from rich.table import Table
 from rich.tree import Tree as RichTree
 from typing_extensions import Annotated
 
+from protean.cli._helpers import handle_cli_exceptions
 from protean.exceptions import NoDomainException
 from protean.utils import DomainObjects
 from protean.utils.domain_discovery import derive_domain
@@ -214,6 +215,7 @@ def _count_nodes(node: "CausationNode") -> int:
 
 
 @app.command()
+@handle_cli_exceptions("events read")
 def read(
     stream: Annotated[
         str,
@@ -258,6 +260,7 @@ def read(
 
 
 @app.command()
+@handle_cli_exceptions("events stats")
 def stats(
     domain: Annotated[str, typer.Option(help="Domain module path")] = ".",
 ) -> None:
@@ -330,6 +333,7 @@ def stats(
 
 
 @app.command()
+@handle_cli_exceptions("events search")
 def search(
     type_name: Annotated[
         str,
@@ -386,6 +390,7 @@ def search(
 
 
 @app.command()
+@handle_cli_exceptions("events history")
 def history(
     aggregate: Annotated[str, typer.Option(help="Aggregate class name (e.g. 'User')")],
     identifier: Annotated[
@@ -462,6 +467,7 @@ def history(
 
 
 @app.command()
+@handle_cli_exceptions("events trace")
 def trace(
     correlation_id: Annotated[str, typer.Argument(help="Correlation ID to trace")],
     domain: Annotated[str, typer.Option(help="Domain module path")] = ".",

--- a/src/protean/cli/generate.py
+++ b/src/protean/cli/generate.py
@@ -1,12 +1,12 @@
-import logging
-
 import typer
 from typing_extensions import Annotated
 
+from protean.cli._helpers import handle_cli_exceptions
 from protean.exceptions import NoDomainException
 from protean.utils.domain_discovery import derive_domain
+from protean.utils.logging import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 app = typer.Typer(no_args_is_help=True)
 
@@ -27,6 +27,7 @@ def callback():
 
 
 @app.command()
+@handle_cli_exceptions("generate docker-compose")
 def docker_compose(
     domain: Annotated[str, typer.Option()] = ".",
 ):

--- a/src/protean/cli/observatory.py
+++ b/src/protean/cli/observatory.py
@@ -1,10 +1,12 @@
 """CLI command for running the Protean Observatory observability server."""
 
+import warnings
 from typing import List, Optional
 
 import typer
 from typing_extensions import Annotated
 
+from protean.cli._helpers import CTX_LOG_CONFIGURED, handle_cli_exceptions
 from protean.exceptions import NoDomainException
 from protean.utils.domain_discovery import derive_domain
 from protean.utils.logging import configure_logging, get_logger
@@ -12,6 +14,7 @@ from protean.utils.logging import configure_logging, get_logger
 logger = get_logger(__name__)
 
 
+@handle_cli_exceptions("observatory")
 def observatory(
     domain: Annotated[
         List[str],
@@ -27,7 +30,21 @@ def observatory(
     """Run the Observatory observability dashboard."""
     from protean.server.observatory import Observatory
 
-    configure_logging(level="DEBUG" if debug else "INFO")
+    if debug:
+        warnings.warn(
+            "--debug is deprecated; use --log-level DEBUG. Will be removed in v0.17.0.",
+            DeprecationWarning,
+            stacklevel=1,
+        )
+
+    # Check parent context for CLI-level logging configuration.
+    # click.get_current_context may fail when called directly (not via CLI).
+    import click
+
+    ctx = click.get_current_context(silent=True)
+    parent_obj = getattr(ctx, "obj", None) or {} if ctx else {}
+    if not parent_obj.get(CTX_LOG_CONFIGURED):
+        configure_logging(level="DEBUG" if debug else "INFO")
 
     if not domain:
         print("Error: at least one --domain is required")

--- a/src/protean/cli/projection.py
+++ b/src/protean/cli/projection.py
@@ -19,6 +19,7 @@ import typer
 from rich import print
 from typing_extensions import Annotated
 
+from protean.cli._helpers import handle_cli_exceptions
 from protean.exceptions import NoDomainException
 from protean.utils import DomainObjects
 from protean.utils.domain_discovery import derive_domain
@@ -38,6 +39,7 @@ def callback():
 
 
 @app.command()
+@handle_cli_exceptions("projection rebuild")
 def rebuild(
     domain: Annotated[str, typer.Option(help="Domain module path")] = ".",
     projection: Annotated[

--- a/src/protean/cli/shell.py
+++ b/src/protean/cli/shell.py
@@ -7,7 +7,6 @@ without having to manually configure the application.
 
 """
 
-import logging
 import sys
 import typing
 
@@ -15,12 +14,15 @@ import typer
 from IPython.terminal.embed import InteractiveShellEmbed
 from typing_extensions import Annotated
 
+from protean.cli._helpers import handle_cli_exceptions
 from protean.exceptions import NoDomainException
 from protean.utils.domain_discovery import derive_domain
+from protean.utils.logging import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
+@handle_cli_exceptions("shell")
 def shell(
     domain: Annotated[str, typer.Option()] = ".",
     traverse: Annotated[bool, typer.Option()] = False,

--- a/src/protean/cli/snapshot.py
+++ b/src/protean/cli/snapshot.py
@@ -4,6 +4,7 @@ import typer
 from rich import print
 from typing_extensions import Annotated
 
+from protean.cli._helpers import handle_cli_exceptions
 from protean.exceptions import (
     IncorrectUsageError,
     NoDomainException,
@@ -24,6 +25,7 @@ def callback():
 
 
 @app.command()
+@handle_cli_exceptions("snapshot create")
 def create(
     domain: Annotated[str, typer.Option(help="Domain module path")] = ".",
     aggregate: Annotated[

--- a/src/protean/cli/subscriptions.py
+++ b/src/protean/cli/subscriptions.py
@@ -20,6 +20,7 @@ from rich import print
 from rich.table import Table
 from typing_extensions import Annotated
 
+from protean.cli._helpers import handle_cli_exceptions
 from protean.exceptions import NoDomainException
 from protean.utils.domain_discovery import derive_domain
 from protean.utils.logging import get_logger
@@ -59,6 +60,7 @@ def _status_style(status: str) -> str:
 
 
 @app.command()
+@handle_cli_exceptions("subscriptions status")
 def status(
     domain: Annotated[str, typer.Option(help="Domain module path")] = ".",
     output_json: Annotated[

--- a/src/protean/utils/logging.py
+++ b/src/protean/utils/logging.py
@@ -21,6 +21,7 @@ Typical usage in application code::
 
 import functools
 import logging
+import logging.config
 import logging.handlers
 import os
 import sys
@@ -87,6 +88,7 @@ def configure_logging(
     backup_count: int = 5,
     extra_processors: Optional[list] = None,
     per_logger: Optional[dict[str, str]] = None,
+    dict_config: Optional[dict[str, Any]] = None,
 ) -> None:
     """Configure structured logging for a Protean application.
 
@@ -115,7 +117,21 @@ def configure_logging(
         per_logger: Optional mapping of logger names to level strings. Applied
             after global setup so individual loggers can be tuned independently.
             Example: ``{"protean.server.engine": "WARNING", "myapp.orders": "DEBUG"}``.
+        dict_config: Optional ``logging.config.dictConfig``-compatible dict.
+            When provided, bypasses the environment-aware setup and applies the
+            dict directly via ``logging.config.dictConfig()``. The user-supplied
+            dict is expected to include any handlers/formatters desired. After
+            applying, ``ProteanCorrelationFilter`` is still installed on the
+            root logger for consistency with ``Domain.configure_logging()``.
     """
+    if dict_config is not None:
+        logging.config.dictConfig(dict_config)
+        # Set up structlog so that get_logger() calls produce well-formed
+        # output even when the user supplies their own stdlib dictConfig.
+        env = _detect_env()
+        _setup_structlog(env=env, format="auto", extra_processors=extra_processors)
+        return
+
     env = _detect_env()
 
     # Resolve log level: explicit arg > env var > environment default

--- a/src/protean/utils/logging.py
+++ b/src/protean/utils/logging.py
@@ -130,6 +130,17 @@ def configure_logging(
         # output even when the user supplies their own stdlib dictConfig.
         env = _detect_env()
         _setup_structlog(env=env, format="auto", extra_processors=extra_processors)
+        # Install ProteanCorrelationFilter on the root logger so correlation_id
+        # and causation_id are available in every log record, matching the
+        # behavior of Domain.configure_logging().
+        try:
+            from protean.integrations.logging import ProteanCorrelationFilter
+
+            root = logging.getLogger()
+            if not any(isinstance(f, ProteanCorrelationFilter) for f in root.filters):
+                root.addFilter(ProteanCorrelationFilter())
+        except ImportError:
+            pass
         return
 
     env = _detect_env()

--- a/tests/cli/test_exception_handling.py
+++ b/tests/cli/test_exception_handling.py
@@ -101,14 +101,16 @@ class TestCliExceptionHandler:
         """typer.Abort passes through the handler without logging."""
         change_working_directory_to("test7")
 
-        result = runner.invoke(
-            app,
-            ["server", "--domain", "foobar"],
-        )
+        with patch("protean.cli._helpers.logger") as mock_logger:
+            result = runner.invoke(
+                app,
+                ["server", "--domain", "foobar"],
+            )
 
-        # Abort produces exit code 1 but is NOT a RuntimeError
-        assert result.exit_code != 0
-        assert not isinstance(result.exception, RuntimeError)
+            # Abort produces exit code 1 but is NOT a RuntimeError
+            assert result.exit_code != 0
+            assert not isinstance(result.exception, RuntimeError)
+            mock_logger.exception.assert_not_called()
 
     def test_typer_exit_is_not_caught(self):
         """typer.Exit passes through the handler without logging."""

--- a/tests/cli/test_exception_handling.py
+++ b/tests/cli/test_exception_handling.py
@@ -1,0 +1,126 @@
+"""Tests for CLI top-level exception handler.
+
+Verifies that the ``handle_cli_exceptions`` decorator / ``cli_exception_handler``
+context manager logs unhandled exceptions with structured output and preserves
+non-zero exit codes.
+"""
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from protean.cli import app
+from tests.shared import change_working_directory_to
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _reset_path():
+    """Reset sys.path and cwd after every test run."""
+    original_path = sys.path[:]
+    cwd = Path.cwd()
+    yield
+    sys.path[:] = original_path
+    os.chdir(cwd)
+
+
+class TestCliExceptionHandler:
+    def test_server_command_logs_exception_on_failure(self):
+        """When a command raises an unhandled exception, it is logged."""
+        change_working_directory_to("test7")
+
+        with patch(
+            "protean.cli.derive_domain",
+            side_effect=RuntimeError("boom"),
+        ):
+            with patch("protean.cli._helpers.logger") as mock_logger:
+                result = runner.invoke(
+                    app,
+                    ["server", "--domain", "publishing7.py"],
+                )
+
+                assert result.exit_code != 0
+                assert isinstance(result.exception, RuntimeError)
+
+                # Check that the exception handler called logger.exception
+                mock_logger.exception.assert_called_once()
+                call_args = mock_logger.exception.call_args
+                assert call_args[0][0] == "cli.command_failed"
+                assert call_args[1]["command"] == "server"
+
+    def test_server_exit_code_nonzero_on_failure(self):
+        """Unhandled exception produces a non-zero exit code."""
+        change_working_directory_to("test7")
+
+        with patch(
+            "protean.cli.derive_domain",
+            side_effect=RuntimeError("boom"),
+        ):
+            result = runner.invoke(
+                app,
+                ["server", "--domain", "publishing7.py"],
+            )
+
+            assert result.exit_code != 0
+            assert isinstance(result.exception, RuntimeError)
+
+    def test_shell_command_logs_exception_on_failure(self):
+        """The exception handler is installed on the shell command."""
+        with patch(
+            "protean.cli.shell.derive_domain",
+            side_effect=RuntimeError("shell boom"),
+        ):
+            with patch("protean.cli._helpers.logger") as mock_logger:
+                result = runner.invoke(app, ["shell", "--domain", "foobar"])
+
+                assert result.exit_code != 0
+                assert isinstance(result.exception, RuntimeError)
+                mock_logger.exception.assert_called_once()
+                assert mock_logger.exception.call_args[1]["command"] == "shell"
+
+    def test_check_command_logs_exception_on_failure(self):
+        """The exception handler is installed on the check command."""
+        with patch(
+            "protean.cli.check.derive_domain",
+            side_effect=RuntimeError("check boom"),
+        ):
+            with patch("protean.cli._helpers.logger") as mock_logger:
+                result = runner.invoke(app, ["check", "--domain", "foobar"])
+
+                assert result.exit_code != 0
+                assert isinstance(result.exception, RuntimeError)
+                mock_logger.exception.assert_called_once()
+                assert mock_logger.exception.call_args[1]["command"] == "check"
+
+    def test_abort_is_not_caught(self):
+        """typer.Abort passes through the handler without logging."""
+        change_working_directory_to("test7")
+
+        result = runner.invoke(
+            app,
+            ["server", "--domain", "foobar"],
+        )
+
+        # Abort produces exit code 1 but is NOT a RuntimeError
+        assert result.exit_code != 0
+        assert not isinstance(result.exception, RuntimeError)
+
+    def test_typer_exit_is_not_caught(self):
+        """typer.Exit passes through the handler without logging."""
+        change_working_directory_to("test7")
+
+        with patch("protean.cli.Engine") as MockEngine:
+            mock_engine = MockEngine.return_value
+            mock_engine.exit_code = 42
+
+            result = runner.invoke(
+                app,
+                ["server", "--domain", "publishing7.py"],
+            )
+
+            assert result.exit_code == 42

--- a/tests/cli/test_logging_flags.py
+++ b/tests/cli/test_logging_flags.py
@@ -175,6 +175,39 @@ class TestLogConfigFlag:
 
         assert result.exit_code != 0
 
+    def test_log_config_oserror_on_read(self, tmp_path):
+        """--log-config prints an OSError message when the file can't be read."""
+        # Create a valid file so Typer's exists=True check passes, then
+        # patch read_text to simulate a read failure (e.g. permissions).
+        config_file = tmp_path / "config.json"
+        config_file.write_text("{}")
+
+        with patch.object(
+            type(config_file),
+            "read_text",
+            side_effect=PermissionError("Permission denied"),
+        ):
+            result = runner.invoke(
+                app,
+                ["--log-config", str(config_file), "server"],
+            )
+
+        assert result.exit_code == 2
+        assert "Unable to read log config" in result.output
+
+    def test_log_config_invalid_json(self, tmp_path):
+        """--log-config with invalid JSON prints a JSONDecodeError message."""
+        config_file = tmp_path / "bad.json"
+        config_file.write_text("{ not valid json !!!")
+
+        result = runner.invoke(
+            app,
+            ["--log-config", str(config_file), "server"],
+        )
+
+        assert result.exit_code == 2
+        assert "Invalid JSON in log config" in result.output
+
 
 class TestDeprecatedDebugFlag:
     def test_debug_flag_emits_deprecation_warning(self):

--- a/tests/cli/test_logging_flags.py
+++ b/tests/cli/test_logging_flags.py
@@ -1,0 +1,228 @@
+"""Tests for CLI global logging flags (--log-level, --log-format, --log-config).
+
+Verifies the Typer callback wires up logging correctly and that the
+deprecated --debug flag still works with a deprecation warning.
+"""
+
+import json
+import logging
+import os
+import sys
+import warnings
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from protean.cli import app
+from tests.shared import change_working_directory_to
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _reset_path():
+    """Reset sys.path and cwd after every test run."""
+    original_path = sys.path[:]
+    cwd = Path.cwd()
+    yield
+    sys.path[:] = original_path
+    os.chdir(cwd)
+
+
+class TestLogLevelFlag:
+    def test_log_level_flag_applies_to_server(self):
+        """--log-level DEBUG sets the root logger level to DEBUG."""
+        change_working_directory_to("test7")
+
+        with patch("protean.cli.Engine") as MockEngine:
+            mock_engine = MockEngine.return_value
+            mock_engine.exit_code = 0
+
+            result = runner.invoke(
+                app,
+                ["--log-level", "DEBUG", "server", "--domain", "publishing7.py"],
+            )
+
+            assert result.exit_code == 0
+            assert logging.getLogger().level == logging.DEBUG
+
+    def test_log_level_warning(self):
+        """--log-level WARNING sets the root logger level to WARNING."""
+        change_working_directory_to("test7")
+
+        with patch("protean.cli.Engine") as MockEngine:
+            mock_engine = MockEngine.return_value
+            mock_engine.exit_code = 0
+
+            result = runner.invoke(
+                app,
+                ["--log-level", "WARNING", "server", "--domain", "publishing7.py"],
+            )
+
+            assert result.exit_code == 0
+            assert logging.getLogger().level == logging.WARNING
+
+    def test_log_level_invalid_value(self):
+        """--log-level with an invalid value exits with error."""
+        result = runner.invoke(app, ["--log-level", "BOGUS", "server"])
+
+        assert result.exit_code != 0
+        assert "Invalid log level" in result.output
+
+    def test_log_level_case_insensitive(self):
+        """--log-level accepts lowercase values."""
+        change_working_directory_to("test7")
+
+        with patch("protean.cli.Engine") as MockEngine:
+            mock_engine = MockEngine.return_value
+            mock_engine.exit_code = 0
+
+            result = runner.invoke(
+                app,
+                ["--log-level", "debug", "server", "--domain", "publishing7.py"],
+            )
+
+            assert result.exit_code == 0
+            assert logging.getLogger().level == logging.DEBUG
+
+
+class TestLogFormatFlag:
+    def test_log_format_json_configures_json(self):
+        """--log-format json configures structlog with JSON rendering."""
+        change_working_directory_to("test7")
+
+        with patch("protean.cli.Engine") as MockEngine:
+            mock_engine = MockEngine.return_value
+            mock_engine.exit_code = 0
+
+            result = runner.invoke(
+                app,
+                [
+                    "--log-format",
+                    "json",
+                    "server",
+                    "--domain",
+                    "publishing7.py",
+                ],
+            )
+
+            assert result.exit_code == 0
+
+    def test_log_format_invalid_value(self):
+        """--log-format with an invalid value exits with error."""
+        result = runner.invoke(app, ["--log-format", "xml", "server"])
+
+        assert result.exit_code != 0
+        assert "Invalid log format" in result.output
+
+
+class TestLogConfigFlag:
+    @pytest.mark.no_test_domain
+    def test_log_config_file_applied(self, tmp_path):
+        """--log-config with a valid JSON dictConfig applies the config."""
+        change_working_directory_to("test7")
+
+        # Provide a dictConfig that includes a handler so Domain.init()
+        # sees root.handlers and skips auto-configuration.
+        custom_config = {
+            "version": 1,
+            "disable_existing_loggers": False,
+            "handlers": {
+                "console": {
+                    "class": "logging.StreamHandler",
+                    "level": "CRITICAL",
+                    "stream": "ext://sys.stderr",
+                },
+            },
+            "root": {"level": "CRITICAL", "handlers": ["console"]},
+        }
+        config_file = tmp_path / "log_config.json"
+        config_file.write_text(json.dumps(custom_config))
+
+        with patch("protean.cli.Engine") as MockEngine:
+            mock_engine = MockEngine.return_value
+            mock_engine.exit_code = 0
+
+            result = runner.invoke(
+                app,
+                [
+                    "--log-config",
+                    str(config_file),
+                    "server",
+                    "--domain",
+                    "publishing7.py",
+                ],
+            )
+
+            assert result.exit_code == 0
+            assert logging.getLogger().level == logging.CRITICAL
+
+    def test_log_config_nonexistent_file(self):
+        """--log-config with a nonexistent file path exits with error."""
+        result = runner.invoke(
+            app,
+            ["--log-config", "/nonexistent/path.json", "server"],
+        )
+
+        assert result.exit_code != 0
+
+
+class TestDeprecatedDebugFlag:
+    def test_debug_flag_emits_deprecation_warning(self):
+        """--debug emits a DeprecationWarning mentioning the new flag."""
+        change_working_directory_to("test7")
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+
+            with patch("protean.cli.Engine") as MockEngine:
+                mock_engine = MockEngine.return_value
+                mock_engine.exit_code = 0
+
+                result = runner.invoke(
+                    app,
+                    ["server", "--domain", "publishing7.py", "--debug"],
+                )
+
+            assert result.exit_code == 0
+
+            deprecation_warnings = [
+                w for w in caught if issubclass(w.category, DeprecationWarning)
+            ]
+            assert len(deprecation_warnings) > 0, "Expected DeprecationWarning"
+            assert "--debug is deprecated" in str(deprecation_warnings[0].message)
+
+    def test_debug_flag_still_sets_debug_level(self):
+        """--debug still sets logging level to DEBUG for backward compat."""
+        change_working_directory_to("test7")
+
+        with patch("protean.cli.Engine") as MockEngine:
+            mock_engine = MockEngine.return_value
+            mock_engine.exit_code = 0
+
+            result = runner.invoke(
+                app,
+                ["server", "--domain", "publishing7.py", "--debug"],
+            )
+
+            assert result.exit_code == 0
+            assert logging.getLogger().level == logging.DEBUG
+
+
+class TestGlobalFlagsInHelpText:
+    def test_help_shows_log_level(self):
+        """protean --help shows --log-level in the output."""
+        result = runner.invoke(app, ["--help"])
+        assert "--log-level" in result.output
+
+    def test_help_shows_log_format(self):
+        """protean --help shows --log-format in the output."""
+        result = runner.invoke(app, ["--help"])
+        assert "--log-format" in result.output
+
+    def test_help_shows_log_config(self):
+        """protean --help shows --log-config in the output."""
+        result = runner.invoke(app, ["--help"])
+        assert "--log-config" in result.output

--- a/tests/cli/test_logging_flags.py
+++ b/tests/cli/test_logging_flags.py
@@ -91,6 +91,8 @@ class TestLogLevelFlag:
 class TestLogFormatFlag:
     def test_log_format_json_configures_json(self):
         """--log-format json configures structlog with JSON rendering."""
+        import structlog
+
         change_working_directory_to("test7")
 
         with patch("protean.cli.Engine") as MockEngine:
@@ -109,6 +111,11 @@ class TestLogFormatFlag:
             )
 
             assert result.exit_code == 0
+            # Verify structlog's processor chain ends with JSONRenderer
+            cfg = structlog.get_config()
+            processors = cfg.get("processors", [])
+            assert len(processors) > 0, "Expected structlog processors"
+            assert isinstance(processors[-1], structlog.processors.JSONRenderer)
 
     def test_log_format_invalid_value(self):
         """--log-format with an invalid value exits with error."""
@@ -212,17 +219,29 @@ class TestDeprecatedDebugFlag:
 
 
 class TestGlobalFlagsInHelpText:
+    """Verify that global logging flags appear in ``protean --help``.
+
+    Rich/Typer may inject ANSI escape codes into the output, so we strip
+    them before matching to avoid false negatives on CI.
+    """
+
+    @staticmethod
+    def _strip_ansi(text: str) -> str:
+        import re
+
+        return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
     def test_help_shows_log_level(self):
         """protean --help shows --log-level in the output."""
         result = runner.invoke(app, ["--help"])
-        assert "--log-level" in result.output
+        assert "--log-level" in self._strip_ansi(result.output)
 
     def test_help_shows_log_format(self):
         """protean --help shows --log-format in the output."""
         result = runner.invoke(app, ["--help"])
-        assert "--log-format" in result.output
+        assert "--log-format" in self._strip_ansi(result.output)
 
     def test_help_shows_log_config(self):
         """protean --help shows --log-config in the output."""
         result = runner.invoke(app, ["--help"])
-        assert "--log-config" in result.output
+        assert "--log-config" in self._strip_ansi(result.output)


### PR DESCRIPTION
## Summary
- Add global `--log-level`, `--log-format`, and `--log-config` options to the Typer callback so every `protean` subcommand inherits them, with precedence: `--log-config` (dictConfig) > `--log-level`/`--log-format` > Domain.init() auto-configuration
- Extend `configure_logging()` with a `dict_config` parameter that applies `logging.config.dictConfig()` while still setting up structlog for `get_logger()` callers
- Deprecate `--debug` on `server` and `observatory` commands with a Tier 1 `DeprecationWarning` pointing to `--log-level DEBUG` (removal in v0.17.0)
- Add `cli_exception_handler` context manager and `handle_cli_exceptions` decorator in `cli/_helpers.py`; apply to all CLI commands so unhandled exceptions are logged with structured output before propagating
- Switch `generate.py` and `shell.py` from stdlib `logging.getLogger` to `get_logger()` for consistency

## Test plan
- [x] 19 new tests in `tests/cli/test_logging_flags.py` and `tests/cli/test_exception_handling.py`
- [x] All 19 existing `tests/cli/test_server.py` tests pass (including `--debug` backward compat)
- [x] All 16 `tests/cli/test_observatory.py` tests pass (including deprecated `--debug`)
- [x] 526 CLI tests pass total (5 pre-existing failures unrelated to this PR)
- [x] `ruff check` and `ruff format` pass
- [x] No new mypy errors introduced
- [x] 100% patch coverage on new code (`_helpers.py`, `observatory.py`, `__init__.py` callback)
- [ ] Full adapter suite (`make test-full`) — Docker unavailable in dev environment

Closes #915