### PR TITLE
Add wide event access log, domain context enrichment, and slow-handler detection

### DIFF
--- a/changes/916.added.md
+++ b/changes/916.added.md
@@ -1,0 +1,1 @@
+Add wide event access log (`protean.access`) that emits one structured log entry per handled message with full domain context (aggregate, events raised, repo operations, UoW outcome, correlation/causation IDs), slow-handler detection via `protean.perf` logger, and `bind_event_context()` / `unbind_event_context()` public API for application-level enrichment.

--- a/src/protean/core/repository.py
+++ b/src/protean/core/repository.py
@@ -196,6 +196,14 @@ class BaseRepository(Element, OptionsMixin):
         transaction in progress, changes are committed immediately to the persistence store. This mechanism
         is part of the DAO's design, and is automatically used wherever one tries to persist data.
         """
+        # Increment access log repo save counter
+        try:
+            from protean.utils.globals import g
+
+            g._access_log_repo_saves = getattr(g, "_access_log_repo_saves", 0) + 1
+        except Exception:
+            pass
+
         tracer = self._domain.tracer
 
         with tracer.start_as_current_span(
@@ -401,6 +409,14 @@ class BaseRepository(Element, OptionsMixin):
         `find_residents_of_area(zipcode)`, etc. It is also possible to make use of more complicated,
         domain-friendly design patterns like the `Specification` pattern.
         """
+        # Increment access log repo load counter
+        try:
+            from protean.utils.globals import g
+
+            g._access_log_repo_loads = getattr(g, "_access_log_repo_loads", 0) + 1
+        except Exception:
+            pass
+
         tracer = self._domain.tracer
 
         with tracer.start_as_current_span(

--- a/src/protean/core/unit_of_work.py
+++ b/src/protean/core/unit_of_work.py
@@ -152,11 +152,24 @@ class UnitOfWork:
 
     def _do_commit(self, span: Any) -> None:  # noqa: C901
         """Internal commit logic wrapped by the ``protean.uow.commit`` span."""
+        from protean.utils.globals import g
         from protean.utils.outbox import Outbox
         from protean.utils.processing import current_priority
 
         # Gather all events from identity map using helper method
         all_events = self._gather_events()
+
+        # Record events raised for the access log wide event
+        try:
+            event_names = [
+                event.__class__.__name__
+                for events in all_events.values()
+                for event in events
+            ]
+            prev = getattr(g, "_access_log_events_raised", None) or []
+            g._access_log_events_raised = prev + event_names
+        except Exception:
+            pass
 
         # Compute event count for span attribute
         total_events = sum(len(events) for events in all_events.values())
@@ -298,6 +311,12 @@ class UnitOfWork:
             metrics.uow_commits.add(1)
             metrics.uow_events_per_commit.record(total_events)
 
+            # Record UoW outcome for the access log wide event
+            try:
+                g._access_log_uow_outcome = "committed"
+            except Exception:
+                pass
+
             logger.debug("uow.commit_successful")
         except ValueError as exc:
             logger.exception("uow.commit_failed", exc_info=True)
@@ -355,6 +374,14 @@ class UnitOfWork:
         # Raise error if the Unit Of Work is not active
         if not self._in_progress:
             raise InvalidOperationError("UnitOfWork is not in progress")
+
+        # Record UoW outcome for the access log wide event
+        try:
+            from protean.utils.globals import g
+
+            g._access_log_uow_outcome = "rolled_back"
+        except Exception:
+            pass
 
         # Exit from Unit of Work
         _uow_context_stack.pop()

--- a/src/protean/utils/logging.py
+++ b/src/protean/utils/logging.py
@@ -7,6 +7,7 @@ Provides environment-aware structured logging built on structlog. Out of the box
 - Method call tracing decorator for debugging handlers
 - Third-party and framework logger noise suppression
 - Optional rotating file handlers
+- Wide event access log for handler observability
 
 Typical usage in application code::
 
@@ -17,6 +18,16 @@ Typical usage in application code::
 
     logger = get_logger(__name__)
     logger.info("customer_registered", customer_id="abc-123")
+
+Wide event access log usage::
+
+    from protean.utils.logging import bind_event_context
+
+    class PlaceOrderHandler:
+        @handle(PlaceOrder)
+        def handle(self, command):
+            bind_event_context(user_id=command.user_id, order_total=command.total)
+            # ... handler logic ...
 """
 
 import functools
@@ -25,8 +36,10 @@ import logging.config
 import logging.handlers
 import os
 import sys
+import time
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable, Iterator, Optional, Union
 
 import structlog
 
@@ -69,9 +82,37 @@ _FRAMEWORK_LOGGERS_NORMAL = {
     "protean.server.engine": logging.INFO,
     "protean.server.subscription": logging.INFO,
     "protean.server.outbox_processor": logging.INFO,
+    "protean.access": logging.INFO,
+    "protean.perf": logging.WARNING,
     "protean.core": logging.WARNING,
     "protean.adapters": logging.WARNING,
 }
+
+# Dedicated loggers for the wide event access log and slow-handler detection
+access_logger = logging.getLogger("protean.access")
+perf_logger = logging.getLogger("protean.perf")
+
+# Framework-reserved field names that application context cannot overwrite
+_FRAMEWORK_FIELDS = frozenset(
+    {
+        "kind",
+        "message_type",
+        "message_id",
+        "aggregate",
+        "aggregate_id",
+        "events_raised",
+        "events_raised_count",
+        "repo_operations",
+        "uow_outcome",
+        "handler",
+        "duration_ms",
+        "status",
+        "error_type",
+        "error_message",
+        "correlation_id",
+        "causation_id",
+    }
+)
 
 
 # ---------------------------------------------------------------------------
@@ -205,6 +246,229 @@ def add_context(**kwargs: Any) -> None:
 def clear_context() -> None:
     """Clear all bound context variables."""
     structlog.contextvars.clear_contextvars()
+
+
+def bind_event_context(**kwargs: Any) -> None:
+    """Add business-specific fields to the current wide event.
+
+    Called from handler code to enrich the access log with domain context
+    that only the application knows (user tier, order total, feature flags, etc.).
+    Fields are merged — multiple calls accumulate, later calls overwrite
+    conflicting keys. Safe to call outside handler context (no-op).
+    """
+    structlog.contextvars.bind_contextvars(**kwargs)
+
+
+def unbind_event_context(*keys: str) -> None:
+    """Remove specific fields from the current wide event context."""
+    structlog.contextvars.unbind_contextvars(*keys)
+
+
+def _reset_access_log_counters() -> None:
+    """Reset per-handler access log counters on g."""
+    try:
+        from protean.utils.globals import g
+
+        g._access_log_repo_loads = 0
+        g._access_log_repo_saves = 0
+        g._access_log_events_raised = []
+        g._access_log_uow_outcome = "no_uow"
+    except Exception:
+        pass
+
+
+def _get_correlation_context() -> tuple[str, str]:
+    """Extract correlation_id and causation_id from the current message context."""
+    try:
+        from protean.utils.globals import g
+
+        msg = g.get("message_in_context")
+        if msg is None:
+            return ("", "")
+        metadata = getattr(msg, "metadata", None)
+        domain_meta = getattr(metadata, "domain", None) if metadata else None
+        if domain_meta is None:
+            return ("", "")
+        return (
+            domain_meta.correlation_id or "",
+            domain_meta.causation_id or "",
+        )
+    except Exception:
+        return ("", "")
+
+
+def _extract_aggregate_info(item: Any, handler_cls: type) -> tuple[str, str]:
+    """Extract aggregate type name and aggregate ID from item or handler class."""
+    aggregate = ""
+    aggregate_id = ""
+
+    # Get aggregate type from item's meta or handler's meta
+    part_of = getattr(getattr(item, "meta_", None), "part_of", None)
+    if part_of is None:
+        part_of = getattr(getattr(handler_cls, "meta_", None), "part_of", None)
+
+    if part_of is not None:
+        aggregate = part_of.__name__
+
+        # Try to extract aggregate_id from the message stream
+        metadata = getattr(item, "_metadata", None)
+        if metadata is not None:
+            headers = getattr(metadata, "headers", None)
+            if headers is not None:
+                stream = getattr(headers, "stream", None) or ""
+                stream_category = getattr(
+                    getattr(part_of, "meta_", None), "stream_category", ""
+                )
+                if stream and stream_category:
+                    cmd_prefix = f"{stream_category}:command-"
+                    evt_prefix = f"{stream_category}-"
+                    if cmd_prefix in stream:
+                        aggregate_id = stream.split(cmd_prefix, 1)[1]
+                    elif stream.startswith(evt_prefix):
+                        aggregate_id = stream[len(evt_prefix) :]
+
+    return aggregate, aggregate_id
+
+
+def _read_access_log_counters() -> tuple[list[str], dict[str, int], str]:
+    """Read per-handler access log counters from g.
+
+    Returns:
+        Tuple of (events_raised, repo_operations, uow_outcome)
+    """
+    try:
+        from protean.utils.globals import g
+
+        events_raised = getattr(g, "_access_log_events_raised", []) or []
+        repo_loads = getattr(g, "_access_log_repo_loads", 0) or 0
+        repo_saves = getattr(g, "_access_log_repo_saves", 0) or 0
+        uow_outcome = getattr(g, "_access_log_uow_outcome", "no_uow") or "no_uow"
+        return (
+            list(events_raised),
+            {"loads": repo_loads, "saves": repo_saves},
+            uow_outcome,
+        )
+    except Exception:
+        return ([], {"loads": 0, "saves": 0}, "no_uow")
+
+
+def _get_slow_handler_threshold() -> float:
+    """Read slow_handler_threshold_ms from domain config. Returns 0 to disable."""
+    try:
+        from protean.utils.globals import current_domain
+
+        if current_domain:
+            logging_config = current_domain.config.get("logging", {})
+            return float(logging_config.get("slow_handler_threshold_ms", 500))
+    except Exception:
+        pass
+    return 500.0
+
+
+@contextmanager
+def access_log_handler(
+    kind: str, item: Any, handler_cls: type, handler_method_name: str
+) -> Iterator[None]:
+    """Context manager that measures handler duration and emits a wide event.
+
+    Clears structlog contextvars at entry, collects framework + app context,
+    emits a single wide event on exit.
+
+    Args:
+        kind: Handler kind — "command", "event", "query", or "projector".
+        item: The domain object being handled (command, event, or query).
+        handler_cls: The handler class dispatching the item.
+        handler_method_name: The name of the specific handler method.
+    """
+    structlog.contextvars.clear_contextvars()
+    _reset_access_log_counters()
+
+    started_at = time.perf_counter()
+    error_info: Optional[Exception] = None
+    try:
+        yield
+    except Exception as exc:
+        error_info = exc
+        raise
+    finally:
+        duration_ms = round((time.perf_counter() - started_at) * 1000, 2)
+
+        # Collect application-provided context (via bind_event_context)
+        app_context = structlog.contextvars.get_contextvars()
+
+        # Clear context vars before emitting to avoid double-merge
+        structlog.contextvars.clear_contextvars()
+
+        # Extract framework fields
+        message_type = getattr(item, "__class__", None)
+        message_type_name = (
+            getattr(message_type, "__type__", None)
+            or getattr(message_type, "__name__", "unknown")
+            if message_type
+            else "unknown"
+        )
+        message_id = ""
+        metadata = getattr(item, "_metadata", None)
+        if metadata is not None:
+            headers = getattr(metadata, "headers", None)
+            if headers is not None:
+                message_id = getattr(headers, "id", "") or ""
+
+        aggregate, aggregate_id = _extract_aggregate_info(item, handler_cls)
+        correlation_id, causation_id = _get_correlation_context()
+        events_raised, repo_operations, uow_outcome = _read_access_log_counters()
+
+        handler_name = f"{handler_cls.__name__}.{handler_method_name}"
+
+        # Determine status
+        if error_info is not None:
+            status = "failed"
+        else:
+            threshold = _get_slow_handler_threshold()
+            status = "slow" if (threshold > 0 and duration_ms > threshold) else "ok"
+
+        # Build the wide event — framework fields take precedence over app context
+        wide_event = {
+            k: v for k, v in app_context.items() if k not in _FRAMEWORK_FIELDS
+        }
+        wide_event.update(
+            {
+                "kind": kind,
+                "message_type": message_type_name,
+                "message_id": str(message_id),
+                "aggregate": aggregate,
+                "aggregate_id": str(aggregate_id),
+                "events_raised": events_raised,
+                "events_raised_count": len(events_raised),
+                "repo_operations": repo_operations,
+                "uow_outcome": uow_outcome,
+                "handler": handler_name,
+                "duration_ms": duration_ms,
+                "status": status,
+                "error_type": type(error_info).__name__ if error_info else None,
+                "error_message": (str(error_info)[:256] if error_info else None),
+                "correlation_id": correlation_id,
+                "causation_id": causation_id,
+            }
+        )
+
+        # Emit the wide event
+        if error_info is not None:
+            access_logger.error(
+                "access.handler_failed",
+                extra=wide_event,
+                exc_info=(
+                    type(error_info),
+                    error_info,
+                    error_info.__traceback__,
+                ),
+            )
+        elif status == "slow":
+            access_logger.warning("access.handler_completed", extra=wide_event)
+            # Separate perf logger for routing slow-handler alerts independently
+            perf_logger.warning("slow_handler", extra=wide_event)
+        else:
+            access_logger.info("access.handler_completed", extra=wide_event)
 
 
 def log_method_call(func: Callable) -> Callable:

--- a/src/protean/utils/logging.py
+++ b/src/protean/utils/logging.py
@@ -92,6 +92,36 @@ _FRAMEWORK_LOGGERS_NORMAL = {
 access_logger = logging.getLogger("protean.access")
 perf_logger = logging.getLogger("protean.perf")
 
+# stdlib LogRecord attributes that must never appear in `extra` to avoid
+# collisions with the logging framework's own fields.
+_RESERVED_LOG_RECORD_ATTRS = frozenset(
+    {
+        "name",
+        "msg",
+        "args",
+        "levelname",
+        "levelno",
+        "pathname",
+        "filename",
+        "module",
+        "exc_info",
+        "exc_text",
+        "stack_info",
+        "lineno",
+        "funcName",
+        "created",
+        "msecs",
+        "relativeCreated",
+        "thread",
+        "threadName",
+        "process",
+        "processName",
+        "message",
+        "asctime",
+        "taskName",
+    }
+)
+
 # Framework-reserved field names that application context cannot overwrite
 _FRAMEWORK_FIELDS = frozenset(
     {
@@ -254,7 +284,9 @@ def bind_event_context(**kwargs: Any) -> None:
     Called from handler code to enrich the access log with domain context
     that only the application knows (user tier, order total, feature flags, etc.).
     Fields are merged — multiple calls accumulate, later calls overwrite
-    conflicting keys. Safe to call outside handler context (no-op).
+    conflicting keys. Outside handler code, this still binds keys to the
+    current structlog context — they will be cleared when the next handler
+    invocation starts.
     """
     structlog.contextvars.bind_contextvars(**kwargs)
 
@@ -371,8 +403,10 @@ def access_log_handler(
 ) -> Iterator[None]:
     """Context manager that measures handler duration and emits a wide event.
 
-    Clears structlog contextvars at entry, collects framework + app context,
-    emits a single wide event on exit.
+    Saves the current structlog contextvars at entry (so outer context such as
+    per-request bindings from ``add_context()`` is preserved), resets them for
+    a clean handler scope, collects framework + app context, emits a single
+    wide event on exit, and restores the previous contextvars.
 
     Args:
         kind: Handler kind — "command", "event", "query", or "projector".
@@ -380,6 +414,8 @@ def access_log_handler(
         handler_cls: The handler class dispatching the item.
         handler_method_name: The name of the specific handler method.
     """
+    # Snapshot and clear outer context so each handler starts clean
+    saved_context = structlog.contextvars.get_contextvars()
     structlog.contextvars.clear_contextvars()
     _reset_access_log_counters()
 
@@ -396,79 +432,116 @@ def access_log_handler(
         # Collect application-provided context (via bind_event_context)
         app_context = structlog.contextvars.get_contextvars()
 
-        # Clear context vars before emitting to avoid double-merge
+        # Restore the outer context that was active before this handler
         structlog.contextvars.clear_contextvars()
+        if saved_context:
+            structlog.contextvars.bind_contextvars(**saved_context)
 
-        # Extract framework fields
-        message_type = getattr(item, "__class__", None)
-        message_type_name = (
-            getattr(message_type, "__type__", None)
-            or getattr(message_type, "__name__", "unknown")
-            if message_type
-            else "unknown"
-        )
-        message_id = ""
-        metadata = getattr(item, "_metadata", None)
-        if metadata is not None:
-            headers = getattr(metadata, "headers", None)
-            if headers is not None:
-                message_id = getattr(headers, "id", "") or ""
-
-        aggregate, aggregate_id = _extract_aggregate_info(item, handler_cls)
-        correlation_id, causation_id = _get_correlation_context()
-        events_raised, repo_operations, uow_outcome = _read_access_log_counters()
-
-        handler_name = f"{handler_cls.__name__}.{handler_method_name}"
-
-        # Determine status
-        if error_info is not None:
-            status = "failed"
-        else:
-            threshold = _get_slow_handler_threshold()
-            status = "slow" if (threshold > 0 and duration_ms > threshold) else "ok"
-
-        # Build the wide event — framework fields take precedence over app context
-        wide_event = {
-            k: v for k, v in app_context.items() if k not in _FRAMEWORK_FIELDS
-        }
-        wide_event.update(
-            {
-                "kind": kind,
-                "message_type": message_type_name,
-                "message_id": str(message_id),
-                "aggregate": aggregate,
-                "aggregate_id": str(aggregate_id),
-                "events_raised": events_raised,
-                "events_raised_count": len(events_raised),
-                "repo_operations": repo_operations,
-                "uow_outcome": uow_outcome,
-                "handler": handler_name,
-                "duration_ms": duration_ms,
-                "status": status,
-                "error_type": type(error_info).__name__ if error_info else None,
-                "error_message": (str(error_info)[:256] if error_info else None),
-                "correlation_id": correlation_id,
-                "causation_id": causation_id,
-            }
-        )
-
-        # Emit the wide event
-        if error_info is not None:
-            access_logger.error(
-                "access.handler_failed",
-                extra=wide_event,
-                exc_info=(
-                    type(error_info),
-                    error_info,
-                    error_info.__traceback__,
-                ),
+        # Build and emit the wide event inside a try/except so that
+        # emission failures never mask the original handler exception
+        # or break otherwise-successful handling.
+        try:
+            _emit_wide_event(
+                kind,
+                item,
+                handler_cls,
+                handler_method_name,
+                duration_ms,
+                error_info,
+                app_context,
             )
-        elif status == "slow":
-            access_logger.warning("access.handler_completed", extra=wide_event)
-            # Separate perf logger for routing slow-handler alerts independently
-            perf_logger.warning("slow_handler", extra=wide_event)
-        else:
-            access_logger.info("access.handler_completed", extra=wide_event)
+        except Exception:
+            # Last-resort: log that the access log itself failed, but
+            # never let this propagate.
+            logging.getLogger(__name__).debug(
+                "access_log_emission_failed", exc_info=True
+            )
+
+
+def _emit_wide_event(
+    kind: str,
+    item: Any,
+    handler_cls: type,
+    handler_method_name: str,
+    duration_ms: float,
+    error_info: Optional[Exception],
+    app_context: dict[str, Any],
+) -> None:
+    """Build and emit the wide event log entry.
+
+    Extracted from ``access_log_handler`` so that emission failures can be
+    caught without interfering with handler exception propagation.
+    """
+    # Extract framework fields
+    message_type = getattr(item, "__class__", None)
+    message_type_name = (
+        getattr(message_type, "__type__", None)
+        or getattr(message_type, "__name__", "unknown")
+        if message_type
+        else "unknown"
+    )
+    message_id = ""
+    metadata = getattr(item, "_metadata", None)
+    if metadata is not None:
+        headers = getattr(metadata, "headers", None)
+        if headers is not None:
+            message_id = getattr(headers, "id", "") or ""
+
+    aggregate, aggregate_id = _extract_aggregate_info(item, handler_cls)
+    correlation_id, causation_id = _get_correlation_context()
+    events_raised, repo_operations, uow_outcome = _read_access_log_counters()
+
+    handler_name = f"{handler_cls.__name__}.{handler_method_name}"
+
+    # Determine status
+    if error_info is not None:
+        status = "failed"
+    else:
+        threshold = _get_slow_handler_threshold()
+        status = "slow" if (threshold > 0 and duration_ms > threshold) else "ok"
+
+    # Build the wide event — strip keys that collide with framework-reserved
+    # names or stdlib LogRecord attributes to prevent KeyError / overwrites.
+    forbidden_keys = _FRAMEWORK_FIELDS | _RESERVED_LOG_RECORD_ATTRS
+    wide_event = {k: v for k, v in app_context.items() if k not in forbidden_keys}
+    wide_event.update(
+        {
+            "kind": kind,
+            "message_type": message_type_name,
+            "message_id": str(message_id),
+            "aggregate": aggregate,
+            "aggregate_id": str(aggregate_id),
+            "events_raised": events_raised,
+            "events_raised_count": len(events_raised),
+            "repo_operations": repo_operations,
+            "uow_outcome": uow_outcome,
+            "handler": handler_name,
+            "duration_ms": duration_ms,
+            "status": status,
+            "error_type": type(error_info).__name__ if error_info else None,
+            "error_message": (str(error_info)[:256] if error_info else None),
+            "correlation_id": correlation_id,
+            "causation_id": causation_id,
+        }
+    )
+
+    # Emit the wide event
+    if error_info is not None:
+        access_logger.error(
+            "access.handler_failed",
+            extra=wide_event,
+            exc_info=(
+                type(error_info),
+                error_info,
+                error_info.__traceback__,
+            ),
+        )
+    elif status == "slow":
+        access_logger.warning("access.handler_completed", extra=wide_event)
+        # Separate perf logger for routing slow-handler alerts independently
+        perf_logger.warning("slow_handler", extra=wide_event)
+    else:
+        access_logger.info("access.handler_completed", extra=wide_event)
 
 
 def log_method_call(func: Callable) -> Callable:

--- a/src/protean/utils/mixins.py
+++ b/src/protean/utils/mixins.py
@@ -269,15 +269,28 @@ class HandlerMixin:
         cls, handlers: set, item: Union[BaseCommand, BaseEvent, BaseQuery]
     ) -> Any:
         """Dispatch item to registered handler methods."""
+        from protean.utils.logging import access_log_handler
+
+        # Map element_type to access log kind
+        _KIND_MAP = {
+            DomainObjects.COMMAND_HANDLER: "command",
+            DomainObjects.EVENT_HANDLER: "event",
+            DomainObjects.QUERY_HANDLER: "query",
+            DomainObjects.PROJECTOR: "projector",
+        }
+        kind = _KIND_MAP.get(cls.element_type, "unknown")
+
         if cls.element_type in (
             DomainObjects.COMMAND_HANDLER,
             DomainObjects.QUERY_HANDLER,
         ):
             handler_method = next(iter(handlers))
-            return handler_method(cls(), item)
+            with access_log_handler(kind, item, cls, handler_method.__name__):
+                return handler_method(cls(), item)
         else:
             for handler_method in handlers:
-                handler_method(cls(), item)
+                with access_log_handler(kind, item, cls, handler_method.__name__):
+                    handler_method(cls(), item)
 
         return None
 

--- a/tests/logging/test_access_log.py
+++ b/tests/logging/test_access_log.py
@@ -1,0 +1,317 @@
+"""Tests for the wide event access log.
+
+Verifies that:
+- Command processing emits a wide event on success
+- Command processing emits a wide event on failure
+- Event handlers emit one wide event per handler method
+- Query dispatch emits a wide event
+- Projector handlers emit a wide event
+- Correlation and causation IDs are present in wide events
+"""
+
+import logging
+from uuid import uuid4
+
+import pytest
+
+from protean.core.aggregate import BaseAggregate
+from protean.core.command import BaseCommand
+from protean.core.command_handler import BaseCommandHandler
+from protean.core.event import BaseEvent
+from protean.core.event_handler import BaseEventHandler
+from protean.core.projection import BaseProjection
+from protean.core.projector import BaseProjector, on
+from protean.core.query import BaseQuery
+from protean.core.query_handler import BaseQueryHandler
+from protean.fields import Identifier, String
+from protean.utils.globals import current_domain
+from protean.utils.mixins import handle, read
+
+
+# --- Domain elements for testing ---
+
+
+class Order(BaseAggregate):
+    order_id = Identifier(identifier=True)
+    customer_name = String()
+    status = String(default="pending")
+
+    def place(self) -> None:
+        self.raise_(
+            OrderPlaced(order_id=self.order_id, customer_name=self.customer_name)
+        )
+
+    def confirm(self) -> None:
+        self.status = "confirmed"
+        self.raise_(OrderConfirmed(order_id=self.order_id))
+
+
+class OrderPlaced(BaseEvent):
+    order_id = Identifier()
+    customer_name = String()
+
+
+class OrderConfirmed(BaseEvent):
+    order_id = Identifier()
+
+
+class PlaceOrder(BaseCommand):
+    order_id = Identifier(identifier=True)
+    customer_name = String()
+
+
+class FailingCommand(BaseCommand):
+    order_id = Identifier(identifier=True)
+
+
+class PlaceOrderHandler(BaseCommandHandler):
+    @handle(PlaceOrder)
+    def handle_place_order(self, command: PlaceOrder) -> None:
+        repo = current_domain.repository_for(Order)
+        order = Order(order_id=command.order_id, customer_name=command.customer_name)
+        order.place()
+        repo.add(order)
+
+
+class FailingCommandHandler(BaseCommandHandler):
+    @handle(FailingCommand)
+    def handle_failing(self, command: FailingCommand) -> None:
+        raise ValueError("Something went wrong")
+
+
+class OrderEventHandler(BaseEventHandler):
+    @handle(OrderPlaced)
+    def on_order_placed(self, event: OrderPlaced) -> None:
+        pass
+
+    @handle(OrderConfirmed)
+    def on_order_confirmed(self, event: OrderConfirmed) -> None:
+        pass
+
+
+class OrderSummary(BaseProjection):
+    order_id = Identifier(identifier=True)
+    customer_name = String()
+    status = String()
+
+
+class OrderSummaryProjector(BaseProjector):
+    @on(OrderPlaced)
+    def on_order_placed(self, event: OrderPlaced) -> None:
+        pass
+
+
+class GetOrderById(BaseQuery):
+    order_id = Identifier(required=True)
+
+
+class OrderQueryHandler(BaseQueryHandler):
+    @read(GetOrderById)
+    def get_by_id(self, query: GetOrderById) -> dict:
+        return {"order_id": query.order_id, "status": "pending"}
+
+
+# --- Helper to extract access log records ---
+
+
+def _access_records(caplog) -> list[logging.LogRecord]:
+    """Return all records emitted on the 'protean.access' logger."""
+    return [r for r in caplog.records if r.name == "protean.access"]
+
+
+class TestCommandEmitsWideEvent:
+    """Command processing emits a wide event access log entry."""
+
+    @pytest.fixture(autouse=True)
+    def register_elements(self, test_domain):
+        test_domain.register(Order)
+        test_domain.register(OrderPlaced, part_of=Order)
+        test_domain.register(OrderConfirmed, part_of=Order)
+        test_domain.register(PlaceOrder, part_of=Order)
+        test_domain.register(PlaceOrderHandler, part_of=Order)
+        # Register event handler to avoid config errors
+        test_domain.register(OrderEventHandler, part_of=Order)
+        test_domain.init(traverse=False)
+
+    def test_command_emits_wide_event_on_success(self, test_domain, caplog):
+        order_id = str(uuid4())
+        with caplog.at_level(logging.DEBUG, logger="protean.access"):
+            test_domain.process(PlaceOrder(order_id=order_id, customer_name="John Doe"))
+
+        records = _access_records(caplog)
+        assert len(records) >= 1, (
+            f"Expected at least one access log record, got: "
+            f"{[r.getMessage() for r in caplog.records]}"
+        )
+
+        # Filter for the command handler's wide event specifically
+        cmd_records = [r for r in records if r.kind == "command"]
+        assert len(cmd_records) >= 1
+        record = cmd_records[0]
+
+        assert "access.handler_completed" in record.getMessage()
+        assert record.kind == "command"
+        assert record.handler == "PlaceOrderHandler.handle_place_order"
+        assert record.status == "ok"
+        assert record.duration_ms > 0
+        assert record.aggregate == "Order"
+        assert record.message_type is not None
+        assert record.uow_outcome == "committed"
+        assert record.levelno == logging.INFO
+
+
+class TestCommandEmitsWideEventOnFailure:
+    """Command handler failure emits a wide event with error details."""
+
+    @pytest.fixture(autouse=True)
+    def register_elements(self, test_domain):
+        test_domain.register(Order)
+        test_domain.register(FailingCommand, part_of=Order)
+        test_domain.register(FailingCommandHandler, part_of=Order)
+        test_domain.init(traverse=False)
+
+    def test_command_emits_wide_event_on_failure(self, test_domain, caplog):
+        order_id = str(uuid4())
+        with caplog.at_level(logging.DEBUG, logger="protean.access"):
+            with pytest.raises(ValueError, match="Something went wrong"):
+                test_domain.process(FailingCommand(order_id=order_id))
+
+        records = _access_records(caplog)
+        assert len(records) >= 1
+
+        record = records[0]
+        assert "access.handler_failed" in record.getMessage()
+        assert record.status == "failed"
+        assert record.error_type == "ValueError"
+        assert record.error_message == "Something went wrong"
+        assert record.levelno == logging.ERROR
+        assert record.exc_info is not None
+        assert record.uow_outcome == "rolled_back"
+
+
+class TestEventHandlerEmitsWideEventPerMethod:
+    """Event handler with multiple @handle methods emits one wide event per method."""
+
+    @pytest.fixture(autouse=True)
+    def register_elements(self, test_domain):
+        test_domain.register(Order)
+        test_domain.register(OrderPlaced, part_of=Order)
+        test_domain.register(OrderConfirmed, part_of=Order)
+        test_domain.register(PlaceOrder, part_of=Order)
+        test_domain.register(PlaceOrderHandler, part_of=Order)
+        test_domain.register(OrderEventHandler, part_of=Order)
+        test_domain.init(traverse=False)
+
+    def test_event_handler_emits_wide_event_per_method(self, test_domain, caplog):
+        """Processing a command that raises events should emit access log entries
+        for each event handler method invocation."""
+        order_id = str(uuid4())
+        with caplog.at_level(logging.DEBUG, logger="protean.access"):
+            test_domain.process(PlaceOrder(order_id=order_id, customer_name="Jane Doe"))
+
+        records = _access_records(caplog)
+        # At minimum: 1 for command handler + 1 for event handler
+        event_handler_records = [r for r in records if r.kind == "event"]
+        assert len(event_handler_records) >= 1
+
+        for record in event_handler_records:
+            assert "access.handler_completed" in record.getMessage()
+            assert record.status == "ok"
+            assert record.duration_ms >= 0
+
+
+class TestQueryEmitsWideEvent:
+    """Query dispatch emits a wide event."""
+
+    @pytest.fixture(autouse=True)
+    def register_elements(self, test_domain):
+        test_domain.register(OrderSummary)
+        test_domain.register(GetOrderById, part_of=OrderSummary)
+        test_domain.register(OrderQueryHandler, part_of=OrderSummary)
+        test_domain.init(traverse=False)
+
+    def test_query_emits_wide_event(self, test_domain, caplog):
+        with caplog.at_level(logging.DEBUG, logger="protean.access"):
+            result = test_domain.dispatch(GetOrderById(order_id="order-42"))
+
+        assert result == {"order_id": "order-42", "status": "pending"}
+
+        records = _access_records(caplog)
+        assert len(records) >= 1
+
+        record = records[0]
+        assert "access.handler_completed" in record.getMessage()
+        assert record.kind == "query"
+        assert record.status == "ok"
+        assert record.duration_ms >= 0
+        assert record.uow_outcome == "no_uow"
+
+
+class TestProjectorEmitsWideEvent:
+    """Projector handler invocation emits a wide event."""
+
+    @pytest.fixture(autouse=True)
+    def register_elements(self, test_domain):
+        test_domain.register(Order)
+        test_domain.register(OrderPlaced, part_of=Order)
+        test_domain.register(OrderConfirmed, part_of=Order)
+        test_domain.register(OrderSummary)
+        test_domain.register(
+            OrderSummaryProjector,
+            projector_for=OrderSummary,
+            aggregates=[Order],
+        )
+        test_domain.register(PlaceOrder, part_of=Order)
+        test_domain.register(PlaceOrderHandler, part_of=Order)
+        test_domain.init(traverse=False)
+
+    def test_projector_emits_wide_event(self, test_domain, caplog):
+        order_id = str(uuid4())
+        with caplog.at_level(logging.DEBUG, logger="protean.access"):
+            test_domain.process(
+                PlaceOrder(order_id=order_id, customer_name="Projector Test")
+            )
+
+        records = _access_records(caplog)
+        projector_records = [r for r in records if r.kind == "projector"]
+        assert len(projector_records) >= 1
+
+        record = projector_records[0]
+        assert "access.handler_completed" in record.getMessage()
+        assert record.status == "ok"
+        assert record.duration_ms >= 0
+
+
+class TestCorrelationAndCausationPresent:
+    """Wide events carry correlation_id and causation_id."""
+
+    @pytest.fixture(autouse=True)
+    def register_elements(self, test_domain):
+        test_domain.register(Order)
+        test_domain.register(OrderPlaced, part_of=Order)
+        test_domain.register(OrderConfirmed, part_of=Order)
+        test_domain.register(PlaceOrder, part_of=Order)
+        test_domain.register(PlaceOrderHandler, part_of=Order)
+        test_domain.register(OrderEventHandler, part_of=Order)
+        test_domain.init(traverse=False)
+
+    def test_correlation_and_causation_present(self, test_domain, caplog):
+        order_id = str(uuid4())
+        with caplog.at_level(logging.DEBUG, logger="protean.access"):
+            test_domain.process(
+                PlaceOrder(order_id=order_id, customer_name="Corr Test")
+            )
+
+        records = _access_records(caplog)
+        assert len(records) >= 1
+
+        # The command handler's wide event should have a correlation_id
+        cmd_records = [r for r in records if r.kind == "command"]
+        assert len(cmd_records) >= 1
+        assert cmd_records[0].correlation_id != ""
+
+        # Event handler wide events should have correlation_id inherited
+        # from the command and a causation_id pointing at the command
+        event_records = [r for r in records if r.kind == "event"]
+        if event_records:
+            assert event_records[0].correlation_id != ""

--- a/tests/logging/test_access_log.py
+++ b/tests/logging/test_access_log.py
@@ -315,3 +315,67 @@ class TestCorrelationAndCausationPresent:
         event_records = [r for r in records if r.kind == "event"]
         if event_records:
             assert event_records[0].correlation_id != ""
+
+
+class TestAccessLogEmissionFailureSafety:
+    """Emission failures in the access log must not crash the handler."""
+
+    @pytest.fixture(autouse=True)
+    def register_elements(self, test_domain):
+        test_domain.register(Order)
+        test_domain.register(OrderPlaced, part_of=Order)
+        test_domain.register(OrderConfirmed, part_of=Order)
+        test_domain.register(PlaceOrder, part_of=Order)
+        test_domain.register(PlaceOrderHandler, part_of=Order)
+        test_domain.register(OrderEventHandler, part_of=Order)
+        test_domain.init(traverse=False)
+
+    def test_emission_failure_does_not_crash_handler(self, test_domain, caplog):
+        """Even if _emit_wide_event raises, the handler result is returned."""
+        from unittest.mock import patch
+
+        order_id = str(uuid4())
+        with patch(
+            "protean.utils.logging._emit_wide_event",
+            side_effect=RuntimeError("broken emission"),
+        ):
+            # Should not raise — the emission error is swallowed
+            test_domain.process(
+                PlaceOrder(order_id=order_id, customer_name="Safe Test")
+            )
+
+        # No access records since emission was broken, but handler succeeded
+        # (verified by absence of exception)
+
+
+class TestAccessLogHelperFallbacks:
+    """Helper functions return safe defaults when no domain context exists."""
+
+    def test_get_correlation_context_without_domain(self):
+        from protean.utils.logging import _get_correlation_context
+
+        corr, caus = _get_correlation_context()
+        assert corr == ""
+        assert caus == ""
+
+    def test_read_access_log_counters_without_domain(self):
+        from protean.utils.logging import _read_access_log_counters
+
+        events, ops, outcome = _read_access_log_counters()
+        assert events == []
+        assert ops == {"loads": 0, "saves": 0}
+        assert outcome == "no_uow"
+
+    def test_get_slow_handler_threshold_without_domain(self):
+        from protean.utils.logging import _get_slow_handler_threshold
+
+        threshold = _get_slow_handler_threshold()
+        assert threshold == 500.0
+
+    def test_extract_aggregate_info_with_bare_object(self):
+        from protean.utils.logging import _extract_aggregate_info
+
+        # Object with no meta_ or _metadata
+        agg, agg_id = _extract_aggregate_info(object(), type)
+        assert agg == ""
+        assert agg_id == ""

--- a/tests/logging/test_slow_handler.py
+++ b/tests/logging/test_slow_handler.py
@@ -1,0 +1,168 @@
+"""Tests for slow handler detection.
+
+Verifies that:
+- Slow handler emits WARNING with status="slow" on protean.access
+- Slow handler also emits WARNING on protean.perf
+- Fast handler does not trigger slow detection
+- Default threshold is 500ms
+- Threshold of 0 disables slow detection
+"""
+
+import logging
+import time
+from uuid import uuid4
+
+import pytest
+
+from protean.core.aggregate import BaseAggregate
+from protean.core.command import BaseCommand
+from protean.core.command_handler import BaseCommandHandler
+from protean.fields import Identifier, String
+from protean.utils.mixins import handle
+
+
+# --- Domain elements ---
+
+
+class Item(BaseAggregate):
+    item_id = Identifier(identifier=True)
+    name = String()
+
+
+class CreateItem(BaseCommand):
+    item_id = Identifier(identifier=True)
+    name = String()
+
+
+class SlowHandler(BaseCommandHandler):
+    @handle(CreateItem)
+    def handle_create(self, command: CreateItem) -> None:
+        time.sleep(0.06)  # 60ms — slow at 10ms threshold
+
+
+class FastHandler(BaseCommandHandler):
+    @handle(CreateItem)
+    def handle_create(self, command: CreateItem) -> None:
+        pass  # returns immediately
+
+
+def _access_records(caplog) -> list[logging.LogRecord]:
+    return [r for r in caplog.records if r.name == "protean.access"]
+
+
+def _perf_records(caplog) -> list[logging.LogRecord]:
+    return [r for r in caplog.records if r.name == "protean.perf"]
+
+
+class TestSlowHandlerWarningEmitted:
+    """Slow handlers emit WARNING on both protean.access and protean.perf."""
+
+    @pytest.fixture(autouse=True)
+    def register_elements(self, test_domain):
+        # Set a low threshold so our 60ms handler is "slow"
+        test_domain.config["logging"]["slow_handler_threshold_ms"] = 10
+        test_domain.register(Item)
+        test_domain.register(CreateItem, part_of=Item)
+        test_domain.register(SlowHandler, part_of=Item)
+        test_domain.init(traverse=False)
+
+    def test_slow_handler_warning_emitted(self, test_domain, caplog):
+        with caplog.at_level(logging.DEBUG, logger="protean.access"):
+            with caplog.at_level(logging.DEBUG, logger="protean.perf"):
+                test_domain.process(CreateItem(item_id=str(uuid4()), name="Slow Item"))
+
+        # Check access log: should be WARNING with status="slow"
+        access_recs = _access_records(caplog)
+        assert len(access_recs) >= 1
+        slow_access = [r for r in access_recs if r.status == "slow"]
+        assert len(slow_access) >= 1
+        assert slow_access[0].levelno == logging.WARNING
+        assert slow_access[0].duration_ms > 10
+
+        # Check perf log: should also have a WARNING
+        perf_recs = _perf_records(caplog)
+        slow_perf = [r for r in perf_recs if "slow_handler" in r.getMessage()]
+        assert len(slow_perf) >= 1
+        assert slow_perf[0].levelno == logging.WARNING
+        assert slow_perf[0].duration_ms > 10
+
+
+class TestFastHandlerNoSlowWarning:
+    """Fast handlers do not trigger slow detection."""
+
+    @pytest.fixture(autouse=True)
+    def register_elements(self, test_domain):
+        test_domain.config["logging"]["slow_handler_threshold_ms"] = 10
+        test_domain.register(Item)
+        test_domain.register(CreateItem, part_of=Item)
+        test_domain.register(FastHandler, part_of=Item)
+        test_domain.init(traverse=False)
+
+    def test_fast_handler_no_slow_warning(self, test_domain, caplog):
+        with caplog.at_level(logging.DEBUG, logger="protean.access"):
+            with caplog.at_level(logging.DEBUG, logger="protean.perf"):
+                test_domain.process(CreateItem(item_id=str(uuid4()), name="Fast Item"))
+
+        # Access log should be INFO with status="ok"
+        access_recs = _access_records(caplog)
+        assert len(access_recs) >= 1
+        assert access_recs[0].status == "ok"
+        assert access_recs[0].levelno == logging.INFO
+
+        # No slow_handler perf records
+        perf_recs = _perf_records(caplog)
+        slow_perf = [r for r in perf_recs if "slow_handler" in r.getMessage()]
+        assert len(slow_perf) == 0
+
+
+class TestThresholdDefaultIs500ms:
+    """Default slow_handler_threshold_ms is 500ms."""
+
+    @pytest.fixture(autouse=True)
+    def register_elements(self, test_domain):
+        # Don't override threshold — use the default (500ms)
+        test_domain.register(Item)
+        test_domain.register(CreateItem, part_of=Item)
+        test_domain.register(FastHandler, part_of=Item)
+        test_domain.init(traverse=False)
+
+    def test_threshold_default_is_500ms(self, test_domain, caplog):
+        """A fast handler with default 500ms threshold should be 'ok'."""
+        with caplog.at_level(logging.DEBUG, logger="protean.access"):
+            test_domain.process(
+                CreateItem(item_id=str(uuid4()), name="Default Threshold")
+            )
+
+        access_recs = _access_records(caplog)
+        assert len(access_recs) >= 1
+        assert access_recs[0].status == "ok"
+
+
+class TestThresholdZeroDisablesSlowDetection:
+    """Setting threshold to 0 disables slow detection."""
+
+    @pytest.fixture(autouse=True)
+    def register_elements(self, test_domain):
+        test_domain.config["logging"]["slow_handler_threshold_ms"] = 0
+        test_domain.register(Item)
+        test_domain.register(CreateItem, part_of=Item)
+        test_domain.register(SlowHandler, part_of=Item)
+        test_domain.init(traverse=False)
+
+    def test_threshold_zero_disables_slow_detection(self, test_domain, caplog):
+        with caplog.at_level(logging.DEBUG, logger="protean.access"):
+            with caplog.at_level(logging.DEBUG, logger="protean.perf"):
+                test_domain.process(
+                    CreateItem(item_id=str(uuid4()), name="No Slow Check")
+                )
+
+        # Access log should be INFO with status="ok" despite slow execution
+        access_recs = _access_records(caplog)
+        assert len(access_recs) >= 1
+        assert access_recs[0].status == "ok"
+        assert access_recs[0].levelno == logging.INFO
+
+        # No slow_handler perf records
+        perf_recs = _perf_records(caplog)
+        slow_perf = [r for r in perf_recs if "slow_handler" in r.getMessage()]
+        assert len(slow_perf) == 0

--- a/tests/logging/test_wide_event_domain_context.py
+++ b/tests/logging/test_wide_event_domain_context.py
@@ -1,0 +1,271 @@
+"""Tests for wide event domain context enrichment.
+
+Verifies that:
+- Aggregate type and ID are populated
+- Events raised are tracked
+- Repository operations are counted
+- UoW outcome is committed on success
+- UoW outcome is rolled_back on failure
+- Query handlers report no_uow
+"""
+
+import logging
+from uuid import uuid4
+
+import pytest
+
+from protean.core.aggregate import BaseAggregate
+from protean.core.command import BaseCommand
+from protean.core.command_handler import BaseCommandHandler
+from protean.core.event import BaseEvent
+from protean.core.event_handler import BaseEventHandler
+from protean.core.projection import BaseProjection
+from protean.core.query import BaseQuery
+from protean.core.query_handler import BaseQueryHandler
+from protean.fields import Identifier, String
+from protean.utils.globals import current_domain
+from protean.utils.mixins import handle, read
+
+
+# --- Domain elements ---
+
+
+class Product(BaseAggregate):
+    product_id = Identifier(identifier=True)
+    name = String()
+    status = String(default="draft")
+
+    def publish(self) -> None:
+        self.status = "published"
+        self.raise_(ProductPublished(product_id=self.product_id, name=self.name))
+
+    def archive(self) -> None:
+        self.status = "archived"
+        self.raise_(ProductArchived(product_id=self.product_id))
+
+
+class ProductPublished(BaseEvent):
+    product_id = Identifier()
+    name = String()
+
+
+class ProductArchived(BaseEvent):
+    product_id = Identifier()
+
+
+class PublishProduct(BaseCommand):
+    product_id = Identifier(identifier=True)
+    name = String()
+
+
+class PublishAndArchive(BaseCommand):
+    """Command that raises two events."""
+
+    product_id = Identifier(identifier=True)
+    name = String()
+
+
+class FailingPublish(BaseCommand):
+    product_id = Identifier(identifier=True)
+
+
+class PublishProductHandler(BaseCommandHandler):
+    @handle(PublishProduct)
+    def handle_publish(self, command: PublishProduct) -> None:
+        repo = current_domain.repository_for(Product)
+        product = Product(product_id=command.product_id, name=command.name)
+        product.publish()
+        repo.add(product)
+
+
+class PublishAndArchiveHandler(BaseCommandHandler):
+    @handle(PublishAndArchive)
+    def handle_publish_and_archive(self, command: PublishAndArchive) -> None:
+        repo = current_domain.repository_for(Product)
+        product = Product(product_id=command.product_id, name=command.name)
+        product.publish()
+        product.archive()
+        repo.add(product)
+
+
+class FailingPublishHandler(BaseCommandHandler):
+    @handle(FailingPublish)
+    def handle_failing(self, command: FailingPublish) -> None:
+        raise RuntimeError("Publish failed")
+
+
+class LoadAndSaveHandler(BaseCommandHandler):
+    """Handler that performs both get() and add() operations."""
+
+    @handle(PublishProduct)
+    def handle_publish(self, command: PublishProduct) -> None:
+        repo = current_domain.repository_for(Product)
+        # First save
+        product = Product(product_id=command.product_id, name=command.name)
+        repo.add(product)
+        # Then load twice
+        repo.get(command.product_id)
+        repo.get(command.product_id)
+
+
+class ProductEventHandler(BaseEventHandler):
+    @handle(ProductPublished)
+    def on_published(self, event: ProductPublished) -> None:
+        pass
+
+
+class ProductSummary(BaseProjection):
+    product_id = Identifier(identifier=True)
+    name = String()
+
+
+class GetProductById(BaseQuery):
+    product_id = Identifier(required=True)
+
+
+class ProductQueryHandler(BaseQueryHandler):
+    @read(GetProductById)
+    def get_by_id(self, query: GetProductById) -> dict:
+        return {"product_id": query.product_id, "name": "Test Product"}
+
+
+def _access_records(caplog) -> list[logging.LogRecord]:
+    return [r for r in caplog.records if r.name == "protean.access"]
+
+
+class TestAggregateTypeAndIdPopulated:
+    @pytest.fixture(autouse=True)
+    def register_elements(self, test_domain):
+        test_domain.register(Product)
+        test_domain.register(ProductPublished, part_of=Product)
+        test_domain.register(ProductArchived, part_of=Product)
+        test_domain.register(PublishProduct, part_of=Product)
+        test_domain.register(PublishProductHandler, part_of=Product)
+        test_domain.register(ProductEventHandler, part_of=Product)
+        test_domain.init(traverse=False)
+
+    def test_aggregate_type_and_id_populated(self, test_domain, caplog):
+        product_id = str(uuid4())
+        with caplog.at_level(logging.DEBUG, logger="protean.access"):
+            test_domain.process(PublishProduct(product_id=product_id, name="Widget"))
+
+        records = _access_records(caplog)
+        cmd_records = [r for r in records if r.kind == "command"]
+        assert len(cmd_records) >= 1
+
+        record = cmd_records[0]
+        assert record.aggregate == "Product"
+        assert record.aggregate_id == product_id
+
+
+class TestEventsRaisedTracked:
+    @pytest.fixture(autouse=True)
+    def register_elements(self, test_domain):
+        test_domain.register(Product)
+        test_domain.register(ProductPublished, part_of=Product)
+        test_domain.register(ProductArchived, part_of=Product)
+        test_domain.register(PublishAndArchive, part_of=Product)
+        test_domain.register(PublishAndArchiveHandler, part_of=Product)
+        test_domain.init(traverse=False)
+
+    def test_events_raised_tracked(self, test_domain, caplog):
+        product_id = str(uuid4())
+        with caplog.at_level(logging.DEBUG, logger="protean.access"):
+            test_domain.process(
+                PublishAndArchive(product_id=product_id, name="Archive Test")
+            )
+
+        records = _access_records(caplog)
+        cmd_records = [r for r in records if r.kind == "command"]
+        assert len(cmd_records) >= 1
+
+        record = cmd_records[0]
+        assert "ProductPublished" in record.events_raised
+        assert "ProductArchived" in record.events_raised
+        assert record.events_raised_count == 2
+
+
+class TestRepoOperationsCounted:
+    @pytest.fixture(autouse=True)
+    def register_elements(self, test_domain):
+        test_domain.register(Product)
+        test_domain.register(ProductPublished, part_of=Product)
+        test_domain.register(ProductArchived, part_of=Product)
+        test_domain.register(PublishProduct, part_of=Product)
+        test_domain.register(LoadAndSaveHandler, part_of=Product)
+        test_domain.init(traverse=False)
+
+    def test_repo_operations_counted(self, test_domain, caplog):
+        product_id = str(uuid4())
+        with caplog.at_level(logging.DEBUG, logger="protean.access"):
+            test_domain.process(
+                PublishProduct(product_id=product_id, name="Count Test")
+            )
+
+        records = _access_records(caplog)
+        cmd_records = [r for r in records if r.kind == "command"]
+        assert len(cmd_records) >= 1
+
+        record = cmd_records[0]
+        assert record.repo_operations["loads"] == 2
+        assert record.repo_operations["saves"] >= 1
+
+
+class TestUoWCommittedOnSuccess:
+    @pytest.fixture(autouse=True)
+    def register_elements(self, test_domain):
+        test_domain.register(Product)
+        test_domain.register(ProductPublished, part_of=Product)
+        test_domain.register(ProductArchived, part_of=Product)
+        test_domain.register(PublishProduct, part_of=Product)
+        test_domain.register(PublishProductHandler, part_of=Product)
+        test_domain.register(ProductEventHandler, part_of=Product)
+        test_domain.init(traverse=False)
+
+    def test_uow_committed_on_success(self, test_domain, caplog):
+        with caplog.at_level(logging.DEBUG, logger="protean.access"):
+            test_domain.process(
+                PublishProduct(product_id=str(uuid4()), name="Commit Test")
+            )
+
+        records = _access_records(caplog)
+        cmd_records = [r for r in records if r.kind == "command"]
+        assert len(cmd_records) >= 1
+        assert cmd_records[0].uow_outcome == "committed"
+
+
+class TestUoWRolledBackOnFailure:
+    @pytest.fixture(autouse=True)
+    def register_elements(self, test_domain):
+        test_domain.register(Product)
+        test_domain.register(ProductPublished, part_of=Product)
+        test_domain.register(ProductArchived, part_of=Product)
+        test_domain.register(FailingPublish, part_of=Product)
+        test_domain.register(FailingPublishHandler, part_of=Product)
+        test_domain.init(traverse=False)
+
+    def test_uow_rolled_back_on_failure(self, test_domain, caplog):
+        with caplog.at_level(logging.DEBUG, logger="protean.access"):
+            with pytest.raises(RuntimeError, match="Publish failed"):
+                test_domain.process(FailingPublish(product_id=str(uuid4())))
+
+        records = _access_records(caplog)
+        assert len(records) >= 1
+        assert records[0].uow_outcome == "rolled_back"
+
+
+class TestNoUoWForQuery:
+    @pytest.fixture(autouse=True)
+    def register_elements(self, test_domain):
+        test_domain.register(ProductSummary)
+        test_domain.register(GetProductById, part_of=ProductSummary)
+        test_domain.register(ProductQueryHandler, part_of=ProductSummary)
+        test_domain.init(traverse=False)
+
+    def test_no_uow_for_query(self, test_domain, caplog):
+        with caplog.at_level(logging.DEBUG, logger="protean.access"):
+            test_domain.dispatch(GetProductById(product_id="prod-1"))
+
+        records = _access_records(caplog)
+        assert len(records) >= 1
+        assert records[0].uow_outcome == "no_uow"

--- a/tests/logging/test_wide_event_enrichment.py
+++ b/tests/logging/test_wide_event_enrichment.py
@@ -1,0 +1,252 @@
+"""Tests for wide event enrichment via bind_event_context().
+
+Verifies that:
+- Application-provided fields appear in the wide event
+- Multiple bind calls merge correctly
+- Later bind calls overwrite conflicting keys
+- unbind removes specific fields
+- bind_event_context outside handler is a no-op
+- Context is cleared between handler invocations
+- App context cannot overwrite framework-reserved fields
+"""
+
+import logging
+from uuid import uuid4
+
+import pytest
+
+from protean.core.aggregate import BaseAggregate
+from protean.core.command import BaseCommand
+from protean.core.command_handler import BaseCommandHandler
+from protean.core.event import BaseEvent
+from protean.core.event_handler import BaseEventHandler
+from protean.fields import Identifier, String
+from protean.utils.logging import bind_event_context, unbind_event_context
+from protean.utils.globals import current_domain
+from protean.utils.mixins import handle
+
+
+# --- Domain elements ---
+
+
+class Account(BaseAggregate):
+    account_id = Identifier(identifier=True)
+    name = String()
+
+    def activate(self) -> None:
+        self.raise_(AccountActivated(account_id=self.account_id))
+
+
+class AccountActivated(BaseEvent):
+    account_id = Identifier()
+
+
+class CreateAccount(BaseCommand):
+    account_id = Identifier(identifier=True)
+    name = String()
+
+
+class BindContextHandler(BaseCommandHandler):
+    @handle(CreateAccount)
+    def handle_create(self, command: CreateAccount) -> None:
+        bind_event_context(
+            user_tier="premium",
+            order_total=9999,
+        )
+
+
+class MultipleBindHandler(BaseCommandHandler):
+    @handle(CreateAccount)
+    def handle_create(self, command: CreateAccount) -> None:
+        bind_event_context(a=1)
+        bind_event_context(b=2)
+
+
+class OverwriteBindHandler(BaseCommandHandler):
+    @handle(CreateAccount)
+    def handle_create(self, command: CreateAccount) -> None:
+        bind_event_context(x=1)
+        bind_event_context(x=2)
+
+
+class UnbindHandler(BaseCommandHandler):
+    @handle(CreateAccount)
+    def handle_create(self, command: CreateAccount) -> None:
+        bind_event_context(a=1, b=2)
+        unbind_event_context("a")
+
+
+class FrameworkOverrideHandler(BaseCommandHandler):
+    @handle(CreateAccount)
+    def handle_create(self, command: CreateAccount) -> None:
+        bind_event_context(kind="hacked", duration_ms=-1)
+
+
+class BindContextEventHandler(BaseEventHandler):
+    @handle(AccountActivated)
+    def on_activated(self, event: AccountActivated) -> None:
+        # This handler does NOT call bind_event_context
+        pass
+
+
+class BindInCommandHandler(BaseCommandHandler):
+    """Handler that binds context and raises an event."""
+
+    @handle(CreateAccount)
+    def handle_create(self, command: CreateAccount) -> None:
+        bind_event_context(user_id="abc")
+        repo = current_domain.repository_for(Account)
+        account = Account(account_id=command.account_id, name=command.name)
+        account.activate()
+        repo.add(account)
+
+
+def _access_records(caplog) -> list[logging.LogRecord]:
+    return [r for r in caplog.records if r.name == "protean.access"]
+
+
+class TestBindEventContextAppearsInWideEvent:
+    @pytest.fixture(autouse=True)
+    def register_elements(self, test_domain):
+        test_domain.register(Account)
+        test_domain.register(AccountActivated, part_of=Account)
+        test_domain.register(CreateAccount, part_of=Account)
+        test_domain.register(BindContextHandler, part_of=Account)
+        test_domain.init(traverse=False)
+
+    def test_bind_event_context_appears_in_wide_event(self, test_domain, caplog):
+        with caplog.at_level(logging.DEBUG, logger="protean.access"):
+            test_domain.process(
+                CreateAccount(account_id=str(uuid4()), name="Test User")
+            )
+
+        records = _access_records(caplog)
+        assert len(records) >= 1
+
+        record = records[0]
+        assert record.user_tier == "premium"
+        assert record.order_total == 9999
+
+
+class TestMultipleBindCallsMerge:
+    @pytest.fixture(autouse=True)
+    def register_elements(self, test_domain):
+        test_domain.register(Account)
+        test_domain.register(AccountActivated, part_of=Account)
+        test_domain.register(CreateAccount, part_of=Account)
+        test_domain.register(MultipleBindHandler, part_of=Account)
+        test_domain.init(traverse=False)
+
+    def test_multiple_bind_calls_merge(self, test_domain, caplog):
+        with caplog.at_level(logging.DEBUG, logger="protean.access"):
+            test_domain.process(
+                CreateAccount(account_id=str(uuid4()), name="Merge Test")
+            )
+
+        records = _access_records(caplog)
+        assert len(records) >= 1
+
+        record = records[0]
+        assert record.a == 1
+        assert record.b == 2
+
+
+class TestBindOverwritesOnConflict:
+    @pytest.fixture(autouse=True)
+    def register_elements(self, test_domain):
+        test_domain.register(Account)
+        test_domain.register(AccountActivated, part_of=Account)
+        test_domain.register(CreateAccount, part_of=Account)
+        test_domain.register(OverwriteBindHandler, part_of=Account)
+        test_domain.init(traverse=False)
+
+    def test_bind_overwrites_on_conflict(self, test_domain, caplog):
+        with caplog.at_level(logging.DEBUG, logger="protean.access"):
+            test_domain.process(
+                CreateAccount(account_id=str(uuid4()), name="Overwrite Test")
+            )
+
+        records = _access_records(caplog)
+        assert len(records) >= 1
+        assert records[0].x == 2
+
+
+class TestUnbindRemovesField:
+    @pytest.fixture(autouse=True)
+    def register_elements(self, test_domain):
+        test_domain.register(Account)
+        test_domain.register(AccountActivated, part_of=Account)
+        test_domain.register(CreateAccount, part_of=Account)
+        test_domain.register(UnbindHandler, part_of=Account)
+        test_domain.init(traverse=False)
+
+    def test_unbind_removes_field(self, test_domain, caplog):
+        with caplog.at_level(logging.DEBUG, logger="protean.access"):
+            test_domain.process(
+                CreateAccount(account_id=str(uuid4()), name="Unbind Test")
+            )
+
+        records = _access_records(caplog)
+        assert len(records) >= 1
+
+        record = records[0]
+        assert not hasattr(record, "a")
+        assert record.b == 2
+
+
+class TestBindOutsideHandlerIsNoop:
+    def test_bind_outside_handler_is_noop(self):
+        """Calling bind_event_context outside any handler should not raise."""
+        bind_event_context(foo="bar")
+        # No error expected — it's a no-op in terms of side effects
+
+
+class TestContextClearedBetweenHandlers:
+    """Context from one handler does not leak into the next."""
+
+    @pytest.fixture(autouse=True)
+    def register_elements(self, test_domain):
+        test_domain.register(Account)
+        test_domain.register(AccountActivated, part_of=Account)
+        test_domain.register(CreateAccount, part_of=Account)
+        test_domain.register(BindInCommandHandler, part_of=Account)
+        test_domain.register(BindContextEventHandler, part_of=Account)
+        test_domain.init(traverse=False)
+
+    def test_context_is_cleared_between_handlers(self, test_domain, caplog):
+        with caplog.at_level(logging.DEBUG, logger="protean.access"):
+            test_domain.process(
+                CreateAccount(account_id=str(uuid4()), name="Clear Test")
+            )
+
+        records = _access_records(caplog)
+        # Find the event handler record (should NOT have user_id)
+        event_records = [r for r in records if r.kind == "event"]
+        if event_records:
+            assert not hasattr(event_records[0], "user_id"), (
+                "user_id from command handler should not leak into event handler"
+            )
+
+
+class TestAppContextDoesNotOverwriteFrameworkFields:
+    @pytest.fixture(autouse=True)
+    def register_elements(self, test_domain):
+        test_domain.register(Account)
+        test_domain.register(AccountActivated, part_of=Account)
+        test_domain.register(CreateAccount, part_of=Account)
+        test_domain.register(FrameworkOverrideHandler, part_of=Account)
+        test_domain.init(traverse=False)
+
+    def test_app_context_does_not_overwrite_framework_fields(self, test_domain, caplog):
+        with caplog.at_level(logging.DEBUG, logger="protean.access"):
+            test_domain.process(
+                CreateAccount(account_id=str(uuid4()), name="Override Test")
+            )
+
+        records = _access_records(caplog)
+        assert len(records) >= 1
+
+        record = records[0]
+        # Framework fields should take precedence
+        assert record.kind == "command"  # NOT "hacked"
+        assert record.duration_ms > 0  # NOT -1

--- a/tests/logging/test_wide_event_enrichment.py
+++ b/tests/logging/test_wide_event_enrichment.py
@@ -8,6 +8,8 @@ Verifies that:
 - bind_event_context outside handler is a no-op
 - Context is cleared between handler invocations
 - App context cannot overwrite framework-reserved fields
+- Outer structlog context is preserved across handler invocations
+- LogRecord-reserved attribute names are stripped from app context
 """
 
 import logging
@@ -80,6 +82,13 @@ class FrameworkOverrideHandler(BaseCommandHandler):
     @handle(CreateAccount)
     def handle_create(self, command: CreateAccount) -> None:
         bind_event_context(kind="hacked", duration_ms=-1)
+
+
+class LogRecordCollisionHandler(BaseCommandHandler):
+    @handle(CreateAccount)
+    def handle_create(self, command: CreateAccount) -> None:
+        # Bind keys that collide with stdlib LogRecord attributes
+        bind_event_context(name="bad", levelno=99, msg="bad", safe_key="safe_value")
 
 
 class BindContextEventHandler(BaseEventHandler):
@@ -250,3 +259,62 @@ class TestAppContextDoesNotOverwriteFrameworkFields:
         # Framework fields should take precedence
         assert record.kind == "command"  # NOT "hacked"
         assert record.duration_ms > 0  # NOT -1
+
+
+class TestOuterContextPreservedAcrossHandlers:
+    """Outer structlog context (bound via add_context) is restored after handler."""
+
+    @pytest.fixture(autouse=True)
+    def register_elements(self, test_domain):
+        test_domain.register(Account)
+        test_domain.register(AccountActivated, part_of=Account)
+        test_domain.register(CreateAccount, part_of=Account)
+        test_domain.register(BindContextHandler, part_of=Account)
+        test_domain.init(traverse=False)
+
+    def test_outer_context_preserved(self, test_domain, caplog):
+        import structlog
+
+        # Bind outer context before handler invocation
+        structlog.contextvars.bind_contextvars(request_id="req-999")
+
+        with caplog.at_level(logging.DEBUG, logger="protean.access"):
+            test_domain.process(
+                CreateAccount(account_id=str(uuid4()), name="Preserve Test")
+            )
+
+        # Outer context should be restored after handler completes
+        ctx = structlog.contextvars.get_contextvars()
+        assert ctx.get("request_id") == "req-999", (
+            "Outer structlog context should be preserved after handler invocation"
+        )
+
+        # Clean up
+        structlog.contextvars.clear_contextvars()
+
+
+class TestLogRecordReservedKeysStripped:
+    """App context keys that collide with LogRecord attrs are stripped."""
+
+    @pytest.fixture(autouse=True)
+    def register_elements(self, test_domain):
+        test_domain.register(Account)
+        test_domain.register(AccountActivated, part_of=Account)
+        test_domain.register(CreateAccount, part_of=Account)
+        test_domain.register(LogRecordCollisionHandler, part_of=Account)
+        test_domain.init(traverse=False)
+
+    def test_logrecord_reserved_keys_stripped(self, test_domain, caplog):
+        """Binding keys that collide with LogRecord attributes should not
+        cause errors — they are silently stripped."""
+        with caplog.at_level(logging.DEBUG, logger="protean.access"):
+            test_domain.process(
+                CreateAccount(account_id=str(uuid4()), name="Collision Test")
+            )
+
+        # The handler should complete successfully (no KeyError)
+        records = _access_records(caplog)
+        assert len(records) >= 1
+        assert records[0].status == "ok"
+        # The safe key should still be present
+        assert records[0].safe_key == "safe_value"


### PR DESCRIPTION
## Summary
- Add `protean.access` logger that emits one structured wide event per handled message with full domain context (kind, message_type, aggregate, aggregate_id, events_raised, repo_operations, uow_outcome, handler, duration_ms, status, correlation/causation IDs)
- Add `protean.perf` logger for slow-handler detection — handlers exceeding `slow_handler_threshold_ms` (default 500ms) emit a separate WARNING for independent alerting
- Add `bind_event_context()` / `unbind_event_context()` public API so application code can enrich the wide event with business-specific fields (user tier, order total, etc.)

## Test plan
- [x] 6 tests in `test_access_log.py` — command/event/query/projector wide events, failure events, correlation IDs
- [x] 7 tests in `test_wide_event_enrichment.py` — bind/unbind, merge, overwrite, no-op outside handler, context clearing, framework field precedence
- [x] 6 tests in `test_wide_event_domain_context.py` — aggregate type/ID, events raised, repo operations, UoW committed/rolled_back/no_uow
- [x] 4 tests in `test_slow_handler.py` — slow warning emission, fast handler no warning, default threshold, threshold=0 disables
- [x] All 1484 existing core tests pass with no regressions

Closes #916