### PR TITLE
Catch duplicate command handlers at domain.init()

### DIFF
--- a/changes/936.fixed.md
+++ b/changes/936.fixed.md
@@ -1,0 +1,1 @@
+Detect cross-handler command collisions at `Domain.init()` instead of at dispatch time — two command handler classes claiming the same command now raise `IncorrectUsageError` during validation, and are also reported by `protean check`.

--- a/src/protean/adapters/event_store/__init__.py
+++ b/src/protean/adapters/event_store/__init__.py
@@ -10,7 +10,7 @@ from protean.core.event_sourced_repository import (
     event_sourced_repository_factory,
 )
 from protean.core.projector import BaseProjector
-from protean.exceptions import ConfigurationError, NotSupportedError
+from protean.exceptions import ConfigurationError
 from protean.utils import fqn
 
 if TYPE_CHECKING:
@@ -180,27 +180,9 @@ class EventStore:
         stream_category = command.meta_.part_of.meta_.stream_category
 
         handler_classes = self._command_streams.get(stream_category, set())
-
-        # No command handlers have been configured to run this command
-        if len(handler_classes) == 0:
-            return None
-
-        # Ensure that a command has a unique handler across all handlers.
-        # HandlerConfigurator validates this at domain.init() time; this is
-        # a runtime safety net.
-        handler_methods = set()
+        command_type = command.__class__.__type__
         for handler_cls in handler_classes:
-            try:
-                handler_method = next(
-                    iter(handler_cls._handlers[command.__class__.__type__])
-                )
-                handler_methods.add((handler_cls, handler_method))
-            except StopIteration:
-                pass
+            if handler_cls._handlers.get(command_type):
+                return handler_cls
 
-        if len(handler_methods) > 1:
-            raise NotSupportedError(
-                f"Command {command.__class__.__name__} cannot be handled by multiple handlers"
-            )
-
-        return next(iter(handler_methods))[0] if handler_methods else None
+        return None

--- a/src/protean/domain/validation.py
+++ b/src/protean/domain/validation.py
@@ -121,6 +121,7 @@ class DomainValidator:
         self._validate_identity_config()
         self._validate_association_fields()
         self._validate_event_sourced_aggregates()
+        self._validate_unique_command_handlers()
         self._validate_entity_providers()
         self._validate_projector_associations()
         self._validate_query_associations()
@@ -153,6 +154,7 @@ class DomainValidator:
             self._validate_identity_config,
             self._validate_association_fields,
             self._validate_event_sourced_aggregates,
+            self._validate_unique_command_handlers,
             self._validate_entity_providers,
             self._validate_projector_associations,
             self._validate_query_associations,
@@ -255,6 +257,36 @@ class DomainValidator:
             raise IncorrectUsageError(
                 f"Events are associated with multiple event sourced aggregates: "
                 f"{', '.join(duplicate_event_class_names)}"
+            )
+
+    def _validate_unique_command_handlers(self) -> None:
+        """Check that no command is handled by more than one command handler class.
+
+        Intra-class duplicates (two ``@handle`` methods for the same command
+        inside a single handler) are caught earlier by
+        ``HandlerConfigurator.setup_command_handlers``.  This validation
+        covers the cross-class case, which otherwise only surfaces at
+        dispatch time.
+        """
+        registry = self._domain.registry
+        handlers_by_command: dict[str, list[str]] = {}
+        for _, ch_record in registry._elements[
+            DomainObjects.COMMAND_HANDLER.value
+        ].items():
+            for command_type in ch_record.cls._handlers.keys():
+                handlers_by_command.setdefault(command_type, []).append(
+                    ch_record.cls.__name__
+                )
+
+        duplicates = sorted(
+            command_type
+            for command_type, handler_names in handlers_by_command.items()
+            if len(handler_names) > 1
+        )
+        if duplicates:
+            raise IncorrectUsageError(
+                f"Commands cannot be handled by multiple handlers: "
+                f"{', '.join(duplicates)}"
             )
 
     def _validate_entity_providers(self) -> None:

--- a/tests/command_handler/test_retrieving_handlers_by_command.py
+++ b/tests/command_handler/test_retrieving_handlers_by_command.py
@@ -3,7 +3,7 @@ import pytest
 from protean.core.aggregate import BaseAggregate
 from protean.core.command import BaseCommand
 from protean.core.command_handler import BaseCommandHandler
-from protean.exceptions import ConfigurationError, NotSupportedError
+from protean.exceptions import ConfigurationError, IncorrectUsageError
 from protean.fields import Identifier, String, Text
 from protean.utils.mixins import handle
 
@@ -95,13 +95,14 @@ def test_retrieving_handlers_for_unknown_command(test_domain):
 
 def test_error_on_defining_multiple_handlers_for_a_command(test_domain):
     test_domain.register(User, is_event_sourced=True)
+    test_domain.register(Register, part_of=User)
     test_domain.register(UserCommandHandlers, part_of=User)
     test_domain.register(AdminUserCommandHandlers, part_of=User)
-    test_domain.init(traverse=False)
 
-    with pytest.raises(NotSupportedError) as exc:
-        test_domain.command_handler_for(Register())
+    with pytest.raises(IncorrectUsageError) as exc:
+        test_domain.init(traverse=False)
 
     assert (
-        exc.value.args[0] == "Command Register cannot be handled by multiple handlers"
+        exc.value.args[0]
+        == f"Commands cannot be handled by multiple handlers: {Register.__type__}"
     )

--- a/tests/server/test_handle_error.py
+++ b/tests/server/test_handle_error.py
@@ -49,6 +49,18 @@ class Register(BaseCommand):
     password_hash: String()
 
 
+class RegisterWithError(BaseCommand):
+    email: String()
+    name: String()
+    password_hash: String()
+
+
+class RegisterWithErrorInErrorHandler(BaseCommand):
+    email: String()
+    name: String()
+    password_hash: String()
+
+
 class User(BaseAggregate):
     email: String()
     name: String()
@@ -113,7 +125,7 @@ class NormalCommandHandler(BaseCommandHandler):
 class ErrorCommandHandler(BaseCommandHandler):
     """Command handler that raises an exception and has a handle_error method"""
 
-    @handle(Register)
+    @handle(RegisterWithError)
     def handle_register(self, command):
         global handler_counter
         handler_counter += 1
@@ -128,7 +140,7 @@ class ErrorCommandHandler(BaseCommandHandler):
 class ErrorInErrorHandlerCommandHandler(BaseCommandHandler):
     """Command handler that raises an exception in both the handler and handle_error"""
 
-    @handle(Register)
+    @handle(RegisterWithErrorInErrorHandler)
     def handle_register(self, command):
         global handler_counter
         handler_counter += 1
@@ -189,6 +201,8 @@ def register(test_domain):
     test_domain.register(User, is_event_sourced=True)
     test_domain.register(Registered, part_of=User)
     test_domain.register(Register, part_of=User)
+    test_domain.register(RegisterWithError, part_of=User)
+    test_domain.register(RegisterWithErrorInErrorHandler, part_of=User)
 
     # Register handlers
     test_domain.register(NormalEventHandler, part_of=User)
@@ -258,31 +272,45 @@ async def test_event_handler_error_handling(test_domain, caplog):
 @pytest.mark.asyncio
 async def test_command_handler_error_handling(test_domain, caplog):
     """Test that handle_error is called when an exception occurs in a command handler"""
-    # Create test command
-    command = Register(
-        email="john.doe@example.com",
-        name="John Doe",
-        password_hash="hash",
+
+    # Each handler class is wired to its own command type, so we
+    # build a dedicated message per handler.
+    def message_for(cmd):
+        return Message.from_domain_object(
+            test_domain._enrich_command(cmd, asynchronous=True)
+        )
+
+    normal_message = message_for(
+        Register(email="john.doe@example.com", name="John Doe", password_hash="hash")
     )
-    message = Message.from_domain_object(
-        test_domain._enrich_command(command, asynchronous=True)
+    error_message = message_for(
+        RegisterWithError(
+            email="john.doe@example.com", name="John Doe", password_hash="hash"
+        )
+    )
+    error_in_error_message = message_for(
+        RegisterWithErrorInErrorHandler(
+            email="john.doe@example.com", name="John Doe", password_hash="hash"
+        )
     )
 
     # Create engine
     engine = Engine(domain=test_domain, test_mode=True)
 
     # Test normal handler
-    await engine.handle_message(NormalCommandHandler, message)
+    await engine.handle_message(NormalCommandHandler, normal_message)
     assert handler_counter == 1
     assert error_handler_counter == 0
 
     # Test handler with error that has handle_error
-    await engine.handle_message(ErrorCommandHandler, message)
+    await engine.handle_message(ErrorCommandHandler, error_message)
     assert handler_counter == 2  # +1 from the handler
     assert error_handler_counter == 1  # +1 from handle_error
 
     # Test handler with error in handle_error
-    await engine.handle_message(ErrorInErrorHandlerCommandHandler, message)
+    await engine.handle_message(
+        ErrorInErrorHandlerCommandHandler, error_in_error_message
+    )
     assert handler_counter == 3  # +1 from the handler
     assert error_in_error_handler_counter == 1  # +1 from handle_error
 

--- a/tests/server/test_version_retry.py
+++ b/tests/server/test_version_retry.py
@@ -117,7 +117,9 @@ def register_elements(test_domain):
     test_domain.register(UserActivated, part_of=User)
     test_domain.register(UserRenamed, part_of=User)
     test_domain.register(RenameUser, part_of=User)
-    test_domain.register(UserCommandHandler, part_of=User)
+    # `UserCommandHandler` is NOT registered here — tests that define
+    # their own `RenameUser` handler would otherwise collide with it.
+    # The one test that needs `UserCommandHandler` registers it itself.
     test_domain.register(UserEventHandler, part_of=User)
     test_domain.init(traverse=False)
 
@@ -221,6 +223,9 @@ class TestRetryOnVersionError:
     @patch("protean.utils.mixins.time.sleep")
     def test_succeeds_on_first_attempt(self, mock_sleep, test_domain):
         """No retry needed when handler succeeds immediately."""
+        test_domain.register(UserCommandHandler, part_of=User)
+        test_domain.init(traverse=False)
+
         identifier = _create_user(test_domain)
 
         command = RenameUser(user_id=identifier, name="Jane")


### PR DESCRIPTION
## Summary

- Cross-handler command collisions previously only surfaced at dispatch time, via a runtime `NotSupportedError` inside `EventStore.command_handler_for`. Two handler classes claiming the same command were silently accepted at init time, so a broken domain config could start up cleanly and fail later during message dispatch.
- Add `DomainValidator._validate_unique_command_handlers`, wired into both `validate()` (the `Domain.init()` path) and `validate_all()` (the `Domain.check()` / `protean check` path). Raises `IncorrectUsageError` listing the offending command type(s).
- Simplify `EventStore.command_handler_for` to return the first matching handler class, since uniqueness is now guaranteed by the validator; drop the newly-unused `NotSupportedError` import.
- Fix pre-existing test fixtures that exploited the old lax behavior:
  - `tests/server/test_version_retry.py` stops pre-registering `UserCommandHandler` in the shared autouse fixture; the one test that needs it registers it itself.
  - `tests/server/test_handle_error.py` gives each error-variant command handler its own command type (`RegisterWithError`, `RegisterWithErrorInErrorHandler`) so three handler classes no longer claim the same `Register` command.

## Behavior change note

The init-time intra-class check in `HandlerConfigurator.setup_command_handlers` is unchanged (still raises `NotSupportedError`). The cross-class case now raises `IncorrectUsageError` at `Domain.init()` rather than `NotSupportedError` at dispatch time. Any downstream code that caught the dispatch-time error for a genuinely broken config will need to catch it at init instead.

## Test plan

- [x] `tests/command_handler/`, `tests/command/`, `tests/domain/`, `tests/event_handler/`, `tests/query_handler/` — 462 passed / 17 skipped
- [x] `tests/server/test_handle_error.py`, `tests/server/test_version_retry.py` — 27 passed
- [x] Full core suite — 8540 passed / 188 skipped (adapter-only) / 1 xfailed