### PR TITLE
Upgrade Elasticsearch client from v7 to v8 to resolve urllib3 vulnerability

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def read(*names, **kwargs):
     ).read()
 
 
-elasticsearch_requires = ["elasticsearch>=7.13.1", "elasticsearch-dsl>=7.3.0"]
+elasticsearch_requires = ["elasticsearch>=8.0.0", "elasticsearch-dsl>=8.0.0"]
 redis_requires = ["redis==3.5.2"]
 sqlite_requires = ["sqlalchemy==1.4.27"]
 postgresql_requires = ["psycopg2>=2.8.4", "sqlalchemy==1.4.27"]

--- a/src/protean/adapters/repository/elasticsearch.py
+++ b/src/protean/adapters/repository/elasticsearch.py
@@ -351,11 +351,7 @@ class ESProvider(BaseProvider):
     def get_connection(self):
         """Get the connection object for the repository"""
 
-        return Elasticsearch(
-            self.conn_info["DATABASE_URI"]["hosts"],
-            use_ssl=self.conn_info.get("USE_SSL", False),
-            verify_certs=self.conn_info.get("VERIFY_CERTS", False),
-        )
+        return Elasticsearch(self.conn_info.get("DATABASE_URI").get("hosts")[0],verify_certs=self.conn_info.get("VERIFY_CERTS", False))
 
     def get_dao(self, entity_cls, model_cls):
         """Return a DAO object configured with a live connection"""

--- a/src/protean/adapters/repository/elasticsearch.py
+++ b/src/protean/adapters/repository/elasticsearch.py
@@ -459,9 +459,7 @@ class ESProvider(BaseProvider):
             model_cls = self.domain.get_model(element_record.cls)
             if provider.conn_info[
                 "DATABASE"
-            ] == Database.ELASTICSEARCH.value and conn.indices.exists(
-                model_cls._index._name
-            ):
+            ] == Database.ELASTICSEARCH.value and conn.indices.exists(index=model_cls._index._name):
                 conn.delete_by_query(
                     refresh=True,
                     index=model_cls._index._name,
@@ -501,7 +499,7 @@ class ESProvider(BaseProvider):
             if provider.conn_info[
                 "DATABASE"
             ] == Database.ELASTICSEARCH.value and model_cls._index.exists(using=conn):
-                conn.indices.delete(model_cls._index._name)
+                conn.indices.delete(index=model_cls._index._name)
 
 
 class DefaultLookup(BaseLookup):


### PR DESCRIPTION
# Upgrade Elasticsearch Client to v8 for urllib3 Vulnerability Resolution

## Summary
This PR upgrades the Elasticsearch Python client from version 7.x to 8.x to address a security vulnerability caused by outdated `urllib3` dependency constraints.

## Background
A vulnerability was identified in the `urllib3` package. The existing Elasticsearch 7.x client version was preventing us from upgrading to a secure version of `urllib3` because of dependency compatibility restrictions.

To resolve this issue, we upgraded:
- `elasticsearch` from `7.13.1` to `8.0.0+`
- `elasticsearch-dsl` from `7.3.0` to `8.0.0+`

## Changes Made
- Updated Elasticsearch-related dependencies in `setup.py`
- Refactored Elasticsearch connection initialization to align with Elasticsearch v8 client API changes
- Updated index existence checks to use Elasticsearch v8 compatible syntax
- Updated index deletion calls for Elasticsearch v8 compatibility

## Reason for Change
This upgrade was required to:
- Remove dependency constraints blocking secure `urllib3` versions
- Resolve reported security vulnerabilities
- Ensure long-term compatibility and support with newer Elasticsearch client versions

## Testing
- Verified Elasticsearch connection initialization
- Tested index existence checks
- Tested index deletion and cleanup flows
- Confirmed application compatibility with Elasticsearch v8 APIs