### PR TITLE
Add F() expressions for column-to-column comparisons in Q lookups

### DIFF
--- a/changes/945.added.md
+++ b/changes/945.added.md
@@ -1,0 +1,1 @@
+Added `F()` expressions for column-to-column comparisons inside `Q` lookups (e.g. `filter(retry_count__lt=F("max_retries"))`). Resolved natively by the in-memory and SQLAlchemy adapters; the Elasticsearch adapter raises `NotImplementedError` for `F()`-bearing predicates. The outbox poll and claim now push the `retry_count < max_retries` check into the database.

--- a/docs/api/queryset.md
+++ b/docs/api/queryset.md
@@ -23,3 +23,19 @@ domain entity: it has no behavior, runs no invariants, and cannot be persisted.
     options:
       show_root_heading: false
       inherited_members: false
+
+---
+
+## F
+
+A reference to another column of the same row, for use as the right-hand side
+of a lookup inside `filter()`/`Q` (e.g. `filter(retry_count__lt=F("max_retries"))`).
+Resolved natively by the in-memory and SQLAlchemy adapters; the Elasticsearch
+adapter raises `NotImplementedError` for `F`-bearing predicates. See the
+[Retrieve Aggregates guide](../guides/change-state/retrieve-aggregates.md#comparing-two-fields-with-f)
+for usage.
+
+::: protean.utils.query.F
+    options:
+      show_root_heading: false
+      inherited_members: false

--- a/docs/concepts/internals/query-system.md
+++ b/docs/concepts/internals/query-system.md
@@ -271,6 +271,17 @@ respectively. `isnull` is one of the required lookups every adapter must
 register, since core framework machinery such as the outbox poll path
 depends on it.
 
+By default a lookup's `target` is a literal value. An `F("other_field")`
+target instead names another column of the same row, turning the predicate
+into a column-to-column comparison (`retry_count < max_retries`). Each adapter
+handles it in `process_target`: SQLAlchemy resolves `F` to the column object so
+the comparison renders as native SQL; the memory adapter resolves it per record
+to the referenced attribute; the Elasticsearch adapter raises
+`NotImplementedError`, since the equivalent needs a Painless script query.
+Because `F` resolution lives in `process_target`, it composes with every
+comparison lookup without per-lookup changes. The outbox poll and claim paths
+use `F` to push `retry_count < max_retries` into the database.
+
 **Key source files:**
 
 - `src/protean/port/dao.py` -- `BaseLookup` base class.

--- a/docs/guides/change-state/retrieve-aggregates.md
+++ b/docs/guides/change-state/retrieve-aggregates.md
@@ -253,6 +253,30 @@ repository.query.filter(archived_at__isnull=True).all().items
 repository.query.filter(archived_at__isnull=False).all().items
 ```
 
+### Comparing two fields with `F`
+
+By default the right-hand side of a lookup is a literal value. To compare one
+field against **another field of the same aggregate**, wrap the other field's
+name in `F`:
+
+```python
+from protean import F
+
+# Messages that still have retries left (retry_count < max_retries)
+repository.query.filter(retry_count__lt=F("max_retries")).all().items
+```
+
+`F` works with any comparison lookup (`exact`, `gt`, `gte`, `lt`, `lte`). The
+comparison is evaluated at the database, so no rows are fetched only to be
+discarded in Python. Only a bare field reference is supported: arithmetic
+(`F("a") + 1`) and functions are not.
+
+!!!note
+    The in-memory and SQLAlchemy adapters resolve `F` to the referenced column.
+    The Elasticsearch adapter raises `NotImplementedError` for `F`-bearing
+    predicates, since column-to-column comparison there would need a script
+    query.
+
 !!!note
     These lookups have database-specific implementations. Refer to your chosen
     adapter's documentation for supported filtering criteria.

--- a/src/protean/__init__.py
+++ b/src/protean/__init__.py
@@ -14,6 +14,7 @@ from .utils import get_version
 from .utils.globals import current_domain, current_uow, g
 from .utils.mixins import handle, read
 from .utils.processing import Priority, current_priority, processing_priority
+from .utils.query import F
 
 __all__ = [
     "apply",
@@ -23,6 +24,7 @@ __all__ = [
     "current_uow",
     "Domain",
     "Engine",
+    "F",
     "g",
     "get_version",
     "handle",

--- a/src/protean/adapters/repository/elasticsearch.py
+++ b/src/protean/adapters/repository/elasticsearch.py
@@ -35,7 +35,7 @@ from protean.port.provider import BaseProvider, DatabaseCapabilities
 from protean.utils import IdentityStrategy, IdentityType, fully_qualified_name
 from protean.utils.container import Options
 from protean.utils.globals import current_domain, current_uow
-from protean.utils.query import Q
+from protean.utils.query import F, Q
 from protean.utils.reflection import attributes, id_field
 from protean.fields.association import _ReferenceField
 from protean.fields.basic import ValueObjectList
@@ -1053,7 +1053,21 @@ class DefaultLookup(BaseLookup):
     """Base class with default implementation of expression construction"""
 
     def process_target(self):
-        """Return target with transformations, if any"""
+        """Return target with transformations, if any.
+
+        Column-to-column comparisons via :class:`~protean.utils.query.F` would
+        require a Painless ``script`` query on Elasticsearch. That path is not
+        implemented, so an ``F`` target fails loudly rather than diverging
+        silently from the other adapters.
+        """
+        if isinstance(self.target, F):
+            raise NotImplementedError(
+                f"Column-to-column comparison via F({self.target.name!r}) is not "
+                "supported on the Elasticsearch adapter. This lookup needs a "
+                "Painless script query, which is not implemented. Use a backend "
+                "that supports column-to-column comparison (the in-memory or "
+                "SQLAlchemy adapter), or express the predicate without F()."
+            )
         if isinstance(self.target, UUID):
             self.target = str(self.target)
 

--- a/src/protean/adapters/repository/memory.py
+++ b/src/protean/adapters/repository/memory.py
@@ -18,7 +18,7 @@ from protean.port.provider import BaseProvider, DatabaseCapabilities
 from protean.utils import fully_qualified_name
 from protean.utils.container import Options
 from protean.utils.globals import current_uow
-from protean.utils.query import Q
+from protean.utils.query import F, Q
 from protean.utils.reflection import fields, id_field
 
 
@@ -230,19 +230,31 @@ class MemoryProvider(BaseProvider):
         return DictDAO(self.domain, self, entity_cls, database_model_cls)
 
     def _evaluate_lookup(self, key, value, negated, db):
-        """Extract values from DB that match the given criteria"""
+        """Extract values from DB that match the given criteria.
+
+        When ``value`` is an :class:`~protean.utils.query.F`, the right-hand
+        side is resolved per record to the referenced column, enabling
+        column-to-column comparisons (e.g. ``retry_count < max_retries``).
+        """
         results = {}
         stripped_key, lookup_class = self._extract_lookup(key)
         null_safe = getattr(lookup_class, "null_safe", False)
+        target_is_column = isinstance(value, F)
+        target_name = value.name if target_is_column else None
         for record_key, record_value in db.items():
             source_value = record_value[stripped_key]
-            lookup = lookup_class(source_value, value)
+            target_value = record_value[target_name] if target_is_column else value
 
-            if source_value is not None or null_safe:
-                result = lookup.evaluate()
-                match = not result if negated else result
-            else:
+            # A comparison against NULL on either side is UNKNOWN in SQL and
+            # never matches, even when negated. ``isnull`` is the null_safe
+            # exception that intentionally tests for NULL.
+            if (source_value is None and not null_safe) or (
+                target_is_column and target_value is None
+            ):
                 match = False
+            else:
+                result = lookup_class(source_value, target_value).evaluate()
+                match = not result if negated else result
 
             if match:
                 results[record_key] = record_value

--- a/src/protean/adapters/repository/sqlalchemy.py
+++ b/src/protean/adapters/repository/sqlalchemy.py
@@ -59,7 +59,7 @@ from protean.utils import IdentityType, fully_qualified_name
 from protean.utils.container import Options
 from protean.utils.globals import current_domain, current_uow
 from protean.utils.logging import get_logging_config_value
-from protean.utils.query import Q
+from protean.utils.query import F, Q
 from protean.utils.reflection import attributes, fields, id_field
 
 logging.getLogger("sqlalchemy").setLevel(logging.ERROR)
@@ -1772,7 +1772,14 @@ class DefaultLookup(BaseLookup):
         return source_col
 
     def process_target(self):
-        """Return target with transformations, if any"""
+        """Return target with transformations, if any.
+
+        An :class:`~protean.utils.query.F` target is resolved to the referenced
+        column on the same table, so the comparison renders as a SQL
+        column-to-column predicate rather than a bind parameter.
+        """
+        if isinstance(self.target, F):
+            return getattr(self.database_model_cls, self.target.name)
         return self.target
 
     def as_expression(self):

--- a/src/protean/utils/outbox.py
+++ b/src/protean/utils/outbox.py
@@ -1,4 +1,3 @@
-import logging
 import traceback
 from datetime import datetime, timezone, timedelta
 from enum import Enum
@@ -12,10 +11,7 @@ from protean.core.repository import BaseRepository
 from protean.fields import Auto
 from protean.utils import ensure_utc_aware
 from protean.utils.eventing import Metadata
-from protean.utils.query import Q
-
-
-logger = logging.getLogger(__name__)
+from protean.utils.query import F, Q
 
 PAGE_SIZE = 50  # Default page size for fetching messages
 DEFAULT_LOCK_DURATION_MINUTES = 5  # How long a claim holds a processing lock
@@ -369,6 +365,11 @@ class OutboxRepository(BaseRepository):
           passes. An actively-locked ``PROCESSING`` row (lock in the future) is
           excluded, so an in-flight message is never stolen.
 
+        The row must also still have retries left (``retry_count <
+        max_retries``). This is a column-to-column comparison, pushed into the
+        query via an ``F`` expression so every predicate is evaluated at the
+        database.
+
         When ``target_broker`` is given, only rows destined for that broker
         match. Shared by :meth:`find_unprocessed` and :meth:`claim_batch` so the
         two cannot drift.
@@ -382,6 +383,7 @@ class OutboxRepository(BaseRepository):
         )
         criteria &= Q(locked_until__isnull=True) | Q(locked_until__lt=now)
         criteria &= Q(next_retry_at__isnull=True) | Q(next_retry_at__lte=now)
+        criteria &= Q(retry_count__lt=F("max_retries"))
         if target_broker is not None:
             criteria &= Q(target_broker=target_broker)
         return criteria
@@ -401,11 +403,9 @@ class OutboxRepository(BaseRepository):
 
         and not expired based on retry count. See :meth:`_eligibility_criteria`.
 
-        Status, lock-window, and retry-window predicates are evaluated at the
-        database. The retry-count check (``retry_count < max_retries``) is a
-        column-to-column comparison and remains in Python until F() expressions
-        land; in practice this filter eliminates near-zero rows on a healthy
-        workload.
+        Every predicate — status, lock window, retry window, and the
+        ``retry_count < max_retries`` column-to-column check — is evaluated at
+        the database, so the poll is a single SELECT with no Python post-filter.
 
         Args:
             limit: Maximum number of messages to return
@@ -431,11 +431,7 @@ class OutboxRepository(BaseRepository):
         # Order by priority (higher first)
         query = query.order_by("-priority")
 
-        candidates = self._apply_limit_and_execute(query, limit)
-
-        # Final guard: retry_count < max_retries (column-to-column).
-        # Pushed to SQL once F() expressions land.
-        return [msg for msg in candidates if msg.retry_count < msg.max_retries]
+        return self._apply_limit_and_execute(query, limit)
 
     def claim_batch(
         self,
@@ -456,7 +452,9 @@ class OutboxRepository(BaseRepository):
         Eligibility is defined by :meth:`_eligibility_criteria`: a lock-free
         ``PENDING`` row, a retry-due ``FAILED`` row, or a ``PROCESSING`` row
         whose lock has expired (a crashed claim, reclaimed for self-healing),
-        optionally filtered to ``target_broker``.
+        with retries remaining (``retry_count < max_retries``), optionally
+        filtered to ``target_broker``. Every predicate is enforced in the claim
+        query itself, so a retry-exhausted row is never claimed.
 
         Args:
             worker_id: Identifier of the worker claiming the messages.
@@ -473,7 +471,7 @@ class OutboxRepository(BaseRepository):
 
         now = datetime.now(timezone.utc)
 
-        claimed = self._dao._claim(
+        return self._dao._claim(
             criteria=self._eligibility_criteria(now, target_broker),
             claim_fields={
                 "status": OutboxStatus.PROCESSING.value,
@@ -484,23 +482,6 @@ class OutboxRepository(BaseRepository):
             limit=limit,
             order_by="-priority",
         )
-
-        # Defense-in-depth guard: retry_count < max_retries (column-to-column,
-        # stays in Python until F() expressions land). By the FAILED/ABANDONED
-        # invariant a claimable row always satisfies this, so it excludes no
-        # claimed row in practice.
-        ready = [msg for msg in claimed if msg.retry_count < msg.max_retries]
-
-        # An excluded row has already been marked PROCESSING by the claim, so it
-        # would sit locked until ``locked_until`` expires. This only happens if
-        # the FAILED/ABANDONED invariant is violated upstream — surface it.
-        if len(ready) != len(claimed):
-            logger.warning(
-                "outbox.claimed_rows_excluded_by_retry_guard",
-                extra={"claimed": len(claimed), "returned": len(ready)},
-            )
-
-        return ready
 
     def find_failed(self, limit: Optional[int] = PAGE_SIZE) -> List[Outbox]:
         """Find messages that have failed processing.

--- a/src/protean/utils/query.py
+++ b/src/protean/utils/query.py
@@ -85,6 +85,44 @@ class RegisterLookupMixin:
         del cls.class_lookups[lookup_name]
 
 
+class F:
+    """Reference to another column of the same row, for use inside ``Q`` lookups.
+
+    ``F`` lets a filter compare two columns of the same row instead of comparing
+    a column against a literal value::
+
+        # column against a literal
+        query.filter(retry_count__lt=3)
+
+        # column against another column
+        query.filter(retry_count__lt=F("max_retries"))
+
+    Only a bare column reference is supported. Arithmetic (``F("a") + 1``),
+    function calls (``Lower(F("email"))``), and aggregations are intentionally
+    out of scope.
+
+    Adapter support: the in-memory and SQLAlchemy adapters resolve ``F`` to the
+    referenced column natively. The Elasticsearch adapter raises
+    ``NotImplementedError`` for ``F``-bearing predicates (column-to-column
+    comparison there needs a Painless script query, which is not implemented);
+    use the in-memory or SQLAlchemy backend for such filters.
+    """
+
+    __slots__ = ("name",)
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def __repr__(self) -> str:
+        return f"F({self.name!r})"
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, F) and self.name == other.name
+
+    def __hash__(self) -> int:
+        return hash(("F", self.name))
+
+
 class Node:
     """
     A class for storing a tree graph. Primarily used for filter constructs.

--- a/tests/adapters/repository/elasticsearch_repo/test_f_expression.py
+++ b/tests/adapters/repository/elasticsearch_repo/test_f_expression.py
@@ -1,0 +1,37 @@
+"""Elasticsearch loud-fail coverage for ``F`` column references.
+
+Column-to-column comparison on Elasticsearch would need a Painless script
+query, which is not implemented. The adapter must fail loudly with an
+actionable message rather than diverge silently from the other adapters.
+"""
+
+import pytest
+
+from protean import F
+from protean.adapters.repository import elasticsearch as repo
+
+
+@pytest.mark.elasticsearch
+class TestElasticsearchFExpression:
+    def test_comparison_lookup_with_f_raises(self, test_domain):
+        lookup = repo.LessThan("retry_count", F("max_retries"))
+
+        with pytest.raises(NotImplementedError) as exc:
+            lookup.as_expression()
+
+        message = str(exc.value)
+        assert "F('max_retries')" in message
+        assert "Elasticsearch" in message
+        assert "script" in message
+
+    def test_exact_lookup_with_f_raises(self, test_domain):
+        lookup = repo.Exact("retry_count", F("max_retries"))
+
+        with pytest.raises(NotImplementedError):
+            lookup.as_expression()
+
+    def test_literal_target_is_unaffected(self, test_domain):
+        # A non-F target still renders the standard range query.
+        lookup = repo.LessThan("age", 6)
+
+        assert lookup.as_expression().to_dict() == {"range": {"age": {"lt": 6}}}

--- a/tests/adapters/repository/sqlalchemy_repo/sqlite/test_f_expression.py
+++ b/tests/adapters/repository/sqlalchemy_repo/sqlite/test_f_expression.py
@@ -1,0 +1,67 @@
+"""SQLite coverage for ``F`` column references.
+
+The SQLAlchemy adapter resolves an ``F`` target to the referenced column, so a
+filter renders as a SQL column-to-column predicate rather than a bind
+parameter. These tests assert both the emitted SQL shape and the resulting
+rows.
+"""
+
+import pytest
+
+from protean import F
+from protean.core.aggregate import BaseAggregate
+from protean.fields import Integer, String
+from protean.utils.query import Q
+
+
+class FJob(BaseAggregate):
+    name = String(max_length=50)
+    retry_count = Integer(default=0)
+    max_retries = Integer(default=3)
+
+
+@pytest.fixture
+def f_domain(test_domain):
+    test_domain.register(FJob)
+    test_domain.init(traverse=False)
+    test_domain.repository_for(FJob)._dao  # registers the table in metadata
+    provider = test_domain.providers["default"]
+    provider._metadata.create_all(provider._engine)
+    yield test_domain
+
+
+def _seed(domain):
+    repo = domain.repository_for(FJob)
+    repo.add(FJob(name="under", retry_count=1, max_retries=3))  # 1 < 3
+    repo.add(FJob(name="equal", retry_count=3, max_retries=3))  # 3 < 3 false
+    repo.add(FJob(name="over", retry_count=5, max_retries=2))  # 5 < 2 false
+
+
+@pytest.mark.sqlite
+class TestSqliteFExpression:
+    def test_emitted_sql_references_the_column_not_a_bind_param(self, f_domain):
+        dao = f_domain.repository_for(FJob)._dao
+        expression = dao._build_filters(Q(retry_count__lt=F("max_retries")))
+        sql = str(expression.compile(dialect=dao.provider._engine.dialect))
+
+        # Both columns appear; the right-hand side is the column, not a bound
+        # literal placeholder.
+        assert "retry_count" in sql
+        assert "max_retries" in sql
+        assert ":max_retries" not in sql
+
+    def test_filter_compares_two_columns(self, f_domain):
+        _seed(f_domain)
+        dao = f_domain.repository_for(FJob)._dao
+
+        result = dao.query.filter(retry_count__lt=F("max_retries")).all()
+
+        assert sorted(job.name for job in result.items) == ["under"]
+
+    def test_gte_filter_compares_two_columns(self, f_domain):
+        _seed(f_domain)
+        dao = f_domain.repository_for(FJob)._dao
+
+        result = dao.query.filter(retry_count__gte=F("max_retries")).all()
+
+        assert sorted(job.name for job in result.items) == ["equal", "over"]

--- a/tests/outbox/test_outbox_repository.py
+++ b/tests/outbox/test_outbox_repository.py
@@ -314,9 +314,10 @@ class TestFindUnprocessedBoundaryConditions:
         assert outbox_repo.find_unprocessed() == []
 
     def test_retries_exhausted_row_is_filtered_out(self, outbox_repo, sample_metadata):
-        """``retry_count >= max_retries`` rows are still excluded.
+        """``retry_count >= max_retries`` rows are excluded.
 
-        This is the one predicate left in Python pending F() expressions.
+        The predicate is pushed to the database via an ``F`` expression in
+        ``_eligibility_criteria``; no Python post-filter is involved.
         """
         msg = Outbox.create_message(
             message_id="retries-exhausted",
@@ -935,14 +936,12 @@ class TestClaimBatch:
         assert len(claimed) == 1
         assert claimed[0].target_broker == "external"
 
-    def test_retry_exhausted_row_is_excluded_and_warns(
-        self, outbox_repo, sample_metadata, caplog
-    ):
-        """A claimable row that fails the retry-count guard is dropped from the
-        batch and logged (defense-in-depth; normally unreachable since such a
-        row would already be ABANDONED)."""
-        import logging
+    def test_retry_exhausted_row_is_not_claimed(self, outbox_repo, sample_metadata):
+        """A retry-exhausted row is never claimed.
 
+        ``retry_count < max_retries`` is part of ``_eligibility_criteria``, so
+        the claim query itself excludes the row — it is never marked
+        PROCESSING."""
         msg = Outbox.create_message(
             message_id="exhausted",
             stream_name="s",
@@ -950,19 +949,15 @@ class TestClaimBatch:
             data={},
             metadata=sample_metadata,
         )
-        # FAILED + retry_count >= max_retries: matches the eligibility criteria
-        # (which cannot express the column-to-column retry check) but fails the
-        # Python guard in claim_batch.
         msg.status = OutboxStatus.FAILED.value
         msg.retry_count = 5
         msg.max_retries = 3
         outbox_repo.add(msg)
 
-        with caplog.at_level(logging.WARNING):
-            claimed = outbox_repo.claim_batch("worker-A", limit=50)
+        claimed = outbox_repo.claim_batch("worker-A", limit=50)
 
         assert claimed == []
-        assert any(
-            "claimed_rows_excluded_by_retry_guard" in r.getMessage()
-            for r in caplog.records
-        )
+        # The row stays FAILED — the claim never touched it.
+        reloaded = outbox_repo.get(msg.id)
+        assert reloaded.status == OutboxStatus.FAILED.value
+        assert reloaded.locked_by is None

--- a/tests/query/test_f_expression.py
+++ b/tests/query/test_f_expression.py
@@ -48,10 +48,10 @@ class TestFClass:
         assert hash(F("max_retries")) == hash(F("max_retries"))
         assert {F("a"), F("a"), F("b")} == {F("a"), F("b")}
 
-    def test_is_immutable(self):
+    def test_slots_reject_unknown_attributes(self):
         f = F("max_retries")
         with pytest.raises(AttributeError):
-            f.other = "x"  # __slots__ forbids new attributes
+            f.other = "x"  # __slots__ forbids attributes other than `name`
 
 
 class TestFInMemoryFilter:

--- a/tests/query/test_f_expression.py
+++ b/tests/query/test_f_expression.py
@@ -1,0 +1,87 @@
+"""Unit tests for ``F`` column references inside ``Q`` lookups.
+
+The behavioural filtering tests run against the in-memory adapter (no marker);
+SQLAlchemy and Elasticsearch behaviour live beside those adapters' suites.
+"""
+
+import pytest
+
+from protean import F
+from protean.core.aggregate import BaseAggregate
+from protean.fields import Integer, String
+from protean.utils.query import F as QueryF
+
+
+class Job(BaseAggregate):
+    name: String(max_length=50)
+    retry_count: Integer(default=0)
+    max_retries: Integer(default=3)
+    ceiling: Integer()  # optional / nullable, for null-target coverage
+
+
+@pytest.fixture(autouse=True)
+def register_elements(test_domain):
+    test_domain.register(Job)
+    test_domain.init(traverse=False)
+
+
+@pytest.fixture
+def repo(test_domain):
+    return test_domain.repository_for(Job)
+
+
+class TestFClass:
+    """The ``F`` value type itself."""
+
+    def test_exported_from_package_root(self):
+        assert F is QueryF
+
+    def test_repr_round_trips_the_name(self):
+        assert repr(F("max_retries")) == "F('max_retries')"
+
+    def test_equality_is_by_name(self):
+        assert F("max_retries") == F("max_retries")
+        assert F("max_retries") != F("retry_count")
+        assert F("max_retries") != "max_retries"
+
+    def test_hashable_and_consistent_with_equality(self):
+        assert hash(F("max_retries")) == hash(F("max_retries"))
+        assert {F("a"), F("a"), F("b")} == {F("a"), F("b")}
+
+    def test_is_immutable(self):
+        f = F("max_retries")
+        with pytest.raises(AttributeError):
+            f.other = "x"  # __slots__ forbids new attributes
+
+
+class TestFInMemoryFilter:
+    """Column-to-column comparisons evaluated by the in-memory adapter."""
+
+    @pytest.fixture(autouse=True)
+    def seed(self, repo):
+        repo.add(Job(name="under", retry_count=1, max_retries=3))  # 1 < 3
+        repo.add(Job(name="equal", retry_count=3, max_retries=3))  # 3 < 3 false
+        repo.add(Job(name="over", retry_count=5, max_retries=2))  # 5 < 2 false
+        return repo
+
+    def _names(self, result):
+        return sorted(job.name for job in result.items)
+
+    def test_lt_compares_two_columns(self, repo):
+        result = repo._dao.query.filter(retry_count__lt=F("max_retries")).all()
+        assert self._names(result) == ["under"]
+
+    def test_gte_compares_two_columns(self, repo):
+        result = repo._dao.query.filter(retry_count__gte=F("max_retries")).all()
+        assert self._names(result) == ["equal", "over"]
+
+    def test_exact_compares_two_columns(self, repo):
+        result = repo._dao.query.filter(retry_count=F("max_retries")).all()
+        assert self._names(result) == ["equal"]
+
+    def test_null_target_never_matches(self, repo):
+        # A row whose F-referenced column is NULL is UNKNOWN in SQL and must
+        # not match the comparison (``ceiling`` is left null here).
+        repo.add(Job(name="null_ceiling", retry_count=0))
+        result = repo._dao.query.filter(retry_count__lt=F("ceiling")).all()
+        assert self._names(result) == []


### PR DESCRIPTION
## Summary

Adds `F()` expressions to the query API so a lookup's right-hand side can name
another column of the same row instead of a literal value:

```python
from protean import F

repository.query.filter(retry_count__lt=F("max_retries")).all().items
```

- New `F` value type in `protean.utils.query`, re-exported as `protean.F`.
- Resolved per-adapter in `process_target` / `_evaluate_lookup`, so it composes
  with every comparison lookup (`exact`, `gt`, `gte`, `lt`, `lte`) without
  per-lookup changes:
  - **Memory**: resolves `F` to the referenced attribute per record (NULL on
    either side is UNKNOWN and never matches, mirroring SQL).
  - **SQLAlchemy**: resolves `F` to the column object, rendering a native
    column-to-column SQL predicate (not a bind parameter).
  - **Elasticsearch**: raises `NotImplementedError` with an actionable message.
    Column-to-column comparison there needs a Painless script query, which is
    deliberately deferred (no current consumer).
- **Outbox follow-through**: the `retry_count < max_retries` check is pushed
  into the shared `_eligibility_criteria` via `F`, so both `find_unprocessed`
  and `claim_batch` enforce it in the query. The Python post-filters (and the
  now-unreachable claim-time retry-guard warning) are removed. A retry-exhausted
  row is never claimed; it surfaces via `find_failed()` / `count_by_status()`.

Scope is bare column references only; arithmetic and function-of-columns are out
of scope (per the issue).

## Test plan

- [x] Core tests pass (9443 passed)
- [x] Adapter suite passes across memory / sqlite / postgresql / elasticsearch
  (1165 passed in the repository/dao/query/outbox blast radius)
- [x] 100% patch coverage
- [x] ruff + format + mypy clean (no new errors)

New tests: `tests/query/test_f_expression.py` (F value type + memory filtering),
`tests/adapters/repository/sqlalchemy_repo/sqlite/test_f_expression.py` (SQL
shape + behavior), `tests/adapters/repository/elasticsearch_repo/test_f_expression.py`
(loud-fail). Two outbox tests updated to reflect the database-side predicate.

Docs land in the same PR: guide (retrieve-aggregates), explanation
(query-system internals), reference (api/queryset), changelog fragment.

Closes #945