### PR TITLE
Add any/overlap array lookups to Elasticsearch and memory adapters

### DIFF
--- a/changes/951.added.md
+++ b/changes/951.added.md
@@ -1,0 +1,1 @@
+Brought the `any` and `overlap` array lookups to the Elasticsearch adapter (rendered as `terms` queries) and added `overlap` to the in-memory adapter, so array-membership filters behave consistently across backends. Documented the per-adapter lookup support matrix.

--- a/docs/concepts/internals/query-system.md
+++ b/docs/concepts/internals/query-system.md
@@ -308,7 +308,8 @@ conformance suites under `tests/adapters/repository/generic/` and
 array field shares an element with the given values: SQLAlchemy maps them to native array operators
 (`= ANY(...)` and `&&`, so they need a backend with array columns such as
 PostgreSQL); Elasticsearch renders both as a `terms` query (its fields are
-natively multivalued); the in-memory store evaluates a set intersection.
+natively multivalued); the in-memory store compares elements by equality (not
+hashing, so unhashable items such as dicts are supported).
 `F()` column references work on the memory and SQLAlchemy adapters but not on
 Elasticsearch. Full-text (`search`), geospatial, and vector-similarity lookups
 are backend-specific and are not part of the portable contract.

--- a/docs/concepts/internals/query-system.md
+++ b/docs/concepts/internals/query-system.md
@@ -282,6 +282,37 @@ Because `F` resolution lives in `process_target`, it composes with every
 comparison lookup without per-lookup changes. The outbox poll and claim paths
 use `F` to push `retry_count < max_retries` into the database.
 
+### Lookup support across adapters
+
+Every adapter registers the same core set of lookups (`REQUIRED_LOOKUPS` on
+`BaseProvider`). A provider missing one warns at load, and using it raises
+`NotImplementedError`. Beyond that core set support varies, but the contract is
+the same everywhere: an unsupported lookup fails loudly rather than silently
+returning wrong results.
+
+| Lookup            | Memory | SQLAlchemy        | Elasticsearch |
+|-------------------|:------:|:-----------------:|:-------------:|
+| `exact` / `iexact`| ✅     | ✅                | ✅            |
+| `contains` / `icontains` | ✅ | ✅            | ✅            |
+| `startswith` / `endswith`| ✅ | ✅            | ✅            |
+| `gt` / `gte` / `lt` / `lte` | ✅ | ✅         | ✅            |
+| `in`              | ✅     | ✅                | ✅            |
+| `isnull`          | ✅     | ✅                | ✅            |
+| `any` (array)     | ✅     | ✅ (native array) | ✅            |
+| `overlap` (array) | ✅     | ✅ (native array) | ✅            |
+| `F()` column ref  | ✅     | ✅                | ❌            |
+
+The twelve lookups above `any` are universal and exercised by the cross-adapter
+conformance suites under `tests/adapters/repository/generic/` and
+`tests/repository/`. The array lookups `any` and `overlap` match documents whose
+array field shares an element with the given values: SQLAlchemy maps them to native array operators
+(`= ANY(...)` and `&&`, so they need a backend with array columns such as
+PostgreSQL); Elasticsearch renders both as a `terms` query (its fields are
+natively multivalued); the in-memory store evaluates a set intersection.
+`F()` column references work on the memory and SQLAlchemy adapters but not on
+Elasticsearch. Full-text (`search`), geospatial, and vector-similarity lookups
+are backend-specific and are not part of the portable contract.
+
 **Key source files:**
 
 - `src/protean/port/dao.py` -- `BaseLookup` base class.

--- a/docs/guides/change-state/retrieve-aggregates.md
+++ b/docs/guides/change-state/retrieve-aggregates.md
@@ -230,7 +230,8 @@ is assumed.
 - **`lte`** -- less than or equal to
 - **`in`** -- value is in a given list
 - **`isnull`** -- field is null (`True`) or not null (`False`)
-- **`any`** -- any of given values matches items in a list field
+- **`any`** -- a list field contains any of the given values
+- **`overlap`** -- a list field shares any element with the given list
 
 ```shell
 In [1]: repository.query.filter(name__contains="Doe").all().total
@@ -278,8 +279,11 @@ discarded in Python. Only a bare field reference is supported: arithmetic
     query.
 
 !!!note
-    These lookups have database-specific implementations. Refer to your chosen
-    adapter's documentation for supported filtering criteria.
+    These lookups have database-specific implementations, and a few (the array
+    lookups `any` / `overlap`, and `F()`) are not supported on every adapter. See
+    the [lookup support matrix](../../concepts/internals/query-system.md#lookup-support-across-adapters)
+    for which adapter supports what; an unsupported lookup raises
+    `NotImplementedError` rather than returning wrong results.
 
 ---
 

--- a/src/protean/adapters/repository/elasticsearch.py
+++ b/src/protean/adapters/repository/elasticsearch.py
@@ -1162,7 +1162,10 @@ class Any(In):
 
     def process_target(self):
         if not isinstance(self.target, (list, tuple)):
-            self.target = [self.target]
+            # Apply the base lookup's per-value handling to the scalar (reject
+            # ``F``, stringify ``UUID``) before wrapping it for the terms query.
+            self.target = [DefaultLookup.process_target(self)]
+            return self.target
         return super().process_target()
 
 

--- a/src/protean/adapters/repository/elasticsearch.py
+++ b/src/protean/adapters/repository/elasticsearch.py
@@ -1149,6 +1149,36 @@ class In(DefaultLookup):
 
 
 @ESProvider.register_lookup
+class Any(In):
+    """Array membership lookup.
+
+    Matches documents where the (multivalued) field contains any of the given
+    values. Elasticsearch fields are natively multivalued, so this is the same
+    ``terms`` query as :class:`In`; the only difference is that ``any`` also
+    accepts a scalar target, normalised here to a single-element list.
+    """
+
+    lookup_name = "any"
+
+    def process_target(self):
+        if not isinstance(self.target, (list, tuple)):
+            self.target = [self.target]
+        return super().process_target()
+
+
+@ESProvider.register_lookup
+class Overlap(Any):
+    """Array overlap lookup.
+
+    Matches documents whose field shares at least one element with the given
+    list. On Elasticsearch this is identical to :class:`Any` (a ``terms``
+    query) because fields are natively multivalued.
+    """
+
+    lookup_name = "overlap"
+
+
+@ESProvider.register_lookup
 class GreaterThan(DefaultLookup):
     lookup_name = "gt"
 

--- a/src/protean/adapters/repository/memory.py
+++ b/src/protean/adapters/repository/memory.py
@@ -819,9 +819,11 @@ class Overlap(Any):
     """Array overlap query.
 
     Matches when the source list shares at least one element with the target
-    list. For the in-memory store this is the same set-intersection test as
-    :class:`Any`; the distinct name keeps parity with the SQLAlchemy adapter,
-    where ``overlap`` maps to the native array ``&&`` operator.
+    list. For the in-memory store this is the same equality-based membership
+    test as :class:`Any` (which compares elements by equality, not hashing, so
+    unhashable items such as dicts are supported); the distinct name keeps
+    parity with the SQLAlchemy adapter, where ``overlap`` maps to the native
+    array ``&&`` operator.
     """
 
     lookup_name = "overlap"

--- a/src/protean/adapters/repository/memory.py
+++ b/src/protean/adapters/repository/memory.py
@@ -807,7 +807,24 @@ class Any(MemoryLookup):
         target = (
             self.target if isinstance(self.target, (list, tuple)) else [self.target]
         )
-        return any(self._coerce(x) in [self._coerce(t) for t in target] for x in source)
+        # A list (not a set) is intentional: list elements such as dicts (from
+        # ``List(content_type=dict)`` or serialized value objects) are not
+        # hashable, so membership must use equality, not hashing.
+        coerced_target = [self._coerce(t) for t in target]
+        return any(self._coerce(x) in coerced_target for x in source)
+
+
+@MemoryProvider.register_lookup
+class Overlap(Any):
+    """Array overlap query.
+
+    Matches when the source list shares at least one element with the target
+    list. For the in-memory store this is the same set-intersection test as
+    :class:`Any`; the distinct name keeps parity with the SQLAlchemy adapter,
+    where ``overlap`` maps to the native array ``&&`` operator.
+    """
+
+    lookup_name = "overlap"
 
 
 @MemoryProvider.register_lookup

--- a/tests/adapters/repository/elasticsearch_repo/test_array_lookups.py
+++ b/tests/adapters/repository/elasticsearch_repo/test_array_lookups.py
@@ -1,0 +1,76 @@
+"""Elasticsearch coverage for the ``any`` and ``overlap`` array lookups.
+
+Elasticsearch fields are natively multivalued, so both lookups render as a
+``terms`` query and match documents whose array field shares any element with
+the given values.
+"""
+
+import pytest
+
+from protean.adapters.repository import elasticsearch as repo
+from protean.core.aggregate import BaseAggregate
+from protean.fields import List, String
+
+
+class Tagged(BaseAggregate):
+    name = String(max_length=50)
+    tags = List(content_type=String)
+
+
+@pytest.mark.elasticsearch
+class TestArrayLookupExpressions:
+    """Unit-level: the lookups build the expected ``terms`` query."""
+
+    def test_any_builds_terms_query(self, test_domain):
+        lookup = repo.Any("tags", ["red", "blue"])
+        assert lookup.as_expression().to_dict() == {"terms": {"tags": ["red", "blue"]}}
+
+    def test_overlap_builds_terms_query(self, test_domain):
+        lookup = repo.Overlap("tags", ["red"])
+        assert lookup.as_expression().to_dict() == {"terms": {"tags": ["red"]}}
+
+    def test_any_normalises_scalar_target_to_list(self, test_domain):
+        lookup = repo.Any("tags", "red")
+        assert lookup.as_expression().to_dict() == {"terms": {"tags": ["red"]}}
+
+
+@pytest.mark.elasticsearch
+class TestArrayLookupQueries:
+    """End-to-end against a live Elasticsearch index."""
+
+    @pytest.fixture
+    def repo_with_data(self, test_domain):
+        test_domain.register(Tagged)
+        test_domain.init(traverse=False)
+        provider = test_domain.providers["default"]
+        provider._create_database_artifacts()
+
+        repository = test_domain.repository_for(Tagged)
+        repository.add(Tagged(name="a", tags=["red", "blue"]))
+        repository.add(Tagged(name="b", tags=["green"]))
+        repository.add(Tagged(name="c", tags=["blue", "green"]))
+
+        yield repository
+
+        # Drop only this aggregate's index, leaving the shared ones in place.
+        model_cls = repository._dao.database_model_cls
+        model_cls._index.delete(using=provider.get_connection(), ignore=[404])
+
+    def _names(self, items):
+        return sorted(item.name for item in items)
+
+    def test_any_matches_documents_sharing_a_value(self, repo_with_data):
+        items = repo_with_data.query.filter(tags__any=["blue"]).all().items
+        assert self._names(items) == ["a", "c"]
+
+    def test_any_with_multiple_values(self, repo_with_data):
+        items = repo_with_data.query.filter(tags__any=["red", "green"]).all().items
+        assert self._names(items) == ["a", "b", "c"]
+
+    def test_any_no_match(self, repo_with_data):
+        items = repo_with_data.query.filter(tags__any=["purple"]).all().items
+        assert items == []
+
+    def test_overlap_matches_shared_elements(self, repo_with_data):
+        items = repo_with_data.query.filter(tags__overlap=["green", "red"]).all().items
+        assert self._names(items) == ["a", "b", "c"]

--- a/tests/adapters/repository/elasticsearch_repo/test_array_lookups.py
+++ b/tests/adapters/repository/elasticsearch_repo/test_array_lookups.py
@@ -33,6 +33,20 @@ class TestArrayLookupExpressions:
         lookup = repo.Any("tags", "red")
         assert lookup.as_expression().to_dict() == {"terms": {"tags": ["red"]}}
 
+    def test_any_scalar_uuid_target_is_stringified(self, test_domain):
+        from uuid import UUID
+
+        uid = UUID("12345678-1234-5678-1234-567812345678")
+        lookup = repo.Any("tags", uid)
+        assert lookup.as_expression().to_dict() == {"terms": {"tags": [str(uid)]}}
+
+    def test_any_scalar_f_target_raises(self, test_domain):
+        from protean import F
+
+        lookup = repo.Any("tags", F("other"))
+        with pytest.raises(NotImplementedError):
+            lookup.as_expression()
+
 
 @pytest.mark.elasticsearch
 class TestArrayLookupQueries:

--- a/tests/adapters/repository/memory/test_memory_any_operator.py
+++ b/tests/adapters/repository/memory/test_memory_any_operator.py
@@ -6,6 +6,10 @@ class User(BaseAggregate):
     emails: List()
 
 
+class Record(BaseAggregate):
+    items: List(content_type=dict)
+
+
 def test_for_any_lookup(test_domain):
     test_domain.register(User)
 
@@ -38,3 +42,50 @@ def test_for_any_lookup(test_domain):
     # Single value in target list
     users = user_repo.query.filter(emails__any=["qux@example.com"]).all().items
     assert len(users) == 1
+
+
+def test_for_overlap_lookup(test_domain):
+    test_domain.register(User)
+
+    user_repo = test_domain.repository_for(User)
+
+    user_repo.add(User(emails=["foo@example.com", "bar@example.com"]))
+    user_repo.add(User(emails=["baz@example.com", "bar@example.com"]))
+    user_repo.add(User(emails=["qux@example.com"]))
+
+    # Shares "bar" with the first two rows
+    users = user_repo.query.filter(emails__overlap=["bar@example.com"]).all().items
+    assert len(users) == 2
+
+    # Shares an element with every row
+    users = (
+        user_repo.query.filter(
+            emails__overlap=["foo@example.com", "baz@example.com", "qux@example.com"]
+        )
+        .all()
+        .items
+    )
+    assert len(users) == 3
+
+    # No shared element
+    users = user_repo.query.filter(emails__overlap=["nope@example.com"]).all().items
+    assert len(users) == 0
+
+
+def test_array_lookups_handle_unhashable_elements(test_domain):
+    # List elements can be dicts (unhashable); membership must compare by
+    # equality, not hashing, so these lookups must not raise TypeError.
+    test_domain.register(Record)
+
+    record_repo = test_domain.repository_for(Record)
+    record_repo.add(Record(items=[{"k": 1}, {"k": 2}]))
+    record_repo.add(Record(items=[{"k": 3}]))
+
+    matched = record_repo.query.filter(items__overlap=[{"k": 1}]).all().items
+    assert len(matched) == 1
+
+    matched = record_repo.query.filter(items__any=[{"k": 3}]).all().items
+    assert len(matched) == 1
+
+    matched = record_repo.query.filter(items__any=[{"k": 9}]).all().items
+    assert len(matched) == 0


### PR DESCRIPTION
## Summary

Brings the `any` and `overlap` array-membership lookups to parity across adapters (issue #951).

- **Elasticsearch**: adds `any` and `overlap`. ES fields are natively multivalued, so both render as a `terms` query. `Any` subclasses `In` (inheriting the `.keyword` handling); `Overlap` subclasses `Any`. A scalar `any` target is normalised to a single-element list.
- **In-memory**: adds `overlap` (subclasses `Any`). Also hoists the coerced target out of the per-record generator. Membership stays list-based (not a set) so unhashable elements (e.g. `List(content_type=dict)`, serialized value objects) compare by equality rather than raising.
- **SQLAlchemy** already supported both via native array operators (`= ANY(...)` / `&&`); verified on PostgreSQL.

Adds a per-adapter **lookup support matrix** to `docs/concepts/internals/query-system.md`, linked from the retrieve-aggregates guide. An unsupported lookup raises `NotImplementedError` rather than returning wrong results.

## Lookup matrix

| Lookup | Memory | SQLAlchemy | Elasticsearch |
|---|:--:|:--:|:--:|
| 12 core lookups (`exact`…`isnull`) | ✅ | ✅ | ✅ |
| `any` / `overlap` (array) | ✅ | ✅ (native array) | ✅ |
| `F()` column ref | ✅ | ✅ | ❌ |

## Test plan

- [x] Core tests pass (9445)
- [x] Array lookups: ES live end-to-end + in-memory (incl. unhashable-element guard)
- [x] Generic filtering conformance green on memory / sqlite / postgresql / elasticsearch
- [x] 100% patch coverage

## Notes

- Cross-adapter `isnull` conformance already exists in `tests/repository/test_count_and_isnull.py`, so no duplicate was added here.

Closes #951