### PR TITLE
Add query-shape test primitives to protean.integrations.pytest

### DIFF
--- a/changes/953.added.md
+++ b/changes/953.added.md
@@ -1,0 +1,1 @@
+Added query-shape test primitives `assert_query_count`, `assert_no_subquery_wrap`, and `assert_no_overfetch` to `protean.integrations.pytest`. These context managers observe the SQL a block issues and fail on query-cost regressions (extra round trips, subquery-wrapped counts, over-fetching). They are no-ops on the in-memory adapter and assert against a real SQLAlchemy backend.

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -203,6 +203,7 @@ specific area.
 - [Application Tests](./guides/testing/application-tests.md) -- Validate commands, handlers, and services.
 - [Event Sourcing Tests](./guides/testing/event-sourcing-tests.md) -- Fluent test DSL for event-sourced aggregates using `protean.testing.given`.
 - [Integration Tests](./guides/testing/integration-tests.md) -- Verify behavior with real infrastructure.
+- [Test Query Shape](./guides/testing/query-shape-tests.md) -- Assert query count and shape to catch query-cost regressions.
 - [Fixtures and Patterns](./guides/testing/fixtures-and-patterns.md) -- Reusable pytest fixtures and conftest recipes.
 - [Pytest Plugin Reference](./reference/testing/pytest-plugin.md) -- `--protean-env`, `--update-snapshots`, and the registered markers.
 

--- a/docs/guides/testing/index.md
+++ b/docs/guides/testing/index.md
@@ -104,5 +104,7 @@ may diverge.
   for event-sourced aggregates using `protean.testing.given`.
 - **[Integration Tests](./integration-tests.md)** — end-to-end flows
   with real infrastructure adapters.
+- **[Test Query Shape](./query-shape-tests.md)** — assert query count and shape
+  (round trips, subquery wraps, over-fetch) to catch query-cost regressions.
 - **[Fixtures and Patterns](./fixtures-and-patterns.md)** — reusable pytest
   fixtures, `DomainFixture`, and `conftest.py` recipes for Protean projects.

--- a/docs/guides/testing/query-shape-tests.md
+++ b/docs/guides/testing/query-shape-tests.md
@@ -87,10 +87,9 @@ multiple of what it returns.
 
 ## Engine resolution
 
-By default the engine is resolved from the active domain: the default
-provider's engine is preferred, falling back to the first SQLAlchemy provider
-found. For tests that manage their own domain or target a non-default provider,
-pass the engine explicitly:
+By default the engine is resolved from the active domain's **default**
+provider. For tests that manage their own domain or target a non-default
+provider, pass the engine explicitly:
 
 ```python
 with assert_query_count(1, engine=my_engine):

--- a/docs/guides/testing/query-shape-tests.md
+++ b/docs/guides/testing/query-shape-tests.md
@@ -1,0 +1,108 @@
+# Test Query Shape
+
+<span class="pathway-tag pathway-tag-ddd">DDD</span> <span class="pathway-tag pathway-tag-cqrs">CQRS</span> <span class="pathway-tag pathway-tag-es">ES</span>
+
+Functional tests confirm a query returns the right rows, but they say nothing
+about how expensive it was. A query can return correct results while issuing an
+extra round trip per row, wrapping a count in a subquery, or fetching three
+times more rows than it needs. On small test datasets these pathologies are
+invisible; in production they are the difference between a healthy queue and a
+stalled one.
+
+Protean ships three pytest context managers that assert query *shape* and
+*round-trip count*, so a cost regression fails at PR time instead of in
+production:
+
+```python
+from protean.integrations.pytest import (
+    assert_query_count,
+    assert_no_subquery_wrap,
+    assert_no_overfetch,
+)
+```
+
+## When to use these
+
+Reach for query-shape assertions on hot read paths where cost matters: poll
+loops, claim-and-process paths, dashboards, and any repository method that runs
+under load. They complement functional tests rather than replace them: assert
+*what* a query returns with ordinary assertions, and *how* it runs with these.
+
+They are SQLAlchemy-specific. When the active provider is the in-memory adapter
+there is no engine to observe, so the context managers are no-ops and assert
+nothing. Mark tests that use them with `@pytest.mark.database` (or a specific
+backend marker) so they run against a real SQL backend where the assertion is
+meaningful.
+
+## `assert_query_count`
+
+Asserts an exact number of queries (data round trips) are issued in the block.
+Catches N+1 patterns and accidental extra round trips:
+
+```python
+import pytest
+from protean.integrations.pytest import assert_query_count
+
+
+@pytest.mark.database
+def test_poll_issues_a_single_query(outbox_repo):
+    with assert_query_count(1):
+        outbox_repo.find_unprocessed(limit=10)
+```
+
+A "query" is a `SELECT`, `INSERT`, `UPDATE`, `DELETE`, or `WITH` statement.
+Connection setup (such as a `PRAGMA` or `SET`) and transaction control
+(`BEGIN`/`COMMIT`) are not counted, so adapters that issue per-connection
+pragmas do not inflate the number. The context manager yields the captured
+statements, so a failing assertion prints exactly what ran.
+
+## `assert_no_subquery_wrap`
+
+Fails if any query wraps a count around a subquery, the
+`SELECT count(*) FROM (SELECT ... ) AS anon_1` shape that a naive
+`.limit(1).all().total` emits instead of a flat `SELECT count(*)`:
+
+```python
+@pytest.mark.database
+def test_count_uses_a_flat_count(outbox_repo):
+    with assert_no_subquery_wrap():
+        outbox_repo.count_by_status()
+```
+
+## `assert_no_overfetch`
+
+Fails if any `LIMIT` exceeds the rows the caller actually needs. Pass the
+expected row count; the assertion allows headroom via `ratio` (default `1.5`):
+
+```python
+@pytest.mark.database
+def test_poll_does_not_overfetch(outbox_repo, seeded_outbox):
+    with assert_no_overfetch(expected_returned=10):
+        outbox_repo.find_unprocessed(limit=10)
+```
+
+A `LIMIT 10` passes (`10 <= 10 * 1.5`); a `min(limit * 3, 1000)` over-fetch that
+emits `LIMIT 30` fails. Widen `ratio` when a path legitimately reads a small
+multiple of what it returns.
+
+## Engine resolution
+
+By default the engine is resolved from the active domain: the default
+provider's engine is preferred, falling back to the first SQLAlchemy provider
+found. For tests that manage their own domain or target a non-default provider,
+pass the engine explicitly:
+
+```python
+with assert_query_count(1, engine=my_engine):
+    ...
+```
+
+## Avoiding false positives
+
+- **Scope the block tightly.** Only wrap the call under test. Seeding, fixture
+  setup, and assertions that themselves query should sit outside the block.
+- **Count what the operation issues, not the framework.** A `.all()` with the
+  default `with_total=True` issues a second `COUNT` query; use
+  `with_total=False` when you mean to assert a single round trip.
+- **These are deterministic, not statistical.** They catch shape regressions,
+  not latency. For timing-based regression detection, use a benchmark instead.

--- a/docs/how-do-i.md
+++ b/docs/how-do-i.md
@@ -259,6 +259,7 @@ need by what you're trying to accomplish.
 | Test application workflows (BDD-style)          | [Application Tests](./guides/testing/application-tests.md) |
 | Test event-sourced aggregates with a fluent DSL | [Event Sourcing Tests](./guides/testing/event-sourcing-tests.md) |
 | Test with real databases and brokers             | [Integration Tests](./guides/testing/integration-tests.md) |
+| Catch query-cost regressions (count, over-fetch) | [Test Query Shape](./guides/testing/query-shape-tests.md) |
 | Set up test fixtures and patterns               | [Fixtures and Patterns](./guides/testing/fixtures-and-patterns.md) |
 | Set up databases for integration tests          | [Database Setup/Teardown](./patterns/setting-up-and-tearing-down-database-for-tests.md) |
 | Test a full event-driven flow end-to-end        | [Test Event-Driven Flows](./patterns/testing-event-driven-flows.md) |

--- a/docs/reference/testing/pytest-plugin.md
+++ b/docs/reference/testing/pytest-plugin.md
@@ -52,6 +52,28 @@ User application tests should construct their domain lifecycle with
 `DomainFixture` instead — see
 [Fixtures and Patterns](../../guides/testing/fixtures-and-patterns.md).
 
+## Query-shape assertions
+
+Three context managers assert query count and shape against a SQLAlchemy
+backend, to catch query-cost regressions in tests. They are no-ops when no
+SQLAlchemy engine is resolved (e.g. the in-memory adapter). See
+[Test Query Shape](../../guides/testing/query-shape-tests.md) for usage.
+
+::: protean.integrations.pytest.assert_query_count
+    options:
+      show_root_heading: true
+      show_source: false
+
+::: protean.integrations.pytest.assert_no_subquery_wrap
+    options:
+      show_root_heading: true
+      show_source: false
+
+::: protean.integrations.pytest.assert_no_overfetch
+    options:
+      show_root_heading: true
+      show_source: false
+
 ## Framework development
 
 The `protean test` CLI command is used to run Protean's own test suite

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -288,6 +288,7 @@ nav:
       - guides/testing/application-tests.md
       - guides/testing/event-sourcing-tests.md
       - guides/testing/integration-tests.md
+      - guides/testing/query-shape-tests.md
       - guides/testing/fixtures-and-patterns.md
 
   - Reference:

--- a/src/protean/integrations/pytest/__init__.py
+++ b/src/protean/integrations/pytest/__init__.py
@@ -12,10 +12,22 @@ adapter package, load the conformance plugin in your ``conftest.py``::
 For event-sourcing test DSL, use :mod:`protean.testing`::
 
     from protean.testing import given
+
+For asserting query shape and round-trip count, use the query assertions::
+
+    from protean.integrations.pytest import assert_query_count
 """
 
+from .query_assertions import (
+    assert_no_overfetch,
+    assert_no_subquery_wrap,
+    assert_query_count,
+)
 from .testbed import DomainFixture
 
 __all__ = [
     "DomainFixture",
+    "assert_no_overfetch",
+    "assert_no_subquery_wrap",
+    "assert_query_count",
 ]

--- a/src/protean/integrations/pytest/query_assertions.py
+++ b/src/protean/integrations/pytest/query_assertions.py
@@ -1,0 +1,203 @@
+"""Pytest helpers that assert query shape and round-trip count.
+
+These context managers hook SQLAlchemy's ``before_cursor_execute`` event to
+observe the SQL a block issues, letting tests catch query-cost regressions
+(extra round trips, subquery-wrapped counts, over-fetching) deterministically,
+without timing-based benchmarks::
+
+    from protean.integrations.pytest import assert_query_count
+
+    def test_poll_issues_one_query(outbox_repo):
+        with assert_query_count(1):
+            outbox_repo.find_unprocessed(limit=10)
+
+They are SQLAlchemy-specific. When the active provider is not SQLAlchemy-backed
+(e.g. the in-memory adapter) there is no engine to observe, so the context
+managers are **no-ops** and assert nothing. Mark tests that rely on them with
+``@pytest.mark.database`` (or a specific backend marker) so they run against a
+real SQL backend where the assertion is meaningful.
+
+The engine is resolved from the active domain (``current_domain``) by default;
+pass ``engine=`` explicitly for tests that manage their own domain or run
+against a non-default provider.
+"""
+
+import re
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Iterator, List, Optional
+
+from protean.utils.globals import current_domain
+
+if TYPE_CHECKING:
+    from sqlalchemy.engine import Engine
+
+# ``sqlalchemy`` is an optional dependency. This module is re-exported from the
+# auto-registered pytest plugin package, so it must import cleanly without it;
+# the engine event API is imported lazily, only on the real-engine path.
+
+# ``SELECT count(*) FROM (SELECT ... ) AS anon_1`` — a count wrapped around a
+# full subquery, the pathology the outbox audit found behind ``.limit(1).all().total``.
+SUBQUERY_WRAP_PATTERN = re.compile(
+    r"SELECT\s+count\(\*\).*\bFROM\s*\(\s*SELECT\b",
+    re.IGNORECASE | re.DOTALL,
+)
+
+LIMIT_PATTERN = re.compile(r"\bLIMIT\s+(\d+)", re.IGNORECASE)
+
+# Statements that count as a "query" (a data round trip). Connection setup such
+# as ``PRAGMA``/``SET`` and transaction control (``BEGIN``/``COMMIT``) are
+# excluded, so adapters that issue per-connection pragmas don't inflate counts.
+_QUERY_VERBS = ("SELECT", "INSERT", "UPDATE", "DELETE", "WITH")
+
+
+def _is_query(statement: str) -> bool:
+    return statement.lstrip().upper().startswith(_QUERY_VERBS)
+
+
+def _resolve_engine(engine: "Optional[Engine]") -> "Optional[Engine]":
+    """Resolve the SQLAlchemy engine to observe.
+
+    Returns the explicit ``engine`` if given; otherwise the active domain's
+    default provider engine. Returns ``None`` when no SQLAlchemy engine is
+    available (e.g. the in-memory adapter or no domain bound), which makes the
+    assertions no-ops. For a non-default provider, pass ``engine=`` explicitly.
+    """
+    if engine is not None:
+        return engine
+
+    try:
+        providers = current_domain.providers
+    except (RuntimeError, AttributeError):
+        # No domain bound to the current context: the ``current_domain`` proxy
+        # resolves to ``None`` (``AttributeError`` on ``.providers``) or raises
+        # ``RuntimeError`` depending on the proxy implementation.
+        return None
+
+    default = providers.get("default")
+    return getattr(default, "_engine", None) if default is not None else None
+
+
+@contextmanager
+def _record_statements(engine: "Optional[Engine]") -> Iterator[List[str]]:
+    """Collect SQL statements emitted on ``engine`` within the block.
+
+    A ``None`` engine yields an empty list and records nothing, so the callers
+    degrade to no-ops on non-SQLAlchemy backends.
+    """
+    statements: List[str] = []
+
+    if engine is None:
+        yield statements
+        return
+
+    # Imported here, not at module top, so the no-op path needs no SQLAlchemy.
+    from sqlalchemy import event
+
+    def _before_cursor_execute(conn, cursor, statement, parameters, context, many):
+        statements.append(statement)
+
+    event.listen(engine, "before_cursor_execute", _before_cursor_execute)
+    try:
+        yield statements
+    finally:
+        event.remove(engine, "before_cursor_execute", _before_cursor_execute)
+
+
+@contextmanager
+def assert_query_count(
+    expected: int, engine: "Optional[Engine]" = None
+) -> Iterator[List[str]]:
+    """Assert exactly ``expected`` queries are issued in the block.
+
+    A "query" is a data round trip (``SELECT``/``INSERT``/``UPDATE``/``DELETE``/
+    ``WITH``); connection setup (``PRAGMA``/``SET``) and transaction control are
+    not counted, so adapters that issue per-connection pragmas don't inflate the
+    count. Catches extra round trips: a ``count_by_status`` per-status loop, a
+    1+N find-and-claim, etc. Yields the captured statements unfiltered (a test
+    can inspect pragmas and transaction control too); the failure message lists
+    only the counted queries. No-op when no SQLAlchemy engine is resolved.
+    """
+    resolved = _resolve_engine(engine)
+    with _record_statements(resolved) as statements:
+        yield statements
+
+    if resolved is None:
+        return
+
+    queries = [s for s in statements if _is_query(s)]
+    actual = len(queries)
+    if actual != expected:
+        raise AssertionError(
+            f"Expected {expected} quer{'y' if expected == 1 else 'ies'}, "
+            f"got {actual}:\n" + _format_statements(queries)
+        )
+
+
+@contextmanager
+def assert_no_subquery_wrap(
+    engine: "Optional[Engine]" = None,
+) -> Iterator[List[str]]:
+    """Fail if any query wraps a ``count`` around a subquery.
+
+    Catches the ``SELECT count(*) FROM (SELECT ... ) AS anon_1`` shape that a
+    naive ``.limit(1).all().total`` emits instead of a flat ``SELECT count(*)``.
+    No-op when no SQLAlchemy engine is resolved.
+    """
+    resolved = _resolve_engine(engine)
+    with _record_statements(resolved) as statements:
+        yield statements
+
+    if resolved is None:
+        return
+
+    offenders = [s for s in statements if SUBQUERY_WRAP_PATTERN.search(s)]
+    if offenders:
+        raise AssertionError(
+            f"{len(offenders)} subquery-wrapped count(s) detected:\n"
+            + _format_statements(offenders)
+        )
+
+
+@contextmanager
+def assert_no_overfetch(
+    expected_returned: int,
+    ratio: float = 1.5,
+    engine: "Optional[Engine]" = None,
+) -> Iterator[List[str]]:
+    """Fail if any ``LIMIT`` exceeds ``expected_returned * ratio``.
+
+    Catches over-fetch patterns such as ``min(limit * 3, 1000)`` that pull far
+    more rows than the caller needs. ``ratio`` is the tolerated headroom over
+    the expected row count. No-op when no SQLAlchemy engine is resolved.
+    """
+    resolved = _resolve_engine(engine)
+    with _record_statements(resolved) as statements:
+        yield statements
+
+    if resolved is None:
+        return
+
+    threshold = expected_returned * ratio
+    offenders = []
+    for statement in statements:
+        # Check every LIMIT in the statement, not just the first: an outer
+        # over-fetch can sit behind a smaller inner-subquery limit.
+        for limit in (int(n) for n in LIMIT_PATTERN.findall(statement)):
+            if limit > threshold:
+                offenders.append((statement, limit))
+
+    if offenders:
+        raise AssertionError(
+            f"Over-fetch detected (expected <= {int(threshold)} rows):\n"
+            + "\n".join(f"  - LIMIT {limit}: {_trim(s)}" for s, limit in offenders)
+        )
+
+
+def _format_statements(statements: List[str]) -> str:
+    return "\n".join(f"  {i + 1}. {_trim(s)}" for i, s in enumerate(statements))
+
+
+def _trim(statement: str, length: int = 200) -> str:
+    """Collapse whitespace and truncate a statement for readable assertions."""
+    collapsed = " ".join(statement.split())
+    return collapsed if len(collapsed) <= length else collapsed[:length] + " ..."

--- a/src/protean/integrations/pytest/query_assertions.py
+++ b/src/protean/integrations/pytest/query_assertions.py
@@ -24,7 +24,7 @@ against a non-default provider.
 
 import re
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Iterator, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Iterator, List, Optional, Tuple
 
 from protean.utils.globals import current_domain
 
@@ -42,7 +42,13 @@ SUBQUERY_WRAP_PATTERN = re.compile(
     re.IGNORECASE | re.DOTALL,
 )
 
-LIMIT_PATTERN = re.compile(r"\bLIMIT\s+(\d+)", re.IGNORECASE)
+# The token following ``LIMIT``: a literal integer, a named bind parameter
+# (``%(name)s`` / ``:name``), or a positional placeholder (``?`` / ``%s``).
+# SQLAlchemy renders LIMIT as a bound parameter on most dialects, so matching
+# literals alone would miss real over-fetch.
+LIMIT_PATTERN = re.compile(r"\bLIMIT\s+(\d+|%\(\w+\)s|:\w+|\?|%s)", re.IGNORECASE)
+_NAMED_PARAM_PATTERN = re.compile(r"%\((\w+)\)s|:(\w+)")
+_PLACEHOLDER_PATTERN = re.compile(r"\?|%s")
 
 # Statements that count as a "query" (a data round trip). Connection setup such
 # as ``PRAGMA``/``SET`` and transaction control (``BEGIN``/``COMMIT``) are
@@ -52,6 +58,34 @@ _QUERY_VERBS = ("SELECT", "INSERT", "UPDATE", "DELETE", "WITH")
 
 def _is_query(statement: str) -> bool:
     return statement.lstrip().upper().startswith(_QUERY_VERBS)
+
+
+def _limit_values(statement: str, parameters: Any) -> Iterator[int]:
+    """Yield the integer LIMIT value(s) in a statement.
+
+    Resolves bound parameters: named (``%(name)s`` / ``:name``) against a dict,
+    positional (``?`` / ``%s``) by index against a sequence. A LIMIT whose value
+    cannot be resolved to an ``int`` is skipped rather than guessed.
+    """
+    for match in LIMIT_PATTERN.finditer(statement):
+        token = match.group(1)
+        if token.isdigit():
+            yield int(token)
+            continue
+
+        named = _NAMED_PARAM_PATTERN.fullmatch(token)
+        if named is not None and isinstance(parameters, dict):
+            value = parameters.get(named.group(1) or named.group(2))
+            if isinstance(value, int):
+                yield value
+            continue
+
+        if isinstance(parameters, (list, tuple)):
+            # Positional: the value sits at the index equal to the number of
+            # placeholders that precede this LIMIT token.
+            index = len(_PLACEHOLDER_PATTERN.findall(statement[: match.start()]))
+            if index < len(parameters) and isinstance(parameters[index], int):
+                yield parameters[index]
 
 
 def _resolve_engine(engine: "Optional[Engine]") -> "Optional[Engine]":
@@ -78,27 +112,27 @@ def _resolve_engine(engine: "Optional[Engine]") -> "Optional[Engine]":
 
 
 @contextmanager
-def _record_statements(engine: "Optional[Engine]") -> Iterator[List[str]]:
-    """Collect SQL statements emitted on ``engine`` within the block.
+def _listen(
+    engine: "Optional[Engine]", callback: Callable[[str, Any], None]
+) -> Iterator[None]:
+    """Invoke ``callback(statement, parameters)`` for each query in the block.
 
-    A ``None`` engine yields an empty list and records nothing, so the callers
-    degrade to no-ops on non-SQLAlchemy backends.
+    A ``None`` engine is a no-op (nothing to observe), so callers degrade
+    cleanly on non-SQLAlchemy backends.
     """
-    statements: List[str] = []
-
     if engine is None:
-        yield statements
+        yield
         return
 
     # Imported here, not at module top, so the no-op path needs no SQLAlchemy.
     from sqlalchemy import event
 
     def _before_cursor_execute(conn, cursor, statement, parameters, context, many):
-        statements.append(statement)
+        callback(statement, parameters)
 
     event.listen(engine, "before_cursor_execute", _before_cursor_execute)
     try:
-        yield statements
+        yield
     finally:
         event.remove(engine, "before_cursor_execute", _before_cursor_execute)
 
@@ -118,7 +152,8 @@ def assert_query_count(
     only the counted queries. No-op when no SQLAlchemy engine is resolved.
     """
     resolved = _resolve_engine(engine)
-    with _record_statements(resolved) as statements:
+    statements: List[str] = []
+    with _listen(resolved, lambda statement, _params: statements.append(statement)):
         yield statements
 
     if resolved is None:
@@ -144,7 +179,8 @@ def assert_no_subquery_wrap(
     No-op when no SQLAlchemy engine is resolved.
     """
     resolved = _resolve_engine(engine)
-    with _record_statements(resolved) as statements:
+    statements: List[str] = []
+    with _listen(resolved, lambda statement, _params: statements.append(statement)):
         yield statements
 
     if resolved is None:
@@ -163,32 +199,36 @@ def assert_no_overfetch(
     expected_returned: int,
     ratio: float = 1.5,
     engine: "Optional[Engine]" = None,
-) -> Iterator[List[str]]:
+) -> Iterator[List[Tuple[str, Any]]]:
     """Fail if any ``LIMIT`` exceeds ``expected_returned * ratio``.
 
     Catches over-fetch patterns such as ``min(limit * 3, 1000)`` that pull far
     more rows than the caller needs. ``ratio`` is the tolerated headroom over
-    the expected row count. No-op when no SQLAlchemy engine is resolved.
+    the expected row count. Resolves LIMIT values whether rendered as literals
+    or bound parameters. No-op when no SQLAlchemy engine is resolved.
     """
     resolved = _resolve_engine(engine)
-    with _record_statements(resolved) as statements:
-        yield statements
+    executions: List[Tuple[str, Any]] = []
+    with _listen(
+        resolved, lambda statement, params: executions.append((statement, params))
+    ):
+        yield executions
 
     if resolved is None:
         return
 
     threshold = expected_returned * ratio
     offenders = []
-    for statement in statements:
+    for statement, parameters in executions:
         # Check every LIMIT in the statement, not just the first: an outer
         # over-fetch can sit behind a smaller inner-subquery limit.
-        for limit in (int(n) for n in LIMIT_PATTERN.findall(statement)):
+        for limit in _limit_values(statement, parameters):
             if limit > threshold:
                 offenders.append((statement, limit))
 
     if offenders:
         raise AssertionError(
-            f"Over-fetch detected (expected <= {int(threshold)} rows):\n"
+            f"Over-fetch detected (expected <= {threshold:g} rows):\n"
             + "\n".join(f"  - LIMIT {limit}: {_trim(s)}" for s, limit in offenders)
         )
 

--- a/tests/integrations/pytest/test_query_assertions.py
+++ b/tests/integrations/pytest/test_query_assertions.py
@@ -7,7 +7,6 @@ covered separately.
 """
 
 import pytest
-from sqlalchemy import create_engine, text
 
 from protean import Domain
 from protean.core.aggregate import BaseAggregate
@@ -17,6 +16,15 @@ from protean.integrations.pytest import (
     assert_no_subquery_wrap,
     assert_query_count,
 )
+from protean.integrations.pytest.query_assertions import _limit_values
+
+# SQLAlchemy is an optional dependency; skip the whole module if it's absent so
+# minimal environments can still collect the suite.
+pytest.importorskip("sqlalchemy")
+
+from sqlalchemy import create_engine, select, table  # noqa: E402
+from sqlalchemy import column as sa_column  # noqa: E402
+from sqlalchemy import text  # noqa: E402
 
 
 @pytest.fixture
@@ -48,6 +56,13 @@ class TestAssertQueryCount:
             with assert_query_count(1, engine=engine) as statements:
                 conn.execute(text("SELECT 42"))
         assert any("SELECT 42" in s for s in statements)
+
+    def test_pragma_and_transaction_statements_are_not_counted(self, engine):
+        # Only data round trips count; PRAGMA/SET and BEGIN/COMMIT do not.
+        with engine.connect() as conn:
+            with assert_query_count(1, engine=engine):
+                conn.execute(text("PRAGMA case_sensitive_like = ON"))
+                conn.execute(text("SELECT 1"))
 
     def test_does_not_swallow_block_exception(self, engine):
         # A failure inside the block propagates; the count is not asserted over it.
@@ -107,6 +122,45 @@ class TestAssertNoOverfetch:
                     conn.execute(
                         text("SELECT id FROM (SELECT id FROM t LIMIT 5) s LIMIT 100")
                     )
+
+    def test_bound_limit_parameter_is_resolved(self, engine):
+        # A SQLAlchemy-built LIMIT renders as a bound parameter (``LIMIT ?`` on
+        # SQLite), not a literal — the over-fetch must still be detected.
+        rows = table("t", sa_column("id"))
+        with engine.connect() as conn:
+            with pytest.raises(AssertionError, match=r"Over-fetch detected"):
+                with assert_no_overfetch(expected_returned=10, engine=engine):
+                    conn.execute(select(rows.c.id).limit(100))
+
+    def test_bound_limit_within_ratio_passes(self, engine):
+        rows = table("t", sa_column("id"))
+        with engine.connect() as conn:
+            with assert_no_overfetch(expected_returned=10, engine=engine):
+                conn.execute(select(rows.c.id).limit(10))
+
+
+class TestLimitValueResolution:
+    """``_limit_values`` resolves LIMIT across paramstyles, deterministically."""
+
+    def test_literal(self):
+        assert list(_limit_values("SELECT id FROM t LIMIT 50", None)) == [50]
+
+    def test_named_pyformat_parameter(self):
+        stmt = "SELECT id FROM t LIMIT %(param_1)s"
+        assert list(_limit_values(stmt, {"param_1": 50})) == [50]
+
+    def test_named_colon_parameter(self):
+        assert list(_limit_values("SELECT id FROM t LIMIT :lim", {"lim": 50})) == [50]
+
+    def test_positional_parameter_uses_placeholder_index(self):
+        # WHERE placeholder precedes LIMIT, so LIMIT resolves to params[1].
+        stmt = "SELECT id FROM t WHERE id > ? LIMIT ? OFFSET ?"
+        assert list(_limit_values(stmt, (0, 50, 0))) == [50]
+
+    def test_unresolvable_parameter_is_skipped(self):
+        # Missing/non-int bound value is skipped rather than guessed.
+        assert list(_limit_values("SELECT id FROM t LIMIT %(p)s", {})) == []
+        assert list(_limit_values("SELECT id FROM t LIMIT ?", ("x",))) == []
 
 
 @pytest.mark.no_test_domain

--- a/tests/integrations/pytest/test_query_assertions.py
+++ b/tests/integrations/pytest/test_query_assertions.py
@@ -1,0 +1,183 @@
+"""Tests for the query-shape assertion primitives.
+
+The core logic runs against an in-process SQLite engine passed explicitly, so
+these are plain core tests (no Docker, no adapter marker). Engine resolution
+from the active domain and the no-op behaviour on non-SQLAlchemy backends are
+covered separately.
+"""
+
+import pytest
+from sqlalchemy import create_engine, text
+
+from protean import Domain
+from protean.core.aggregate import BaseAggregate
+from protean.fields import Integer, String
+from protean.integrations.pytest import (
+    assert_no_overfetch,
+    assert_no_subquery_wrap,
+    assert_query_count,
+)
+
+
+@pytest.fixture
+def engine():
+    eng = create_engine("sqlite://")
+    with eng.begin() as conn:
+        conn.execute(text("CREATE TABLE t (id INTEGER, name VARCHAR)"))
+        conn.execute(text("INSERT INTO t VALUES (1, 'a'), (2, 'b'), (3, 'c')"))
+    yield eng
+    eng.dispose()
+
+
+class TestAssertQueryCount:
+    def test_passes_on_exact_count(self, engine):
+        with engine.connect() as conn:
+            with assert_query_count(2, engine=engine):
+                conn.execute(text("SELECT 1"))
+                conn.execute(text("SELECT 2"))
+
+    def test_fails_on_wrong_count(self, engine):
+        with engine.connect() as conn:
+            with pytest.raises(AssertionError, match=r"Expected 1 query, got 2"):
+                with assert_query_count(1, engine=engine):
+                    conn.execute(text("SELECT 1"))
+                    conn.execute(text("SELECT 2"))
+
+    def test_yields_captured_statements(self, engine):
+        with engine.connect() as conn:
+            with assert_query_count(1, engine=engine) as statements:
+                conn.execute(text("SELECT 42"))
+        assert any("SELECT 42" in s for s in statements)
+
+    def test_does_not_swallow_block_exception(self, engine):
+        # A failure inside the block propagates; the count is not asserted over it.
+        with pytest.raises(ValueError):
+            with assert_query_count(1, engine=engine):
+                raise ValueError("boom")
+
+
+class TestAssertNoSubqueryWrap:
+    def test_passes_on_flat_count(self, engine):
+        with engine.connect() as conn:
+            with assert_no_subquery_wrap(engine=engine):
+                conn.execute(text("SELECT count(*) FROM t"))
+
+    def test_fails_on_subquery_wrapped_count(self, engine):
+        with engine.connect() as conn:
+            with pytest.raises(AssertionError, match=r"subquery-wrapped count"):
+                with assert_no_subquery_wrap(engine=engine):
+                    conn.execute(
+                        text("SELECT count(*) FROM (SELECT id FROM t) AS anon_1")
+                    )
+
+    def test_plain_select_is_not_flagged(self, engine):
+        with engine.connect() as conn:
+            with assert_no_subquery_wrap(engine=engine):
+                conn.execute(text("SELECT id FROM t"))
+
+
+class TestAssertNoOverfetch:
+    def test_passes_when_limit_within_ratio(self, engine):
+        with engine.connect() as conn:
+            with assert_no_overfetch(expected_returned=10, engine=engine):
+                conn.execute(text("SELECT id FROM t LIMIT 10"))
+
+    def test_fails_when_limit_exceeds_ratio(self, engine):
+        with engine.connect() as conn:
+            with pytest.raises(AssertionError, match=r"Over-fetch detected"):
+                with assert_no_overfetch(expected_returned=10, engine=engine):
+                    conn.execute(text("SELECT id FROM t LIMIT 100"))
+
+    def test_ratio_is_configurable(self, engine):
+        with engine.connect() as conn:
+            # LIMIT 25 with expected 10 and ratio 3.0 -> threshold 30, passes.
+            with assert_no_overfetch(expected_returned=10, ratio=3.0, engine=engine):
+                conn.execute(text("SELECT id FROM t LIMIT 25"))
+
+    def test_query_without_limit_is_ignored(self, engine):
+        with engine.connect() as conn:
+            with assert_no_overfetch(expected_returned=1, engine=engine):
+                conn.execute(text("SELECT id FROM t"))
+
+    def test_outer_limit_behind_smaller_inner_limit_is_caught(self, engine):
+        # The inner subquery's LIMIT 5 must not mask the outer LIMIT 100.
+        with engine.connect() as conn:
+            with pytest.raises(AssertionError, match=r"Over-fetch detected"):
+                with assert_no_overfetch(expected_returned=10, engine=engine):
+                    conn.execute(
+                        text("SELECT id FROM (SELECT id FROM t LIMIT 5) s LIMIT 100")
+                    )
+
+
+@pytest.mark.no_test_domain
+class TestNoOpOnMemoryBackend:
+    """With a memory-backed domain (no SQLAlchemy engine), the primitives are
+    no-ops. A dedicated memory domain is built so the result does not depend on
+    the ``--db`` the suite runs under."""
+
+    @pytest.fixture
+    def memory_domain(self):
+        domain = Domain(name="QueryAssertionsMemory")
+        domain.init(traverse=False)  # default provider is the in-memory adapter
+        with domain.domain_context():
+            yield domain
+
+    def test_query_count_is_noop(self, memory_domain):
+        with assert_query_count(999):
+            pass
+
+    def test_subquery_wrap_is_noop(self, memory_domain):
+        with assert_no_subquery_wrap():
+            pass
+
+    def test_overfetch_is_noop(self, memory_domain):
+        with assert_no_overfetch(expected_returned=1):
+            pass
+
+
+@pytest.mark.no_test_domain
+class TestNoOpWithoutDomain:
+    """With no domain bound at all, engine resolution degrades to a no-op
+    rather than raising (the ``current_domain`` proxy resolves to ``None``)."""
+
+    def test_query_count_is_noop_without_domain(self):
+        with assert_query_count(999):
+            pass
+
+    def test_overfetch_is_noop_without_domain(self):
+        with assert_no_overfetch(expected_returned=1):
+            pass
+
+
+class _Counter(BaseAggregate):
+    name = String(max_length=50)
+    value = Integer(default=0)
+
+
+@pytest.mark.no_test_domain
+class TestEngineResolutionFromDomain:
+    """The engine is resolved from ``current_domain`` when not passed explicitly."""
+
+    @pytest.fixture
+    def sqlite_domain(self):
+        domain = Domain(name="QueryAssertions")
+        domain.config["databases"]["default"] = {
+            "provider": "sqlite",
+            "database_uri": "sqlite://",
+        }
+        domain.register(_Counter)
+        domain.init(traverse=False)
+        with domain.domain_context():
+            provider = domain.providers["default"]
+            domain.repository_for(_Counter)._dao  # register the table in metadata
+            provider._metadata.create_all(provider._engine)
+            yield domain
+
+    def test_resolves_default_provider_engine(self, sqlite_domain):
+        repo = sqlite_domain.repository_for(_Counter)
+        repo.add(_Counter(name="a"))
+
+        # No explicit engine: resolved from the active domain's default provider.
+        # ``with_total=False`` keeps it to a single SELECT (no extra count query).
+        with assert_query_count(1):
+            repo._dao.query.filter(name="a").all(with_total=False)

--- a/tests/outbox/test_outbox_perf.py
+++ b/tests/outbox/test_outbox_perf.py
@@ -2,12 +2,13 @@
 
 Gated behind ``@pytest.mark.database`` so it runs only against a real SQL
 provider (e.g. ``protean test --sqlite`` / ``--postgresql``), where emitted
-statements are observable and meaningful. The test attaches a SQLAlchemy
-``before_cursor_execute`` listener to count statements issued on the poll path
-and asserts the performance contract introduced by #942:
+statements are observable and meaningful. The tests use the query-shape
+primitives from :mod:`protean.integrations.pytest` to assert the performance
+contract introduced by #942:
 
-- ``find_unprocessed`` issues a single ``SELECT`` (the 3x over-fetch loop is
-  gone — lock/retry-window predicates are evaluated in the database).
+- ``find_unprocessed`` issues a single ``SELECT`` and does not over-fetch (the
+  3x over-fetch loop is gone — lock/retry-window predicates are evaluated in the
+  database).
 - ``count_by_status`` issues one flat ``SELECT COUNT(*)`` per status with no
   subquery wrapper (no ``FROM (SELECT ... ) AS anon_1``).
 - ``cleanup_old_published`` / ``cleanup_old_abandoned`` issue a single
@@ -18,12 +19,15 @@ benchmarks — they assert statement *counts* and *shapes*, which are
 deterministic, rather than wall-clock duration.
 """
 
-from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 
 import pytest
-from sqlalchemy import event
 
+from protean.integrations.pytest import (
+    assert_no_overfetch,
+    assert_no_subquery_wrap,
+    assert_query_count,
+)
 from protean.utils.eventing import DomainMeta, Metadata, MessageHeaders
 from protean.utils.outbox import Outbox, OutboxRepository, OutboxStatus
 
@@ -53,35 +57,6 @@ def sample_metadata():
             sequence_id="1",
         ),
     )
-
-
-@pytest.fixture
-def sa_engine(test_domain):
-    """The SQLAlchemy engine backing the default provider.
-
-    Skips the test when the active provider is not SQLAlchemy-based (statement
-    counting is only meaningful against a real SQL backend).
-    """
-    provider = test_domain.providers["default"]
-    engine = getattr(provider, "_engine", None)
-    if engine is None:
-        pytest.skip("Outbox perf microbenchmark requires a SQLAlchemy provider")
-    return engine
-
-
-@contextmanager
-def capture_statements(engine):
-    """Collect SQL statements emitted on ``engine`` within the block."""
-    statements: list[str] = []
-
-    def _before_cursor_execute(conn, cursor, statement, parameters, context, many):
-        statements.append(statement)
-
-    event.listen(engine, "before_cursor_execute", _before_cursor_execute)
-    try:
-        yield statements
-    finally:
-        event.remove(engine, "before_cursor_execute", _before_cursor_execute)
 
 
 def _seed(test_domain, sample_metadata):
@@ -144,75 +119,78 @@ def _seed(test_domain, sample_metadata):
 @pytest.mark.database
 @pytest.mark.usefixtures("db")
 class TestOutboxPollPathQueryCounts:
-    """The poll path must not regress to multi-query / over-fetch shapes."""
+    """The poll path must not regress to multi-query / over-fetch shapes.
+
+    Expressed with the query-shape primitives, which resolve the engine from the
+    active domain. The yielded statement list is reused for the finer-grained
+    predicate/shape assertions the primitives don't cover (WHERE-clause contents,
+    no-read-before-delete). No-op on the in-memory backend.
+    """
 
     def _selects(self, statements: list[str]) -> list[str]:
         return [s for s in statements if s.lstrip().upper().startswith("SELECT")]
 
-    def _deletes(self, statements: list[str]) -> list[str]:
-        return [s for s in statements if s.lstrip().upper().startswith("DELETE")]
-
-    def test_find_unprocessed_issues_single_select(
-        self, test_domain, sample_metadata, sa_engine
+    def test_find_unprocessed_issues_a_single_select_without_overfetch(
+        self, test_domain, sample_metadata
     ):
         _seed(test_domain, sample_metadata)
         repo = test_domain.repository_for(Outbox)
 
-        with capture_statements(sa_engine) as statements:
-            ready = repo.find_unprocessed(limit=5)
+        with assert_no_overfetch(expected_returned=5):
+            with assert_query_count(1) as statements:
+                ready = repo.find_unprocessed(limit=5)
 
-        selects = self._selects(statements)
-        assert len(selects) == 1, f"expected a single SELECT, got: {selects}"
-        # Lock + retry-window predicates are in the WHERE clause, not Python.
-        where = selects[0].upper()
-        assert "LOCKED_UNTIL" in where
-        assert "NEXT_RETRY_AT" in where
         assert len(ready) == 5
+        # Statement-shape checks only run against a real SQL backend (the
+        # primitives capture nothing on the in-memory adapter).
+        if statements:
+            # Lock + retry-window predicates are in the WHERE clause, not Python.
+            where = self._selects(statements)[0].upper()
+            assert "LOCKED_UNTIL" in where
+            assert "NEXT_RETRY_AT" in where
 
     def test_count_by_status_issues_flat_counts_without_wrapper(
-        self, test_domain, sample_metadata, sa_engine
+        self, test_domain, sample_metadata
     ):
         _seed(test_domain, sample_metadata)
         repo = test_domain.repository_for(Outbox)
 
-        with capture_statements(sa_engine) as statements:
-            counts = repo.count_by_status()
+        with assert_no_subquery_wrap():
+            with assert_query_count(len(OutboxStatus)) as statements:
+                counts = repo.count_by_status()
 
-        selects = self._selects(statements)
-        # One flat COUNT per status, no subquery-wrapped projection.
-        assert len(selects) == len(OutboxStatus)
-        for stmt in selects:
-            upper = stmt.upper()
-            assert "COUNT(" in upper
-            assert "ANON_1" not in upper, f"unexpected subquery wrapper: {stmt}"
         assert counts[OutboxStatus.PENDING.value] == 5
         assert counts[OutboxStatus.FAILED.value] == 3
         assert counts[OutboxStatus.PUBLISHED.value] == 4
         assert counts[OutboxStatus.ABANDONED.value] == 2
+        # One flat COUNT per status (the query count above pins the round trips).
+        if statements:
+            for stmt in self._selects(statements):
+                assert "COUNT(" in stmt.upper()
 
     def test_cleanup_old_published_issues_single_delete(
-        self, test_domain, sample_metadata, sa_engine
+        self, test_domain, sample_metadata
     ):
         _seed(test_domain, sample_metadata)
         repo = test_domain.repository_for(Outbox)
 
-        with capture_statements(sa_engine) as statements:
+        with assert_query_count(1) as statements:
             deleted = repo.cleanup_old_published(older_than_hours=1)
 
         assert deleted == 4
-        assert len(self._deletes(statements)) == 1
-        # No read pass before the delete.
-        assert self._selects(statements) == []
+        # The single query is the DELETE — no read pass precedes it.
+        if statements:
+            assert self._selects(statements) == []
 
     def test_cleanup_old_abandoned_issues_single_delete(
-        self, test_domain, sample_metadata, sa_engine
+        self, test_domain, sample_metadata
     ):
         _seed(test_domain, sample_metadata)
         repo = test_domain.repository_for(Outbox)
 
-        with capture_statements(sa_engine) as statements:
+        with assert_query_count(1) as statements:
             deleted = repo.cleanup_old_abandoned(older_than_hours=1)
 
         assert deleted == 2
-        assert len(self._deletes(statements)) == 1
-        assert self._selects(statements) == []
+        if statements:
+            assert self._selects(statements) == []


### PR DESCRIPTION
## Summary

Adds three pytest context managers (issue #953) that assert query *shape* and
*round-trip count*, so query-cost regressions fail at PR time instead of in
production. Exported from `protean.integrations.pytest`:

```python
from protean.integrations.pytest import (
    assert_query_count,
    assert_no_subquery_wrap,
    assert_no_overfetch,
)
```

- **`assert_query_count(n)`** — exactly `n` data round trips (`SELECT`/`INSERT`/
  `UPDATE`/`DELETE`/`WITH`); connection setup (`PRAGMA`/`SET`) and transaction
  control are not counted, so per-connection pragmas don't inflate the number.
- **`assert_no_subquery_wrap()`** — fails on the `SELECT count(*) FROM (SELECT … )`
  shape a naive `.limit(1).all().total` emits.
- **`assert_no_overfetch(expected_returned, ratio=1.5)`** — fails when any `LIMIT`
  exceeds the rows the caller needs (checks every `LIMIT` in the statement).

They hook SQLAlchemy's `before_cursor_execute`, resolve the engine from the
active domain (or an explicit `engine=`), and are **no-ops** when no SQLAlchemy
engine is available (e.g. the in-memory adapter). `sqlalchemy` is an optional
dependency, so it is imported lazily — the auto-registered pytest plugin package
imports cleanly without it.

The outbox poll-path perf tests are **migrated onto the primitives**, replacing
their hand-rolled `capture_statements`/`sa_engine` helpers. Functional
assertions run on every backend; statement-shape assertions are gated for a real
SQL backend.

## Test plan

- [x] Primitive tests (positive + negative for each, plus no-op/no-domain and
  multi-LIMIT edge cases): green on memory / sqlite / postgresql
- [x] Outbox perf tests pass on memory / sqlite / postgresql
- [x] Core tests pass (9467)
- [x] 100% patch coverage
- [x] `import protean.integrations.pytest` does not pull in sqlalchemy

## Docs

- Guide: `docs/guides/testing/query-shape-tests.md` (+ nav, contents, how-do-i)
- Reference: query-shape assertions section in the pytest-plugin page

Closes #953