### PR TITLE
Add projection staleness detection (#893)

### DIFF
--- a/changes/893.added.md
+++ b/changes/893.added.md
@@ -1,0 +1,1 @@
+Projection staleness detection: the new `protean projection status` command reports, per projection, how far behind it is in time (staleness) and in events (lag), when it last advanced, and its current row count. A `protean.projection.staleness_seconds` gauge (Prometheus `protean_projection_staleness_seconds`) is exposed for monitoring and Observatory dashboards.

--- a/docs/concepts/async-processing/subscriptions.md
+++ b/docs/concepts/async-processing/subscriptions.md
@@ -200,6 +200,22 @@ StreamSubscription uses Redis Streams' built-in consumer group tracking:
 - Pending messages are tracked automatically
 - Failed messages can be retried or moved to DLQ
 
+## Projection staleness
+
+Because each EventStoreSubscription records its position together with the time
+that position was written, Protean can tell how far behind a projection is. A
+projection's **staleness** is the time since the projector feeding it last
+advanced while events remained unprocessed; its **lag** is the number of events
+still behind the stream head. A projection fed by several projectors is as stale
+as its worst feeder.
+
+The position-write timestamp is what makes time-based staleness possible, so it
+is reported for event-store-backed projectors. Stream-backed (Redis) projectors
+report lag but not time-based staleness. Inspect staleness with
+`protean projection status` or the `protean_projection_staleness_seconds`
+metric; see
+[Monitor the System](../../guides/server/monitoring.md#monitoring-projection-staleness).
+
 ## Error Handling
 
 Subscriptions handle errors at multiple levels:

--- a/docs/guides/consume-state/projections.md
+++ b/docs/guides/consume-state/projections.md
@@ -224,6 +224,7 @@ the cache client.
 
     - [Projectors](./projectors.md) — How to define and configure projectors that maintain projections.
     - [Query Handlers](./query-handlers.md) — How to dispatch structured read intents via `domain.dispatch()`.
+    - [Monitor the System](../../guides/server/monitoring.md#monitoring-projection-staleness) — Check projection staleness, lag, and row counts.
 
     **Patterns:**
 

--- a/docs/guides/server/monitoring.md
+++ b/docs/guides/server/monitoring.md
@@ -46,6 +46,7 @@ Monitor these metrics in production (available at `/metrics`):
 | `protean_subscription_lag` | Per-subscription lag behind stream head |
 | `protean_subscription_pending` | Per-subscription unacknowledged messages |
 | `protean_subscription_dlq_depth` | Per-subscription dead letter queue depth |
+| `protean_projection_staleness_seconds` | Per-projection seconds behind source events |
 
 ## Monitoring subscription lag
 
@@ -80,6 +81,34 @@ groups:
 ```
 
 See [`protean subscriptions`](../../reference/cli/runtime/subscriptions.md)
+for full CLI documentation.
+
+## Monitoring projection staleness
+
+Check whether read models are keeping up with their events, either from the CLI:
+
+```bash
+protean projection status --domain=my_app
+```
+
+or via the `protean_projection_staleness_seconds` metric. Alert when a
+projection stays behind:
+
+```yaml
+# prometheus alert rule
+groups:
+  - name: protean
+    rules:
+      - alert: ProjectionStale
+        expr: protean_projection_staleness_seconds > 60
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Projection {{ $labels.projection }} is stale"
+```
+
+See [`protean projection status`](../../reference/cli/data/projection.md#protean-projection-status)
 for full CLI documentation.
 
 ## Prometheus scrape configuration

--- a/docs/how-do-i.md
+++ b/docs/how-do-i.md
@@ -99,6 +99,7 @@ need by what you're trying to accomplish.
 | Dispatch a named read intent                    | [Query Handlers](./guides/consume-state/query-handlers.md) |
 | Treat projection rebuilds as a deployment operation | [Projection Rebuilds as Deployment](./patterns/projection-rebuilds-as-deployment.md) |
 | Rebuild a projection from historical events     | [`protean projection rebuild`](./reference/cli/data/projection.md) |
+| Check whether a projection is up to date (staleness, lag) | [`protean projection status`](./reference/cli/data/projection.md#protean-projection-status) |
 | Listen to messages from an external broker      | [Subscribers](./guides/consume-state/subscribers.md) |
 | Use fact events for cross-context integration   | [Fact Events as Integration Contracts](./patterns/fact-events-as-integration-contracts.md) |
 | Publish events to external brokers for other bounded contexts | [External Event Dispatch](./guides/server/external-event-dispatch.md) |

--- a/docs/reference/cli/data/projection.md
+++ b/docs/reference/cli/data/projection.md
@@ -1,8 +1,9 @@
 # `protean projection`
 
 The `protean projection` command group manages projections -- read-optimized
-views built from domain events. Currently it provides a `rebuild` command
-that reconstructs projections by replaying events from the event store.
+views built from domain events. It provides a `rebuild` command that
+reconstructs projections by replaying events from the event store, and a
+`status` command that reports how far behind each projection is.
 
 Projection rebuilding is essential when:
 
@@ -29,6 +30,7 @@ All commands accept a `--domain` option to specify the domain module path
 | Command | Description |
 |---------|-------------|
 | `protean projection rebuild` | Rebuild projections by replaying events |
+| `protean projection status` | Report per-projection staleness, lag, and row count |
 
 ## `protean projection rebuild`
 
@@ -96,6 +98,55 @@ not cause the rebuild to fail.
 | No projectors for projection | Aborts with error message |
 | No projections in domain | Prints "No projections found in domain." |
 | Unresolvable event type | Logs warning, skips event, continues |
+
+## `protean projection status`
+
+Reports, for every projection, how far behind it is and how large it is, by
+reading each feeding projector's last processed position. Useful for spotting
+read models that have stalled. Does not require the server to be running.
+
+```bash
+protean projection status --domain=my_domain
+```
+
+For each projection the report shows:
+
+- **Staleness**: seconds since the projection last advanced. `0` when caught
+  up, blank when the projector has never run or its position is unknown.
+- **Lag**: events behind the stream head, taken from the worst (most behind)
+  of its feeding projectors.
+- **Last updated**: when the projection last advanced.
+- **Rows**: number of records currently in the projection store.
+- **Status**: `ok` (caught up), `lagging` (behind), or `unknown`.
+
+A projection fed by several projectors reports the worst staleness and lag
+across all of them.
+
+!!! note
+
+    Time-based staleness comes from each projector's position-write timestamp,
+    so it is reported for event-store-backed projectors. Stream-backed (Redis)
+    projectors show lag and status, but their staleness is blank.
+
+### JSON output
+
+```bash
+protean projection status --domain=my_domain --json
+```
+
+Emits a JSON array of objects (`projection_name`, `projectors`, `last_updated`,
+`staleness_seconds`, `lag`, `row_count`, `status`), suitable for piping into
+other tooling.
+
+**Options**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--domain` | Domain module path | `.` (current directory) |
+| `--json` | Output raw JSON instead of a table | `false` |
+
+For continuous monitoring, scrape the `protean_projection_staleness_seconds`
+metric instead; see [Server Observability](../../server/observability.md).
 
 ## Domain discovery
 

--- a/docs/reference/server/observability.md
+++ b/docs/reference/server/observability.md
@@ -500,6 +500,10 @@ protean_stream_messages_total 2139
 # HELP protean_stream_pending Pending (in-flight) messages
 # TYPE protean_stream_pending gauge
 protean_stream_pending 5
+
+# HELP protean_projection_staleness_seconds Seconds a projection is behind its source events
+# TYPE protean_projection_staleness_seconds gauge
+protean_projection_staleness_seconds{domain="identity",projection="UserDirectory"} 0
 ```
 
 Available metrics:
@@ -519,6 +523,7 @@ Available metrics:
 | `protean_subscription_pending` | gauge | Unacknowledged messages (per subscription) |
 | `protean_subscription_dlq_depth` | gauge | Dead letter queue depth (per subscription) |
 | `protean_subscription_status` | gauge | Subscription health: 1=ok, 0=not ok |
+| `protean_projection_staleness_seconds` | gauge | Seconds a projection is behind its source events (per projection) |
 
 ### Prometheus scrape configuration
 

--- a/src/protean/cli/projection.py
+++ b/src/protean/cli/projection.py
@@ -13,10 +13,12 @@ Usage::
     protean projection rebuild --domain=my_domain
 """
 
+import json as json_mod
 from typing import TYPE_CHECKING
 
 import typer
 from rich import print
+from rich.table import Table
 from typing_extensions import Annotated
 
 from protean.cli._helpers import handle_cli_exceptions
@@ -141,3 +143,98 @@ def _rebuild_all(domain: "Domain", batch_size: int) -> None:
     print(
         f"Rebuilt {len(results)} projection(s), {total_events} total events processed."
     )
+
+
+def _status_style(status: str) -> str:
+    """Return a Rich markup colour for a status string."""
+    if status == "ok":
+        return "[green]ok[/green]"
+    if status == "lagging":
+        return "[red]lagging[/red]"
+    return "[yellow]unknown[/yellow]"
+
+
+@app.command()
+@handle_cli_exceptions("projection status")
+def status(
+    domain: Annotated[str, typer.Option(help="Domain module path")] = ".",
+    output_json: Annotated[
+        bool,
+        typer.Option("--json", help="Output raw JSON instead of a table"),
+    ] = False,
+) -> None:
+    """Show staleness, lag, and row count for every projection.
+
+    For each projection (read model) this reports how far behind it is in time
+    (``staleness``) and in events (``lag``) across all the projectors that feed it,
+    plus its current row count. Does not require the server to be running.
+    """
+    from protean.server.projection_status import collect_projection_statuses
+
+    try:
+        derived_domain = derive_domain(domain)
+    except NoDomainException as exc:
+        msg = f"Error loading Protean domain: {exc.args[0]}"
+        print(msg)
+        logger.error(msg)
+        raise typer.Abort()
+
+    assert derived_domain is not None
+    derived_domain.init()
+
+    with derived_domain.domain_context():
+        statuses = collect_projection_statuses(derived_domain)
+
+    if not statuses:
+        if output_json:
+            print(json_mod.dumps([]))
+        else:
+            print("No projections found in domain.")
+        return
+
+    if output_json:
+        print(json_mod.dumps([s.to_dict() for s in statuses], indent=2, default=str))
+        return
+
+    table = Table(title=f"Projections — {derived_domain.name}")
+    table.add_column("Projection", style="bold")
+    table.add_column("Projectors")
+    table.add_column("Last Updated")
+    table.add_column("Staleness (s)", justify="right", style="cyan")
+    table.add_column("Lag", justify="right")
+    table.add_column("Rows", justify="right")
+    table.add_column("Status")
+
+    for s in statuses:
+        staleness_str = (
+            f"{s.staleness_seconds:.0f}" if s.staleness_seconds is not None else "-"
+        )
+        lag_str = str(s.lag) if s.lag is not None else "-"
+        rows_str = str(s.row_count) if s.row_count is not None else "-"
+
+        table.add_row(
+            s.projection_name,
+            ", ".join(s.projectors) if s.projectors else "-",
+            s.last_updated or "-",
+            staleness_str,
+            lag_str,
+            rows_str,
+            _status_style(s.status),
+        )
+
+    print(table)
+
+    total = len(statuses)
+    ok_count = sum(1 for s in statuses if s.status == "ok")
+    lagging_count = sum(1 for s in statuses if s.status == "lagging")
+    unknown_count = sum(1 for s in statuses if s.status == "unknown")
+
+    summary_parts = [f"{total} projection(s)"]
+    if ok_count:
+        summary_parts.append(f"[green]{ok_count} ok[/green]")
+    if lagging_count:
+        summary_parts.append(f"[red]{lagging_count} lagging[/red]")
+    if unknown_count:
+        summary_parts.append(f"[yellow]{unknown_count} unknown[/yellow]")
+
+    print(f"\n{', '.join(summary_parts)}")

--- a/src/protean/server/observatory/metrics.py
+++ b/src/protean/server/observatory/metrics.py
@@ -26,6 +26,7 @@ Infrastructure gauges (OTEL instrument name / Prometheus text name):
 - protean.subscription.pending_messages — Unacknowledged messages per subscription
 - protean_subscription_dlq_depth — Dead letter queue depth per subscription
 - protean_subscription_status — Subscription health (1=ok, 0=not ok)
+- protean.projection.staleness_seconds — Seconds a projection is behind its source events
 - protean.db.pool_size — Database connection pool size
 - protean.db.pool_checked_out — Checked out database connections
 - protean.db.pool_overflow — Overflow database connections
@@ -127,6 +128,33 @@ def _collect_subscription_statuses(domains: List[Domain]) -> list:
     return _scrape_cache.get("subscription_statuses", _do_collect)
 
 
+def _collect_projection_statuses(domains: List[Domain]) -> list:
+    """Collect projection statuses from all domains.
+
+    Cached per scrape cycle so the gauge callback and any other consumer reuse
+    the same data. Returns ``(domain, ProjectionStatus)`` tuples.
+    """
+
+    def _do_collect() -> list:
+        from protean.server.projection_status import collect_projection_statuses
+
+        results: list = []
+        for domain in domains:
+            try:
+                # Scrape path only reads staleness; skip the row COUNT queries.
+                for s in collect_projection_statuses(domain, include_row_count=False):
+                    results.append((domain, s))
+            except Exception as exc:
+                logger.debug(
+                    "Shared collection: projection status failed for %s: %s",
+                    domain.name,
+                    exc,
+                )
+        return results
+
+    return _scrape_cache.get("projection_statuses", _do_collect)
+
+
 def _collect_pool_stats(domains: List[Domain]) -> list:
     """Collect connection pool statistics from all providers across domains.
 
@@ -143,9 +171,7 @@ def _collect_pool_stats(domains: List[Domain]) -> list:
                         for name, provider in providers._providers.items():
                             stats = provider.pool_stats()
                             if stats:
-                                db_type = getattr(
-                                    provider, "__database__", "unknown"
-                                )
+                                db_type = getattr(provider, "__database__", "unknown")
                                 results.append((name, db_type, stats))
             except Exception as exc:
                 logger.debug(
@@ -179,9 +205,7 @@ def _collect_broker_pool_stats(domains: List[Domain]) -> list:
                             if pool is None:
                                 continue
                             created = getattr(pool, "_created_connections", 0)
-                            available = len(
-                                getattr(pool, "_available_connections", [])
-                            )
+                            available = len(getattr(pool, "_available_connections", []))
                             max_conn = getattr(pool, "max_connections", 0)
                             active = created - available
                             results.append((name, active, available, max_conn))
@@ -362,10 +386,30 @@ def _register_infrastructure_gauges(domains: List[Domain]) -> None:
         return callback
 
     for metric_name, field, description, transform in [
-        ("protean.subscription.consumer_lag", "lag", "Messages behind stream head", None),
-        ("protean.subscription.pending_messages", "pending", "Unacknowledged messages", None),
-        ("protean_subscription_dlq_depth", "dlq_depth", "Dead letter queue depth", None),
-        ("protean_subscription_status", "status", "Subscription health (1=ok, 0=not ok)", lambda v: 1 if v == "ok" else 0),
+        (
+            "protean.subscription.consumer_lag",
+            "lag",
+            "Messages behind stream head",
+            None,
+        ),
+        (
+            "protean.subscription.pending_messages",
+            "pending",
+            "Unacknowledged messages",
+            None,
+        ),
+        (
+            "protean_subscription_dlq_depth",
+            "dlq_depth",
+            "Dead letter queue depth",
+            None,
+        ),
+        (
+            "protean_subscription_status",
+            "status",
+            "Subscription health (1=ok, 0=not ok)",
+            lambda v: 1 if v == "ok" else 0,
+        ),
     ]:
         meter.create_observable_gauge(
             metric_name,
@@ -379,16 +423,18 @@ def _register_infrastructure_gauges(domains: List[Domain]) -> None:
             observations = []
             for name, db_type, stats in _collect_pool_stats(domains):
                 attrs = {"provider_name": name, "database_type": db_type}
-                observations.append(
-                    create_observation(stats.get(stat_key, 0), attrs)
-                )
+                observations.append(create_observation(stats.get(stat_key, 0), attrs))
             return observations
 
         return callback
 
     for stat_key, metric_name, description in [
         ("size", "protean.db.pool_size", "Database connection pool size"),
-        ("checked_out", "protean.db.pool_checked_out", "Checked out database connections"),
+        (
+            "checked_out",
+            "protean.db.pool_checked_out",
+            "Checked out database connections",
+        ),
         ("overflow", "protean.db.pool_overflow", "Overflow database connections"),
         ("checked_in", "protean.db.pool_checked_in", "Available database connections"),
     ]:
@@ -403,9 +449,7 @@ def _register_infrastructure_gauges(domains: List[Domain]) -> None:
     def _broker_pool_active_callback(_options):
         observations = []
         for name, active, _available, _max_conn in _collect_broker_pool_stats(domains):
-            observations.append(
-                create_observation(active, {"broker_name": name})
-            )
+            observations.append(create_observation(active, {"broker_name": name}))
         return observations
 
     meter.create_observable_gauge(
@@ -413,6 +457,27 @@ def _register_infrastructure_gauges(domains: List[Domain]) -> None:
         callbacks=[_broker_pool_active_callback],
         description="Active broker pool connections",
         unit="{connection}",
+    )
+
+    # --- Projection staleness gauge (shared collection) ---
+    def _projection_staleness_callback(_options):
+        observations = []
+        for domain, p in _collect_projection_statuses(domains):
+            if p.staleness_seconds is None:
+                continue
+            observations.append(
+                create_observation(
+                    p.staleness_seconds,
+                    {"domain": domain.name, "projection": p.projection_name},
+                )
+            )
+        return observations
+
+    meter.create_observable_gauge(
+        "protean.projection.staleness_seconds",
+        callbacks=[_projection_staleness_callback],
+        description="Seconds a projection is behind its source events",
+        unit="s",
     )
 
     setattr(target_domain, _GAUGES_REGISTERED_KEY, True)
@@ -574,6 +639,27 @@ def _hand_rolled_metrics(domains: List[Domain]) -> str:
     except Exception as e:
         logger.debug(f"Metrics: subscription status failed: {e}")
 
+    # --- Projection staleness metrics (shared collection) ---
+    try:
+        projections = _collect_projection_statuses(domains)
+        if projections:
+            lines.append("")
+            lines.append(
+                "# HELP protean_projection_staleness_seconds Seconds a projection "
+                "is behind its source events"
+            )
+            lines.append("# TYPE protean_projection_staleness_seconds gauge")
+            for domain, p in projections:
+                if p.staleness_seconds is None:
+                    continue
+                labels = f'domain="{domain.name}",projection="{p.projection_name}"'
+                lines.append(
+                    f"protean_projection_staleness_seconds{{{labels}}} "
+                    f"{p.staleness_seconds}"
+                )
+    except Exception as e:
+        logger.debug(f"Metrics: projection staleness failed: {e}")
+
     # --- Per-consumer metrics (via XINFO CONSUMERS) ---
     try:
         from protean.server.observatory.api import _discover_streams, _get_redis
@@ -638,9 +724,7 @@ def _hand_rolled_metrics(domains: List[Domain]) -> str:
         pool_data = _collect_pool_stats(domains)
         if pool_data:
             lines.append("")
-            lines.append(
-                "# HELP protean_db_pool_size Database connection pool size"
-            )
+            lines.append("# HELP protean_db_pool_size Database connection pool size")
             lines.append("# TYPE protean_db_pool_size gauge")
             lines.append("")
             lines.append(
@@ -660,17 +744,15 @@ def _hand_rolled_metrics(domains: List[Domain]) -> str:
 
             for name, db_type, stats in pool_data:
                 labels = f'provider_name="{name}",database_type="{db_type}"'
+                lines.append(f"protean_db_pool_size{{{labels}}} {stats.get('size', 0)}")
                 lines.append(
-                    f'protean_db_pool_size{{{labels}}} {stats.get("size", 0)}'
+                    f"protean_db_pool_checked_out{{{labels}}} {stats.get('checked_out', 0)}"
                 )
                 lines.append(
-                    f'protean_db_pool_checked_out{{{labels}}} {stats.get("checked_out", 0)}'
+                    f"protean_db_pool_overflow{{{labels}}} {stats.get('overflow', 0)}"
                 )
                 lines.append(
-                    f'protean_db_pool_overflow{{{labels}}} {stats.get("overflow", 0)}'
-                )
-                lines.append(
-                    f'protean_db_pool_checked_in{{{labels}}} {stats.get("checked_in", 0)}'
+                    f"protean_db_pool_checked_in{{{labels}}} {stats.get('checked_in', 0)}"
                 )
     except Exception as e:
         logger.debug(f"Metrics: pool stats failed: {e}")

--- a/src/protean/server/projection_status.py
+++ b/src/protean/server/projection_status.py
@@ -185,7 +185,8 @@ def _aggregate(
             stale_values.append(0.0)
             continue
         if feeder_time is not None:
-            stale_values.append((now - feeder_time).total_seconds())
+            # Clamp clock skew (position timestamp slightly ahead of now) to 0.
+            stale_values.append(max(0.0, (now - feeder_time).total_seconds()))
     staleness_seconds = max(stale_values) if stale_values else None
 
     status = _classify_status(lag)
@@ -220,7 +221,9 @@ def _parse_time(iso_value: str | None) -> datetime | None:
     if not iso_value:
         return None
     try:
-        parsed = datetime.fromisoformat(iso_value)
+        # ``fromisoformat`` does not reliably accept a trailing ``Z``; normalize
+        # to ``+00:00`` so timestamps from any adapter parse consistently.
+        parsed = datetime.fromisoformat(iso_value.replace("Z", "+00:00"))
     except (ValueError, TypeError):
         return None
     return ensure_utc_aware(parsed)

--- a/src/protean/server/projection_status.py
+++ b/src/protean/server/projection_status.py
@@ -1,0 +1,226 @@
+"""Projection staleness monitoring for Protean applications.
+
+Projections (read models) are the unit operators reason about — "is my
+``OrderSummary`` up to date?" — but a single projection can be fed by several
+projectors, each subscribing to one or more stream categories. This module
+aggregates those per-projector subscription positions into one projection-centric
+view: how far behind the read model is in *time* (staleness) and in *events* (lag),
+plus its current row count.
+
+It reuses the same position data as :mod:`protean.server.subscription_status`
+(the single source of truth for position/lag), grouped by the projection each
+projector writes to.
+
+Usage::
+
+    from protean.server.projection_status import collect_projection_statuses
+
+    for p in collect_projection_statuses(domain):
+        print(f"{p.projection_name}: stale={p.staleness_seconds}s, lag={p.lag}")
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+from protean.server.subscription.config_resolver import ConfigResolver
+from protean.server.subscription.profiles import SubscriptionType
+
+# Internal reuse: these helpers read the position stream / consumer group for a
+# single subscription and already populate ``lag`` and ``last_updated``. The
+# projection view groups their results by target projection.
+from protean.server.subscription_status import (
+    SubscriptionStatus,
+    _classify_status,
+    _collect_event_store_status,
+    _collect_stream_status,
+)
+from protean.utils import ensure_utc_aware
+
+if TYPE_CHECKING:
+    from protean.domain import Domain
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ProjectionStatus:
+    """Staleness snapshot for a single projection (read model)."""
+
+    projection_name: str
+    """The projection class name (e.g. ``"OrderSummary"``)."""
+
+    projectors: list[str]
+    """Names of the projectors that feed this projection."""
+
+    last_updated: str | None
+    """ISO timestamp the projection last advanced (most recent feeder), or ``None``."""
+
+    staleness_seconds: float | None
+    """Seconds behind: ``0`` when caught up, time-since-last-update when lagging,
+    ``None`` when unknown or never updated."""
+
+    lag: int | None
+    """Events behind head — the worst (max) across feeders. ``None`` when unavailable."""
+
+    row_count: int | None
+    """Rows currently in the projection store, or ``None`` when uncountable."""
+
+    status: str
+    """``"ok"`` | ``"lagging"`` | ``"unknown"``."""
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+# ---------------------------------------------------------------------------
+# Public collection function
+# ---------------------------------------------------------------------------
+
+
+def collect_projection_statuses(
+    domain: Domain, *, include_row_count: bool = True
+) -> list[ProjectionStatus]:
+    """Collect a staleness snapshot for every projection in a domain.
+
+    Walks the registry to map projectors to the projection each writes to, reads
+    each projector subscription's position, and aggregates per projection. Does
+    **not** require the Engine to be running.
+
+    Args:
+        domain: An initialised Protean domain.
+        include_row_count: When ``False``, skip the per-projection row ``COUNT``
+            query. The metrics scrape path passes ``False`` since it only reads
+            staleness; the CLI leaves it ``True`` to show row counts.
+
+    Returns:
+        One :class:`ProjectionStatus` per registered projection.
+    """
+    statuses: list[ProjectionStatus] = []
+    config_resolver = ConfigResolver(domain)
+    now = datetime.now(timezone.utc)
+
+    for _, record in domain.registry.projections.items():
+        projection_cls = record.cls
+        feeders = _feeder_statuses(domain, projection_cls, config_resolver)
+        projectors = sorted({f.handler_name for f in feeders})
+        row_count = _row_count(domain, projection_cls) if include_row_count else None
+        statuses.append(_aggregate(projection_cls, feeders, projectors, now, row_count))
+
+    return statuses
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _feeder_statuses(
+    domain: Domain,
+    projection_cls: type,
+    config_resolver: ConfigResolver,
+) -> list[SubscriptionStatus]:
+    """Collect the subscription status of every projector feeding a projection."""
+    feeders: list[SubscriptionStatus] = []
+
+    for projector_name, record in domain.registry.projectors.items():
+        projector_cls = record.cls
+        if projector_cls.meta_.projector_for is not projection_cls:
+            continue
+
+        for stream_category in projector_cls.meta_.stream_categories:
+            sub_name = f"{projector_name}-{stream_category}"
+            config = config_resolver.resolve(
+                projector_cls, stream_category=stream_category
+            )
+            if config.subscription_type == SubscriptionType.EVENT_STORE:
+                feeders.append(
+                    _collect_event_store_status(
+                        domain, sub_name, projector_cls, stream_category
+                    )
+                )
+            else:
+                feeders.append(
+                    _collect_stream_status(
+                        domain, sub_name, projector_cls, stream_category
+                    )
+                )
+
+    return feeders
+
+
+def _aggregate(
+    projection_cls: type,
+    feeders: list[SubscriptionStatus],
+    projectors: list[str],
+    now: datetime,
+    row_count: int | None,
+) -> ProjectionStatus:
+    """Fold per-feeder statuses into one projection-centric snapshot (pure)."""
+    lags = [f.lag for f in feeders if f.lag is not None]
+    lag = max(lags) if lags else None
+
+    # Parse each feeder's last-updated once; reuse for both the display
+    # timestamp and the staleness computation.
+    parsed = [(f, _parse_time(f.last_updated)) for f in feeders]
+    times = [t for _, t in parsed if t is not None]
+    last_updated = max(times) if times else None
+
+    # Per-feeder staleness: caught-up feeders contribute 0; lagging feeders
+    # contribute time-since-their-last-update; unknown/never-updated contribute
+    # nothing. The projection is as stale as its worst feeder.
+    stale_values: list[float] = []
+    for feeder, feeder_time in parsed:
+        if feeder.lag is None:
+            continue
+        if feeder.lag == 0:
+            stale_values.append(0.0)
+            continue
+        if feeder_time is not None:
+            stale_values.append((now - feeder_time).total_seconds())
+    staleness_seconds = max(stale_values) if stale_values else None
+
+    status = _classify_status(lag)
+
+    return ProjectionStatus(
+        projection_name=projection_cls.__name__,
+        projectors=projectors,
+        last_updated=last_updated.isoformat() if last_updated else None,
+        staleness_seconds=staleness_seconds,
+        lag=lag,
+        row_count=row_count,
+        status=status,
+    )
+
+
+def _row_count(domain: Domain, projection_cls: type) -> int | None:
+    """Count rows in a projection's store, or ``None`` if uncountable (e.g. cache)."""
+    try:
+        with domain.domain_context():
+            return domain.repository_for(projection_cls).query.count()
+    except Exception as exc:
+        logger.debug(
+            "Could not count rows for projection %s: %s",
+            projection_cls.__name__,
+            exc,
+        )
+        return None
+
+
+def _parse_time(iso_value: str | None) -> datetime | None:
+    """Parse an ISO timestamp into an aware UTC datetime, or ``None``."""
+    if not iso_value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(iso_value)
+    except (ValueError, TypeError):
+        return None
+    return ensure_utc_aware(parsed)

--- a/src/protean/server/subscription_status.py
+++ b/src/protean/server/subscription_status.py
@@ -16,6 +16,7 @@ Usage::
 
 from __future__ import annotations
 
+import json
 import logging
 from collections import defaultdict
 from dataclasses import asdict, dataclass
@@ -72,6 +73,9 @@ class SubscriptionStatus:
 
     dlq_depth: int
     """Messages in the dead-letter queue."""
+
+    last_updated: str | None = None
+    """ISO timestamp of the last processed position (event-store subscriptions only)."""
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -135,9 +139,10 @@ def _collect_event_store_status(
         with domain.domain_context():
             store = domain.event_store.store
 
-            # Current position from the position stream
+            # Current position (and when it was last written) from the stream
             last_msg = store._read_last_message(position_stream)
             current_position = last_msg["data"]["position"] if last_msg else -1
+            last_updated = _extract_position_time(last_msg)
 
             # Head of the category stream
             head_position = store.stream_head_position(stream_category)
@@ -162,6 +167,7 @@ def _collect_event_store_status(
                 status=status,
                 consumer_count=0,
                 dlq_depth=0,
+                last_updated=last_updated,
             )
     except Exception as exc:
         logger.debug(
@@ -606,6 +612,31 @@ def collect_subscription_statuses(domain: Domain) -> list[SubscriptionStatus]:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _as_dict(value: object) -> dict | None:
+    """Return *value* as a dict, JSON-decoding a string first, else ``None``."""
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except (ValueError, TypeError):
+            return None
+    return value if isinstance(value, dict) else None
+
+
+def _extract_position_time(last_msg: dict | None) -> str | None:
+    """Pull the ISO timestamp of a position write from its stored message.
+
+    ``write_position`` stamps ``metadata.headers.time``; some stores also expose a
+    top-level ``time``. Returns ``None`` when no message or timestamp is present.
+    """
+    if not last_msg:
+        return None
+    if last_msg.get("time"):
+        return last_msg["time"]
+    metadata = _as_dict(last_msg.get("metadata"))
+    headers = _as_dict(metadata.get("headers")) if metadata else None
+    return headers.get("time") if headers else None
 
 
 def _classify_status(lag: int | None, pending: int = 0) -> str:

--- a/src/protean/server/subscription_status.py
+++ b/src/protean/server/subscription_status.py
@@ -20,6 +20,7 @@ import json
 import logging
 from collections import defaultdict
 from dataclasses import asdict, dataclass
+from datetime import datetime
 from typing import TYPE_CHECKING
 
 from protean.server.subscription.config_resolver import ConfigResolver
@@ -628,15 +629,20 @@ def _extract_position_time(last_msg: dict | None) -> str | None:
     """Pull the ISO timestamp of a position write from its stored message.
 
     ``write_position`` stamps ``metadata.headers.time``; some stores also expose a
-    top-level ``time``. Returns ``None`` when no message or timestamp is present.
+    top-level ``time``. Some adapters return that value as a ``datetime`` rather
+    than a string, so normalize to ISO format. Returns ``None`` when no message or
+    timestamp is present.
     """
     if not last_msg:
         return None
-    if last_msg.get("time"):
-        return last_msg["time"]
-    metadata = _as_dict(last_msg.get("metadata"))
-    headers = _as_dict(metadata.get("headers")) if metadata else None
-    return headers.get("time") if headers else None
+    raw = last_msg.get("time")
+    if not raw:
+        metadata = _as_dict(last_msg.get("metadata"))
+        headers = _as_dict(metadata.get("headers")) if metadata else None
+        raw = headers.get("time") if headers else None
+    if isinstance(raw, datetime):
+        return raw.isoformat()
+    return raw if isinstance(raw, str) else None
 
 
 def _classify_status(lag: int | None, pending: int = 0) -> str:

--- a/tests/cli/test_projection.py
+++ b/tests/cli/test_projection.py
@@ -1,5 +1,6 @@
 """Tests for CLI projection commands (protean projection ...)."""
 
+import json
 import os
 import sys
 from pathlib import Path
@@ -10,6 +11,7 @@ from typer.testing import CliRunner
 
 from protean.cli import app
 from protean.exceptions import NoDomainException
+from protean.server.projection_status import ProjectionStatus
 from protean.utils.projection_rebuilder import RebuildResult
 from tests.shared import change_working_directory_to
 
@@ -238,3 +240,104 @@ class TestProjectionRebuildEdgeCases:
             )
             assert result.exit_code != 0
             assert "Error loading Protean domain" in result.output
+
+
+class TestProjectionStatus:
+    """Tests for `protean projection status`."""
+
+    @pytest.fixture(autouse=True)
+    def reset_path(self):
+        original_path = sys.path[:]
+        cwd = Path.cwd()
+        yield
+        sys.path[:] = original_path
+        os.chdir(cwd)
+
+    @staticmethod
+    def _status(
+        projection_name="Balances",
+        projectors=("BalancesProjector",),
+        last_updated="2026-06-27T12:00:00+00:00",
+        staleness_seconds=90.0,
+        lag=5,
+        row_count=3,
+        status="lagging",
+    ):
+        return ProjectionStatus(
+            projection_name=projection_name,
+            projectors=list(projectors),
+            last_updated=last_updated,
+            staleness_seconds=staleness_seconds,
+            lag=lag,
+            row_count=row_count,
+            status=status,
+        )
+
+    def _run(self, statuses, *extra):
+        change_working_directory_to("test7")
+        mock_domain = MagicMock()
+        mock_domain.name = "test-domain"
+        with (
+            patch("protean.cli.projection.derive_domain", return_value=mock_domain),
+            patch(
+                "protean.server.projection_status.collect_projection_statuses",
+                return_value=statuses,
+            ),
+        ):
+            return runner.invoke(
+                app,
+                ["projection", "status", "--domain", "publishing7.py", *extra],
+            )
+
+    def test_shows_table(self):
+        result = self._run([self._status(), self._status("Tokens", status="ok", lag=0)])
+        assert result.exit_code == 0
+        assert "Balances" in result.output
+        assert "2 projection(s)" in result.output
+        assert "1 lagging" in result.output
+        assert "1 ok" in result.output
+
+    def test_empty_message(self):
+        result = self._run([])
+        assert result.exit_code == 0
+        assert "No projections found" in result.output
+
+    def test_json_output(self):
+        result = self._run([self._status()], "--json")
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
+        assert parsed[0]["projection_name"] == "Balances"
+        assert parsed[0]["staleness_seconds"] == 90.0
+
+    def test_json_output_empty(self):
+        result = self._run([], "--json")
+        assert result.exit_code == 0
+        assert json.loads(result.output) == []
+
+    def test_renders_dashes_for_unknown(self):
+        result = self._run(
+            [
+                self._status(
+                    status="unknown",
+                    lag=None,
+                    staleness_seconds=None,
+                    row_count=None,
+                    last_updated=None,
+                    projectors=(),
+                )
+            ]
+        )
+        assert result.exit_code == 0
+        assert "1 unknown" in result.output
+
+    def test_domain_loading_error(self):
+        change_working_directory_to("test7")
+        with patch(
+            "protean.cli.projection.derive_domain",
+            side_effect=NoDomainException("not found"),
+        ):
+            result = runner.invoke(
+                app, ["projection", "status", "--domain", "nonexistent.py"]
+            )
+        assert result.exit_code != 0

--- a/tests/server/test_projection_otel_metrics.py
+++ b/tests/server/test_projection_otel_metrics.py
@@ -1,0 +1,132 @@
+"""OTel scrape tests for the projection staleness gauge.
+
+Verifies that ``protean.projection.staleness_seconds`` is registered and emits
+observations when the metrics are scraped with telemetry enabled. Mirrors
+``test_subscription_otel_metrics.py``.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from opentelemetry.sdk.metrics import MeterProvider as SDKMeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+from opentelemetry.sdk.resources import Resource
+
+from protean.core.aggregate import BaseAggregate
+from protean.core.event import BaseEvent
+from protean.core.projection import BaseProjection
+from protean.core.projector import BaseProjector, on
+from protean.fields import Float, Identifier, String
+from protean.server.observatory.metrics import (
+    _register_infrastructure_gauges,
+    _scrape_cache,
+)
+from protean.utils import fqn
+
+
+class Registered(BaseEvent):
+    user_id = Identifier()
+    email = String()
+    name = String()
+
+
+class User(BaseAggregate):
+    email = String()
+    name = String()
+
+
+class Balances(BaseProjection):
+    user_id = Identifier(identifier=True)
+    name = String()
+    balance = Float()
+
+
+class BalancesProjector(BaseProjector):
+    @on(Registered)
+    def on_registered(self, event: Registered):
+        pass
+
+
+class Tokens(BaseProjection):
+    token_id = Identifier(identifier=True)
+
+
+class TokensProjector(BaseProjector):
+    @on(Registered)
+    def on_registered(self, event: Registered):
+        pass
+
+
+@pytest.fixture(autouse=True)
+def register_elements(test_domain):
+    test_domain.register(User)
+    test_domain.register(Registered, part_of=User)
+    test_domain.register(Balances)
+    test_domain.register(BalancesProjector, projector_for=Balances, aggregates=[User])
+    # A second projection with no position written -> staleness is None, exercising
+    # the gauge callback's skip branch alongside Balances (which emits).
+    test_domain.register(Tokens)
+    test_domain.register(TokensProjector, projector_for=Tokens, aggregates=[User])
+    test_domain.init(traverse=False)
+
+
+@pytest.fixture(autouse=True)
+def clear_scrape_cache():
+    _scrape_cache.clear()
+    yield
+    _scrape_cache.clear()
+
+
+def _init_telemetry_in_memory(domain):
+    """Attach an in-memory OTel meter provider to the domain."""
+    resource = Resource.create({"service.name": domain.normalized_name})
+    metric_reader = InMemoryMetricReader()
+    meter_provider = SDKMeterProvider(resource=resource, metric_readers=[metric_reader])
+    domain._otel_meter_provider = meter_provider
+    domain._otel_init_attempted = True
+    return metric_reader
+
+
+def _get_metric(metric_reader, name: str):
+    data = metric_reader.get_metrics_data()
+    for resource_metric in data.resource_metrics:
+        for scope_metric in resource_metric.scope_metrics:
+            for metric in scope_metric.metrics:
+                if metric.name == name:
+                    return metric
+    return None
+
+
+def _seed_caught_up(test_domain):
+    with test_domain.domain_context():
+        store = test_domain.event_store.store
+        category = BalancesProjector.meta_.stream_categories[0]
+        for i in range(3):
+            store._write(f"{category}-{i}", "Registered", {"user_id": str(i)})
+        head = store.stream_head_position(category)
+        store._write(
+            f"position-{fqn(BalancesProjector)}-{category}",
+            "Read",
+            {"position": head},
+            metadata={"headers": {"time": datetime.now(timezone.utc).isoformat()}},
+        )
+
+
+def test_staleness_gauge_emits_on_scrape(test_domain):
+    """Scraping with telemetry on runs the gauge callback and yields the metric."""
+    _seed_caught_up(test_domain)
+    metric_reader = _init_telemetry_in_memory(test_domain)
+
+    _register_infrastructure_gauges([test_domain])
+
+    metric = _get_metric(metric_reader, "protean.projection.staleness_seconds")
+    assert metric is not None
+
+    points = list(metric.data.data_points)
+    assert any(p.attributes.get("projection") == "Balances" for p in points)
+    # Caught-up projection reports zero staleness.
+    balances_point = next(
+        p for p in points if p.attributes.get("projection") == "Balances"
+    )
+    assert balances_point.value == 0

--- a/tests/server/test_projection_status.py
+++ b/tests/server/test_projection_status.py
@@ -1,0 +1,452 @@
+"""Tests for projection staleness monitoring (``projection_status``).
+
+Exercises the collector against a real in-memory domain (registry walking, position
+reading, lag/staleness aggregation, row counting) plus unit tests for the helpers.
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from protean.core.aggregate import BaseAggregate
+from protean.core.event import BaseEvent
+from protean.core.projection import BaseProjection
+from protean.core.projector import BaseProjector, on
+from protean.fields import Float, Identifier, String
+from protean.server.projection_status import (
+    ProjectionStatus,
+    _aggregate,
+    _feeder_statuses,
+    _parse_time,
+    _row_count,
+    collect_projection_statuses,
+)
+from protean.server.subscription.profiles import SubscriptionType
+from protean.server.subscription_status import (
+    SubscriptionStatus,
+    _extract_position_time,
+)
+from protean.utils import fqn
+
+
+# ---------------------------------------------------------------------------
+# Test elements
+# ---------------------------------------------------------------------------
+
+
+class User(BaseAggregate):
+    email: String()
+    name: String()
+
+
+class Registered(BaseEvent):
+    user_id: Identifier()
+    email: String()
+    name: String()
+
+
+class Balances(BaseProjection):
+    user_id: Identifier(identifier=True)
+    name: String()
+    balance: Float()
+
+
+class BalancesProjector(BaseProjector):
+    @on(Registered)
+    def on_registered(self, event: Registered):
+        pass
+
+
+@pytest.fixture(autouse=True)
+def register_elements(test_domain):
+    test_domain.register(User)
+    test_domain.register(Registered, part_of=User)
+    test_domain.register(Balances)
+    test_domain.register(BalancesProjector, projector_for=Balances, aggregates=[User])
+    test_domain.init(traverse=False)
+
+
+# ---------------------------------------------------------------------------
+# Helpers to drive event-store state
+# ---------------------------------------------------------------------------
+
+
+def _stream_category() -> str:
+    return BalancesProjector.meta_.stream_categories[0]
+
+
+def _write_events(store, n: int) -> int:
+    """Append ``n`` events to the projector's category; return the head position."""
+    category = _stream_category()
+    for i in range(n):
+        # Events live in per-aggregate streams (``category-<id>``) that the
+        # category head aggregates.
+        store._write(f"{category}-{i}", "Registered", {"user_id": str(i)})
+    return store.stream_head_position(category)
+
+
+def _write_position(store, position: int, *, when: str | None = None) -> None:
+    """Simulate the projector having processed up to ``position`` at time ``when``."""
+    when = when or datetime.now(timezone.utc).isoformat()
+    position_stream = f"position-{fqn(BalancesProjector)}-{_stream_category()}"
+    store._write(
+        position_stream,
+        "Read",
+        {"position": position},
+        metadata={"headers": {"time": when}},
+    )
+
+
+def _seed_rows(test_domain, n: int) -> None:
+    repo = test_domain.repository_for(Balances)
+    for i in range(n):
+        repo.add(Balances(user_id=str(i), name=f"U{i}", balance=float(i)))
+
+
+# ---------------------------------------------------------------------------
+# collect_projection_statuses — real domain
+# ---------------------------------------------------------------------------
+
+
+class TestCollectProjectionStatuses:
+    def test_lagging_projection_reports_staleness_lag_and_rows(self, test_domain):
+        with test_domain.domain_context():
+            store = test_domain.event_store.store
+            head = _write_events(store, 5)
+            _write_position(store, 2)  # processed up to 2, behind head
+            _seed_rows(test_domain, 3)
+
+            statuses = collect_projection_statuses(test_domain)
+
+        by_name = {s.projection_name: s for s in statuses}
+        assert "Balances" in by_name
+        status = by_name["Balances"]
+        assert status.lag == head - 2
+        assert status.status == "lagging"
+        # Position was just written, so staleness is a small non-negative number.
+        assert status.staleness_seconds is not None
+        assert status.staleness_seconds >= 0
+        assert status.row_count == 3
+        assert status.projectors == ["BalancesProjector"]
+        assert status.last_updated is not None
+
+    def test_caught_up_projection_is_ok_with_zero_staleness(self, test_domain):
+        with test_domain.domain_context():
+            store = test_domain.event_store.store
+            head = _write_events(store, 4)
+            _write_position(store, head)  # fully caught up
+
+            statuses = collect_projection_statuses(test_domain)
+
+        status = {s.projection_name: s for s in statuses}["Balances"]
+        assert status.lag == 0
+        assert status.status == "ok"
+        assert status.staleness_seconds == 0.0
+
+    def test_never_updated_projection_is_lagging_with_null_staleness(self, test_domain):
+        """Events exist but the projector never wrote a position."""
+        with test_domain.domain_context():
+            store = test_domain.event_store.store
+            _write_events(store, 3)  # no position written
+
+            statuses = collect_projection_statuses(test_domain)
+
+        status = {s.projection_name: s for s in statuses}["Balances"]
+        assert status.lag is not None and status.lag > 0
+        assert status.status == "lagging"
+        assert status.last_updated is None
+        assert status.staleness_seconds is None
+
+    def test_no_events_is_unknown(self, test_domain):
+        """No events at all → head is -1 → lag and staleness unknown."""
+        with test_domain.domain_context():
+            statuses = collect_projection_statuses(test_domain)
+
+        status = {s.projection_name: s for s in statuses}["Balances"]
+        assert status.lag is None
+        assert status.status == "unknown"
+        assert status.staleness_seconds is None
+
+    def test_to_dict_roundtrips_all_fields(self, test_domain):
+        with test_domain.domain_context():
+            statuses = collect_projection_statuses(test_domain)
+        d = statuses[0].to_dict()
+        assert set(d) == {
+            "projection_name",
+            "projectors",
+            "last_updated",
+            "staleness_seconds",
+            "lag",
+            "row_count",
+            "status",
+        }
+
+    def test_include_row_count_false_skips_count(self, test_domain):
+        with test_domain.domain_context():
+            statuses = collect_projection_statuses(test_domain, include_row_count=False)
+        assert statuses
+        assert all(s.row_count is None for s in statuses)
+
+
+# ---------------------------------------------------------------------------
+# _parse_time
+# ---------------------------------------------------------------------------
+
+
+class TestParseTime:
+    def test_none_returns_none(self):
+        assert _parse_time(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert _parse_time("") is None
+
+    def test_aware_iso_preserved(self):
+        result = _parse_time("2026-06-27T10:00:00+00:00")
+        assert result is not None
+        assert result.tzinfo is not None
+
+    def test_naive_iso_assumed_utc(self):
+        result = _parse_time("2026-06-27T10:00:00")
+        assert result is not None
+        assert result.tzinfo == timezone.utc
+
+    def test_garbage_returns_none(self):
+        assert _parse_time("not-a-timestamp") is None
+
+
+# ---------------------------------------------------------------------------
+# _extract_position_time
+# ---------------------------------------------------------------------------
+
+
+class TestExtractPositionTime:
+    def test_none_message(self):
+        assert _extract_position_time(None) is None
+
+    def test_top_level_time(self):
+        assert _extract_position_time({"time": "2026-01-01T00:00:00Z"}) == (
+            "2026-01-01T00:00:00Z"
+        )
+
+    def test_metadata_headers_time_dict(self):
+        msg = {"metadata": {"headers": {"time": "2026-02-02T00:00:00Z"}}}
+        assert _extract_position_time(msg) == "2026-02-02T00:00:00Z"
+
+    def test_metadata_headers_time_json_string(self):
+        msg = {"metadata": '{"headers": {"time": "2026-03-03T00:00:00Z"}}'}
+        assert _extract_position_time(msg) == "2026-03-03T00:00:00Z"
+
+    def test_missing_time_returns_none(self):
+        assert _extract_position_time({"data": {"position": 1}}) is None
+
+    def test_malformed_metadata_json_returns_none(self):
+        assert _extract_position_time({"metadata": "{not json"}) is None
+
+    def test_headers_as_json_string(self):
+        msg = {"metadata": {"headers": '{"time": "2026-04-04T00:00:00Z"}'}}
+        assert _extract_position_time(msg) == "2026-04-04T00:00:00Z"
+
+    def test_malformed_headers_json_returns_none(self):
+        assert _extract_position_time({"metadata": {"headers": "{bad"}}) is None
+
+
+# ---------------------------------------------------------------------------
+# _feeder_statuses / _row_count — branch coverage
+# ---------------------------------------------------------------------------
+
+
+class TestFeederStatuses:
+    def test_skips_projector_for_other_projection(self):
+        domain = MagicMock()
+        other = MagicMock()
+        other.meta_.projector_for = object()  # not Balances
+        record = MagicMock()
+        record.cls = other
+        domain.registry.projectors = {"other": record}
+
+        assert _feeder_statuses(domain, Balances, MagicMock()) == []
+
+    def test_stream_type_projector_uses_stream_collector(self):
+        domain = MagicMock()
+        projector = MagicMock()
+        projector.meta_.projector_for = Balances
+        projector.meta_.stream_categories = ["user"]
+        record = MagicMock()
+        record.cls = projector
+        domain.registry.projectors = {"p": record}
+
+        resolver = MagicMock()
+        resolver.resolve.return_value.subscription_type = SubscriptionType.STREAM
+
+        stub = SubscriptionStatus(
+            name="p-user",
+            handler_name="P",
+            subscription_type="stream",
+            stream_category="user",
+            lag=None,
+            pending=0,
+            current_position=None,
+            head_position=None,
+            status="unknown",
+            consumer_count=0,
+            dlq_depth=0,
+        )
+        with patch(
+            "protean.server.projection_status._collect_stream_status",
+            return_value=stub,
+        ) as mock_stream:
+            feeders = _feeder_statuses(domain, Balances, resolver)
+
+        mock_stream.assert_called_once()
+        assert len(feeders) == 1
+
+
+class TestRowCount:
+    def test_returns_none_on_error(self):
+        domain = MagicMock()
+        domain.repository_for.side_effect = RuntimeError("boom")
+        assert _row_count(domain, Balances) is None
+
+
+# ---------------------------------------------------------------------------
+# _aggregate — pure aggregation with controlled "now"
+# ---------------------------------------------------------------------------
+
+
+_NOW = datetime(2026, 6, 27, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _feeder(lag, last_updated):
+    return SubscriptionStatus(
+        name="sub",
+        handler_name="BalancesProjector",
+        subscription_type="event_store",
+        stream_category="user",
+        lag=lag,
+        pending=0,
+        current_position=None,
+        head_position=None,
+        status="x",
+        consumer_count=0,
+        dlq_depth=0,
+        last_updated=last_updated,
+    )
+
+
+class TestAggregate:
+    def test_staleness_is_time_since_last_update_when_lagging(self):
+        when = (_NOW - timedelta(seconds=90)).isoformat()
+        result = _aggregate(
+            Balances, [_feeder(5, when)], ["BalancesProjector"], _NOW, 0
+        )
+        assert result.lag == 5
+        assert result.status == "lagging"
+        assert result.staleness_seconds == 90.0
+
+    def test_staleness_zero_when_caught_up(self):
+        when = (_NOW - timedelta(seconds=90)).isoformat()
+        result = _aggregate(
+            Balances, [_feeder(0, when)], ["BalancesProjector"], _NOW, 0
+        )
+        assert result.status == "ok"
+        assert result.staleness_seconds == 0.0
+
+    def test_takes_worst_staleness_and_lag_across_feeders(self):
+        recent = (_NOW - timedelta(seconds=30)).isoformat()
+        old = (_NOW - timedelta(seconds=120)).isoformat()
+        feeders = [_feeder(2, recent), _feeder(9, old)]
+        result = _aggregate(Balances, feeders, ["BalancesProjector"], _NOW, 0)
+        assert result.lag == 9
+        assert result.staleness_seconds == 120.0
+
+    def test_unknown_when_all_feeders_unknown(self):
+        result = _aggregate(
+            Balances, [_feeder(None, None)], ["BalancesProjector"], _NOW, 0
+        )
+        assert result.lag is None
+        assert result.status == "unknown"
+        assert result.staleness_seconds is None
+
+    def test_never_updated_feeder_is_lagging_with_null_staleness(self):
+        result = _aggregate(
+            Balances, [_feeder(3, None)], ["BalancesProjector"], _NOW, 0
+        )
+        assert result.status == "lagging"
+        assert result.staleness_seconds is None
+
+    def test_no_feeders_is_unknown(self):
+        result = _aggregate(Balances, [], [], _NOW, None)
+        assert result.lag is None
+        assert result.status == "unknown"
+        assert result.last_updated is None
+
+
+def test_status_is_dataclass_instance(test_domain):
+    with test_domain.domain_context():
+        statuses = collect_projection_statuses(test_domain)
+    assert all(isinstance(s, ProjectionStatus) for s in statuses)
+
+
+# ---------------------------------------------------------------------------
+# Staleness metric wiring (observatory/metrics)
+# ---------------------------------------------------------------------------
+
+
+class TestStalenessMetric:
+    @pytest.fixture(autouse=True)
+    def clear_cache(self):
+        from protean.server.observatory.metrics import _scrape_cache
+
+        _scrape_cache.clear()
+        yield
+        _scrape_cache.clear()
+
+    def test_hand_rolled_metrics_includes_staleness(self, test_domain):
+        from protean.server.observatory.metrics import _hand_rolled_metrics
+
+        with test_domain.domain_context():
+            store = test_domain.event_store.store
+            head = _write_events(store, 4)
+            _write_position(store, head)  # caught up -> staleness 0.0
+
+        text = _hand_rolled_metrics([test_domain])
+        assert "protean_projection_staleness_seconds" in text
+        assert 'projection="Balances"' in text
+
+    def test_metrics_collector_returns_domain_status_tuples(self, test_domain):
+        from protean.server.observatory.metrics import _collect_projection_statuses
+
+        with test_domain.domain_context():
+            _write_events(test_domain.event_store.store, 3)
+
+        collected = _collect_projection_statuses([test_domain])
+        assert any(s.projection_name == "Balances" for _, s in collected)
+
+    def test_collector_swallows_collection_errors(self, test_domain):
+        from protean.server.observatory.metrics import _collect_projection_statuses
+
+        with patch(
+            "protean.server.projection_status.collect_projection_statuses",
+            side_effect=RuntimeError("boom"),
+        ):
+            assert _collect_projection_statuses([test_domain]) == []
+
+    def test_hand_rolled_skips_projection_without_staleness(self, test_domain):
+        from protean.server.observatory.metrics import _hand_rolled_metrics
+
+        # No events -> staleness is None -> data line skipped, HELP still emitted.
+        text = _hand_rolled_metrics([test_domain])
+        assert "# HELP protean_projection_staleness_seconds" in text
+        assert "protean_projection_staleness_seconds{domain=" not in text
+
+    def test_hand_rolled_handles_collection_error(self, test_domain):
+        from protean.server.observatory import metrics as metrics_mod
+
+        with patch.object(
+            metrics_mod,
+            "_collect_projection_statuses",
+            side_effect=RuntimeError("boom"),
+        ):
+            text = metrics_mod._hand_rolled_metrics([test_domain])
+        assert "protean_projection_staleness_seconds" not in text

--- a/tests/server/test_projection_status.py
+++ b/tests/server/test_projection_status.py
@@ -214,6 +214,11 @@ class TestParseTime:
     def test_garbage_returns_none(self):
         assert _parse_time("not-a-timestamp") is None
 
+    def test_z_suffix_parsed_as_utc(self):
+        result = _parse_time("2026-06-27T10:00:00Z")
+        assert result is not None
+        assert result.tzinfo == timezone.utc
+
 
 # ---------------------------------------------------------------------------
 # _extract_position_time
@@ -249,6 +254,15 @@ class TestExtractPositionTime:
 
     def test_malformed_headers_json_returns_none(self):
         assert _extract_position_time({"metadata": {"headers": "{bad"}}) is None
+
+    def test_datetime_value_normalized_to_isoformat(self):
+        dt = datetime(2026, 5, 5, 12, 0, 0, tzinfo=timezone.utc)
+        assert _extract_position_time({"time": dt}) == dt.isoformat()
+
+    def test_metadata_datetime_value_normalized(self):
+        dt = datetime(2026, 5, 5, 12, 0, 0, tzinfo=timezone.utc)
+        msg = {"metadata": {"headers": {"time": dt}}}
+        assert _extract_position_time(msg) == dt.isoformat()
 
 
 # ---------------------------------------------------------------------------
@@ -374,6 +388,14 @@ class TestAggregate:
         )
         assert result.status == "lagging"
         assert result.staleness_seconds is None
+
+    def test_future_timestamp_clamps_staleness_to_zero(self):
+        # Clock skew: position timestamp ahead of "now" must not go negative.
+        future = (_NOW + timedelta(seconds=30)).isoformat()
+        result = _aggregate(
+            Balances, [_feeder(5, future)], ["BalancesProjector"], _NOW, 0
+        )
+        assert result.staleness_seconds == 0.0
 
     def test_no_feeders_is_unknown(self):
         result = _aggregate(Balances, [], [], _NOW, None)

--- a/tests/server/test_subscription_status.py
+++ b/tests/server/test_subscription_status.py
@@ -56,6 +56,8 @@ class TestSubscriptionStatusDataclass:
         assert d["status"] == "lagging"
         assert d["consumer_count"] == 0
         assert d["dlq_depth"] == 0
+        assert "last_updated" in d
+        assert d["last_updated"] is None
 
     def test_to_dict_with_none_lag(self):
         status = SubscriptionStatus(


### PR DESCRIPTION
## Summary

Adds projection staleness detection (epic #891, Theme 2):

- **`protean projection status`** CLI command: per-projection staleness (seconds behind), lag (events behind), last-updated time, and row count, as a table or `--json`.
- **`protean.projection.staleness_seconds`** metric: an OpenTelemetry observable gauge plus a hand-rolled Prometheus fallback, labelled by domain and projection.
- A **projection-centric collector** (`collect_projection_statuses`) that aggregates each projection's feeding projector positions, reusing the existing subscription position data as the single source of truth. `SubscriptionStatus` gains an additive `last_updated` field.

Staleness is `0` when caught up, the time-since-last-advance when lagging, and blank when never updated or unknown. A projection fed by several projectors reports the worst staleness and lag across them. Time-based staleness comes from the position-write timestamp, so it is reported for event-store-backed projectors; stream-backed projectors report lag only.

Docs span all four Diataxis quadrants (CLI reference, metrics reference, monitoring guide, subscriptions concept) plus a `how-do-i` entry and a changelog fragment.

## Test plan

- [x] Core tests pass (`protean test`)
- [x] Full adapter suite passes (`protean test -c FULL`, all 9 suites)
- [x] 100% patch coverage on changed files

Closes #893