### PR TITLE
Accept string part_of for command/event handlers and repositories (#969)

### DIFF
--- a/changes/969.fixed.md
+++ b/changes/969.fixed.md
@@ -1,0 +1,1 @@
+`command_handler`, `event_handler`, and `repository` now accept a string `part_of` reference (e.g. `part_of="Order"`) and resolve it like every other element, instead of raising at registration. This removes the import-ordering and circular-import friction that previously forced class references for exactly these three elements.

--- a/src/protean/core/command_handler.py
+++ b/src/protean/core/command_handler.py
@@ -125,6 +125,18 @@ class BaseCommandHandler(Element, HandlerMixin, OptionsMixin):
 _T = TypeVar("_T")
 
 
+def derive_command_stream_category(aggregate_cls: Any) -> str:
+    """Derive a command handler's stream category from its aggregate.
+
+    Command handlers subscribe to the aggregate's command stream, named
+    ``<aggregate stream category>:command``. This is the single source of
+    truth for that convention; it is applied eagerly by
+    ``command_handler_factory`` for class references and by the
+    ``ElementResolver`` once a string ``part_of`` reference is resolved.
+    """
+    return f"{aggregate_cls.meta_.stream_category}:command"
+
+
 def command_handler_factory(
     element_cls: type[_T], domain: Any, **opts: Any
 ) -> type[_T]:
@@ -135,9 +147,13 @@ def command_handler_factory(
             f"Command Handler `{element_cls.__name__}` needs to be associated with an Aggregate"
         )
 
-    # Always derive stream_category from the aggregate - cannot be overridden
-    element_cls.meta_.stream_category = (
-        f"{element_cls.meta_.part_of.meta_.stream_category}:command"
-    )
+    # Always derive stream_category from the aggregate - cannot be overridden.
+    # When ``part_of`` is a string reference, the aggregate is not yet
+    # resolved; the ElementResolver derives stream_category once the
+    # reference is resolved.
+    if not isinstance(element_cls.meta_.part_of, str):
+        element_cls.meta_.stream_category = derive_command_stream_category(
+            element_cls.meta_.part_of
+        )
 
     return element_cls

--- a/src/protean/core/event_handler.py
+++ b/src/protean/core/event_handler.py
@@ -120,10 +120,19 @@ class BaseEventHandler(Element, HandlerMixin, OptionsMixin):
             getattr(cls.meta_, "part_of") if hasattr(cls.meta_, "part_of") else None
         )
 
+        # When ``part_of`` is a string reference, the aggregate is not yet
+        # resolved, so its stream_category cannot be derived here. The
+        # ElementResolver fills it in once the reference is resolved.
+        stream_category = (
+            part_of.meta_.stream_category
+            if part_of and not isinstance(part_of, str)
+            else None
+        )
+
         return [
             ("part_of", part_of),
             ("source_stream", None),
-            ("stream_category", part_of.meta_.stream_category if part_of else None),
+            ("stream_category", stream_category),
             # Subscription configuration options
             ("subscription_type", None),  # SubscriptionType enum or None for default
             ("subscription_profile", None),  # SubscriptionProfile enum or None

--- a/src/protean/core/repository.py
+++ b/src/protean/core/repository.py
@@ -455,9 +455,14 @@ def repository_factory(element_cls: type[_T], domain: Any, **opts: Any) -> type[
 
     # Enforce that user-defined repositories can only be associated with Aggregates.
     # Auto-constructed repositories (for child entities, projections) are created
-    # internally and bypass this check.
-    if not auto_constructed and not issubclass(
-        element_cls.meta_.part_of, BaseAggregate
+    # internally and bypass this check. When ``part_of`` is a string reference,
+    # the check is deferred: the ElementResolver only resolves it against
+    # registered aggregates, so a non-aggregate target surfaces as an
+    # unresolved reference during validation.
+    if (
+        not auto_constructed
+        and not isinstance(element_cls.meta_.part_of, str)
+        and not issubclass(element_cls.meta_.part_of, BaseAggregate)
     ):
         raise IncorrectUsageError(
             f"Repository `{element_cls.__name__}` can only be associated with an Aggregate"

--- a/src/protean/domain/resolver.py
+++ b/src/protean/domain/resolver.py
@@ -68,6 +68,7 @@ class ElementResolver:
                                 (DomainObjects.AGGREGATE,),
                             )
                             cls.meta_.part_of = to_cls
+                            self._finalize_aggregate_link(cls, to_cls)
                         case "ProjectionCls":
                             cls = params
                             to_cls = self._domain.fetch_element_cls_from_registry(
@@ -100,6 +101,29 @@ class ElementResolver:
 
             if resolved:
                 del pending[name]
+
+    def _finalize_aggregate_link(self, cls, aggregate_cls) -> None:
+        """Complete element wiring deferred when ``part_of`` was a string.
+
+        Command and event handler factories derive their ``stream_category``
+        from the associated aggregate. When ``part_of`` is given as a string
+        reference, that derivation is skipped at registration (the aggregate
+        is not yet resolved) and completed here, once the reference points at
+        a real aggregate class. Class-reference ``part_of`` is finalized
+        eagerly in the factory and never reaches this path.
+        """
+        element_type = cls.element_type
+        if element_type == DomainObjects.COMMAND_HANDLER:
+            # Imported lazily to avoid a core <-> domain import cycle, matching
+            # the function-local imports used elsewhere in this module.
+            from protean.core.command_handler import derive_command_stream_category
+
+            cls.meta_.stream_category = derive_command_stream_category(aggregate_cls)
+        elif element_type == DomainObjects.EVENT_HANDLER:
+            # Respect an explicitly configured stream_category; only derive
+            # when the handler relied on its aggregate for the value.
+            if cls.meta_.stream_category is None:
+                cls.meta_.stream_category = aggregate_cls.meta_.stream_category
 
     def assign_aggregate_clusters(self) -> None:
         """Assign aggregate clusters to all relevant elements."""

--- a/tests/domain/test_element_resolver.py
+++ b/tests/domain/test_element_resolver.py
@@ -196,6 +196,156 @@ class TestResolveAggregateClsStringReference:
 
 
 # ============================================================================
+# resolve_references -- AggregateCls for handlers and repositories (#969)
+#
+# command_handler, event_handler, and repository previously rejected a string
+# ``part_of`` because their factories dereferenced it eagerly at registration.
+# The factory now defers that work and the resolver completes it, so a string
+# ``part_of`` resolves uniformly across every element.
+# ============================================================================
+
+
+class TestResolveHandlerAndRepositoryStringReference:
+    """command_handler, event_handler, and repository accept string part_of."""
+
+    def test_command_handler_part_of_string_resolves_and_derives_stream(
+        self, test_domain
+    ):
+        from protean.core.command_handler import BaseCommandHandler
+        from protean.utils.mixins import handle
+
+        class PublishPostCmd(BaseCommand):
+            post_id: Identifier()
+
+        class PostCommandHandler(BaseCommandHandler):
+            @handle(PublishPostCmd)
+            def publish(self, command: PublishPostCmd) -> None:
+                pass
+
+        test_domain.register(Post)
+        test_domain.register(PublishPostCmd, part_of="Post")
+        test_domain.register(PostCommandHandler, part_of="Post")
+        test_domain.init(traverse=False)
+
+        assert PostCommandHandler.meta_.part_of is Post
+        # stream_category is derived from the aggregate, post-resolution
+        assert (
+            PostCommandHandler.meta_.stream_category
+            == f"{Post.meta_.stream_category}:command"
+        )
+
+    def test_event_handler_part_of_string_resolves_and_derives_stream(
+        self, test_domain
+    ):
+        from protean.core.event_handler import BaseEventHandler
+        from protean.utils.mixins import handle
+
+        class PostWasPublished(BaseEvent):
+            post_id: Identifier()
+
+        class PostEventHandler(BaseEventHandler):
+            @handle(PostWasPublished)
+            def on_published(self, event: PostWasPublished) -> None:
+                pass
+
+        test_domain.register(Post)
+        test_domain.register(PostWasPublished, part_of="Post")
+        test_domain.register(PostEventHandler, part_of="Post")
+        test_domain.init(traverse=False)
+
+        assert PostEventHandler.meta_.part_of is Post
+        assert PostEventHandler.meta_.stream_category == Post.meta_.stream_category
+
+    def test_string_and_class_part_of_yield_identical_stream_category(
+        self, test_domain
+    ):
+        """A string part_of resolves to exactly what a class part_of produces."""
+        from protean.core.command_handler import BaseCommandHandler
+        from protean.utils.mixins import handle
+
+        class PublishPostCmd(BaseCommand):
+            post_id: Identifier()
+
+        class ArchivePostCmd(BaseCommand):
+            post_id: Identifier()
+
+        class StringRefHandler(BaseCommandHandler):
+            @handle(PublishPostCmd)
+            def publish(self, command: PublishPostCmd) -> None:
+                pass
+
+        class ClassRefHandler(BaseCommandHandler):
+            @handle(ArchivePostCmd)
+            def archive(self, command: ArchivePostCmd) -> None:
+                pass
+
+        test_domain.register(Post)
+        test_domain.register(PublishPostCmd, part_of="Post")
+        test_domain.register(ArchivePostCmd, part_of="Post")
+        test_domain.register(StringRefHandler, part_of="Post")
+        test_domain.register(ClassRefHandler, part_of=Post)
+        test_domain.init(traverse=False)
+
+        assert (
+            StringRefHandler.meta_.stream_category
+            == ClassRefHandler.meta_.stream_category
+        )
+
+    def test_event_handler_explicit_stream_category_is_preserved(self, test_domain):
+        """An explicit stream_category wins over the aggregate-derived default."""
+        from protean.core.event_handler import BaseEventHandler
+        from protean.utils.mixins import handle
+
+        class PostWasPublished(BaseEvent):
+            post_id: Identifier()
+
+        class PostEventHandler(BaseEventHandler):
+            @handle(PostWasPublished)
+            def on_published(self, event: PostWasPublished) -> None:
+                pass
+
+        test_domain.register(Post)
+        test_domain.register(PostWasPublished, part_of="Post")
+        test_domain.register(
+            PostEventHandler, part_of="Post", stream_category="custom-stream"
+        )
+        test_domain.init(traverse=False)
+
+        assert PostEventHandler.meta_.part_of is Post
+        assert PostEventHandler.meta_.stream_category == "custom-stream"
+
+    def test_repository_part_of_string_resolves_to_aggregate(self, test_domain):
+        from protean.core.repository import BaseRepository
+
+        class PostRepository(BaseRepository):
+            pass
+
+        test_domain.register(Post)
+        test_domain.register(PostRepository, part_of="Post")
+        test_domain.init(traverse=False)
+
+        assert PostRepository.meta_.part_of is Post
+
+    def test_repository_string_part_of_to_non_aggregate_is_rejected(self, test_domain):
+        """A string part_of that names a non-aggregate stays unresolved and
+        is reported at init, preserving the aggregate-only guarantee."""
+        from protean.exceptions import ConfigurationError
+        from protean.core.repository import BaseRepository
+
+        class PostRepository(BaseRepository):
+            pass
+
+        # Comment is an entity, not an aggregate; the resolver only matches
+        # the string against registered aggregates.
+        test_domain.register(Post)
+        test_domain.register(Comment, part_of=Post)
+        test_domain.register(PostRepository, part_of="Comment")
+
+        with pytest.raises(ConfigurationError):
+            test_domain.init(traverse=False)
+
+
+# ============================================================================
 # resolve_references -- Unresolved references are left pending
 # ============================================================================
 


### PR DESCRIPTION
## Summary

`part_of` accepts a string reference for most domain elements (entity, event, command, query, query_handler, application_service) via the domain's deferred resolution. But `command_handler`, `event_handler`, and `repository` rejected strings: their factories dereferenced `part_of` eagerly at registration (`.meta_` / `issubclass()`), before the resolver runs, so a string raised `AttributeError` / `TypeError`. This forced class references and import-ordering friction for exactly the three elements where string refs are most useful.

This change makes `part_of` accept a string uniformly across every element:

- **Factories defer for strings.** `command_handler`, `event_handler`, and `repository` factories skip the eager `stream_category` derivation / aggregate `issubclass` check when `part_of` is a string.
- **Resolver completes the wiring.** `ElementResolver._finalize_aggregate_link` derives the handler `stream_category` once the string resolves to a real aggregate, mirroring the existing `ProjectionCls` / `QueryProjectionCls` resolution cases.
- **Single source of truth.** A shared `derive_command_stream_category` helper centralizes the `<aggregate>:command` convention used by both the eager (class-ref) and deferred (string-ref) paths.

Class-reference `part_of` is unchanged. A non-aggregate string target for a repository surfaces as a normal unresolved-reference error at init (the resolver only matches strings against registered aggregates).

This is a purely additive `.fixed` change, so no breaking-change mitigation is required. Behavior now matches what the docs already imply (string `part_of` is documented as a general capability with no carve-out).

## Test plan

- [x] 6 new tests in `tests/domain/test_element_resolver.py` (handlers derive stream_category, explicit `stream_category` preserved, string==class equivalence, repository resolves, repository→non-aggregate rejected)
- [x] Core suite: 9565 passed
- [x] Changed-area adapter tests (PostgreSQL/Elasticsearch/Redis/SQLite): 572 passed
- [x] 100% patch coverage (diff-cover)
- [x] ruff + format clean

Closes #969