### PR TITLE
Fix observatory CLI tests for the loopback default

### DIFF
--- a/tests/cli/test_observatory.py
+++ b/tests/cli/test_observatory.py
@@ -54,7 +54,7 @@ class TestObservatoryCommand:
 
             assert result.exit_code == 0
             MockObservatory.assert_called_once()
-            mock_obs.run.assert_called_once_with(host="0.0.0.0", port=9000)
+            mock_obs.run.assert_called_once_with(host="127.0.0.1", port=9000)
 
     def test_observatory_initializes_domain(self):
         """Test that the observatory command correctly derives and initializes the domain."""
@@ -146,7 +146,7 @@ class TestObservatoryCommand:
             result = runner.invoke(app, args)
 
             assert result.exit_code == 0
-            mock_obs.run.assert_called_once_with(host="0.0.0.0", port=8080)
+            mock_obs.run.assert_called_once_with(host="127.0.0.1", port=8080)
 
     def test_observatory_custom_title(self):
         """Test that observatory accepts a custom title."""


### PR DESCRIPTION
## Summary

A regression follow-up to #991. That PR changed the `protean observatory` default `--host` from `0.0.0.0` to `127.0.0.1`, but two existing tests in `tests/cli/test_observatory.py` still assert the old default (they invoke the command without `--host`):

- `test_observatory_with_valid_domain` → `run(host="0.0.0.0", port=9000)`
- `test_observatory_custom_port` → `run(host="0.0.0.0", port=8080)`

These now fail on `main` (surfaced by the 3.14 job on #993). Update both to the new loopback default. The `test_observatory_custom_host` test (which passes `--host` explicitly) and the new `test_observatory_binding.py` were already correct.

## Test plan
- [x] `tests/cli/test_observatory.py`: 16 passed
- [x] ruff clean

This unblocks `main` (and the #993 / #994 cut PRs, which only inherited the breakage).