### PR TITLE
Make v0.16 patch releases always shippable

### DIFF
--- a/.claude/skills/release-check/reference.md
+++ b/.claude/skills/release-check/reference.md
@@ -34,18 +34,20 @@ With `tag.gpgsign` on, the `v0.X.Y` tag is signed too. Verify with
 uv sync --group dev
 
 # Minor release (e.g., 0.15.0 → 0.16.0)
-bump-my-version bump minor
+bump-my-version bump minor --no-commit --no-tag
 
 # Patch release (e.g., 0.15.0 → 0.15.1)
-bump-my-version bump patch
+bump-my-version bump patch --no-commit --no-tag
 ```
 
 Version is updated automatically in: `pyproject.toml`, `src/protean/__init__.py`,
 `src/protean/template/domain_template/pyproject.toml.jinja`,
 `docs/guides/getting-started/installation.md`, `.bumpversion.toml`.
 
-`bump-my-version` auto-creates a commit and tag (e.g., `v0.16.0`). Push the tag
-to trigger the publish workflow.
+`bump-my-version`'s own commit/tag is aborted by the `uv-lock` pre-commit hook
+(see the minor and patch workflows below), so both release flows bump files only
+with `--no-commit --no-tag`, then `uv lock` and commit + tag manually. Pushing
+the resulting tag triggers the publish workflow.
 
 The GitHub Actions workflow (`.github/workflows/publish.yml`) handles:
 - Building with uv
@@ -57,7 +59,7 @@ The GitHub Actions workflow (`.github/workflows/publish.yml`) handles:
 ```
 main:  ──A──B──C──[tag v0.16.0]──D──E──...
                       │
-release/0.16.x:       └── (created on demand for patches)
+release/0.16.x:       └── (cut from the tag when the minor ships; patches land here)
 ```
 
 **Cutting a minor release:**

--- a/.claude/skills/release-check/reference.md
+++ b/.claude/skills/release-check/reference.md
@@ -9,6 +9,24 @@ are cut straight from `main` when the changelog has substantive entries. Bugs
 discovered after a release are shipped as **patch releases** from the release
 branch.
 
+## Prerequisite: signed commits and tags
+
+Release commits and tags go to `main`/`release/*` directly (not via a PR), so
+they are only "Verified" on GitHub if your local git is set up to sign. On a
+fresh machine, configure SSH signing **before** bumping:
+
+```bash
+git config --global gpg.format ssh
+git config --global user.signingkey ~/.ssh/<your_key>.pub   # a GitHub Signing Key
+git config --global commit.gpgsign true
+git config --global tag.gpgsign true
+```
+
+The key must be registered on GitHub as a **Signing Key** (a separate list from
+auth keys: Settings → SSH and GPG keys → New SSH key → type *Signing Key*).
+With `tag.gpgsign` on, the `v0.X.Y` tag is signed too. Verify with
+`git log --show-signature -1`.
+
 ## Version bump commands
 
 ```bash

--- a/.claude/skills/release-check/reference.md
+++ b/.claude/skills/release-check/reference.md
@@ -74,22 +74,47 @@ git push origin release/0.16.x
 
 ## Patch release workflow (from release branch)
 
-Bugfixes land on `main` first, then are cherry-picked to the release branch:
+The `release/0.X.x` branch is created when the minor ships (step 3 above) and
+stays around for the life of that line, so a patch never waits on branch
+creation. Bugfixes land on `main` first, then are cherry-picked to the release
+branch:
 
 ```bash
 # Fix the bug on main, merge PR, then:
 git checkout release/0.16.x
 git pull --ff-only
-git cherry-pick <commit-hash>
+git cherry-pick <commit-hash>                 # CI runs on the release branch push
 
 # Update CHANGELOG on the release branch under [0.16.1]
 $EDITOR CHANGELOG.md
 git add CHANGELOG.md
 git commit -m "Mark 0.16.1 release in CHANGELOG"
 
-bump-my-version bump patch                    # 0.16.0 → 0.16.1
-git push origin release/0.16.x --tags
+# Bump version, then commit + tag MANUALLY — same uv-lock gotcha as the minor
+# flow: bump-my-version's own commit is aborted by the `uv-lock` pre-commit
+# hook (the stale uv.lock is regenerated and pre-commit rolls the commit back).
+bump-my-version bump patch --no-commit --no-tag   # 0.16.0 → 0.16.1, files only
+uv lock                                            # bring uv.lock to the new version
+git add -A
+git commit -m "Bump version: 0.16.0 → 0.16.1"      # uv-lock hook now passes
+git tag -a v0.16.1 -m "Bump version: 0.16.0 → 0.16.1"
+git push origin release/0.16.x
+git push origin v0.16.1                             # tag push triggers publish.yml
 ```
+
+## Backporting fixes to the release branch
+
+Two ways to get a `main` fix onto `release/0.X.x`:
+
+- **Automated (preferred):** add the `backport release/0.X.x` label to the PR
+  before merging. The `Backport` workflow (`.github/workflows/backport.yml`)
+  opens a cherry-pick PR against the release branch on merge. Review and merge
+  that PR, then cut the patch.
+- **Manual:** cherry-pick the merge commit as shown in the patch workflow above.
+  Use this when the automated cherry-pick conflicts.
+
+Only the latest minor line is patched (see `SECURITY.md`); don't backport to
+older `release/*` branches.
 
 ## Post-release checklist
 

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,37 @@
+name: Backport
+
+# When a merged PR carries a `backport release/0.X.x` label, open a PR that
+# cherry-picks it onto that release branch. Keeps the supported patch line
+# (see SECURITY.md) in sync without relying on a maintainer to remember the
+# cherry-pick. The opened PR still goes through CI on the release branch.
+on:
+  pull_request_target:
+    types: [closed, labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  backport:
+    name: Backport PR
+    runs-on: ubuntu-latest
+    # Only act on merged PRs that carry at least one `backport ...` label.
+    if: >
+      github.event.pull_request.merged == true &&
+      (
+        github.event.action == 'closed' ||
+        startsWith(github.event.label.name, 'backport ')
+      )
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create backport PR
+        uses: korthout/backport-action@v3
+        with:
+          label_pattern: '^backport (?<target>release/[^ ]+)$'
+          pull_title: '[Backport ${target_branch}] ${pull_title}'
+          pull_description: |-
+            Automated backport of #${pull_number} to `${target_branch}`.

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -17,11 +17,15 @@ jobs:
     name: Backport PR
     runs-on: ubuntu-latest
     # Only act on merged PRs that carry at least one `backport ...` label.
+    # On `closed` (merge): require an existing `backport ` label on the PR.
+    # On `labeled`: require the just-added label to be a `backport ` one.
     if: >
       github.event.pull_request.merged == true &&
       (
-        github.event.action == 'closed' ||
-        startsWith(github.event.label.name, 'backport ')
+        (github.event.action == 'closed' &&
+         contains(join(github.event.pull_request.labels.*.name, '|'), 'backport ')) ||
+        (github.event.action == 'labeled' &&
+         startsWith(github.event.label.name, 'backport '))
       )
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, "release/**"]
   pull_request:
-    branches: [main]
+    branches: [main, "release/**"]
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,46 @@
+# Security Policy
+
+## Supported versions
+
+Protean is pre-1.0. To keep the maintenance surface small while the API is still
+evolving, **only the latest minor release line receives security and bug-fix
+patches.** Patches are shipped from the corresponding `release/0.X.x` branch
+(for example, `release/0.16.x` for the 0.16 line).
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.16.x  | :white_check_mark: |
+| < 0.16  | :x:                |
+
+When a new minor ships, the previous line stops receiving patches. Upgrading to
+the latest minor is the supported path for picking up fixes. Each minor follows
+the tiered breaking-change policy in
+[ADR-0004](docs/adr/0004-release-workflow-and-breaking-change-policy.md), so
+upgrades within the supported window come with deprecation warnings and upgrade
+notes rather than silent breaks.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for security vulnerabilities.**
+
+Report privately through GitHub's
+[private vulnerability reporting](https://github.com/proteanhq/protean/security/advisories/new)
+("Report a vulnerability" under the repository's **Security** tab). If you cannot
+use GitHub advisories, email the maintainer at
+**subhash.bhushan@gmail.com** with `[protean-security]` in the subject.
+
+Please include:
+
+- The affected version(s) and a description of the issue.
+- Steps to reproduce, or a proof-of-concept, where possible.
+- The impact you foresee (data exposure, RCE, denial of service, etc.).
+
+### What to expect
+
+- **Acknowledgement** within 3 business days.
+- An initial assessment and severity classification within 7 days.
+- A coordinated fix on the supported release line, shipped as a patch release,
+  followed by a public advisory crediting the reporter (unless anonymity is
+  requested).
+
+Thank you for helping keep Protean and its users safe.


### PR DESCRIPTION
Closes the gaps that would block shipping a `v0.16` patch on short notice.

## Problem
- `release/0.16.x` did not exist (now cut from `v0.16.0` and pushed) — a hotfix would have required creating the branch under pressure.
- CI was **main-only** (`push`/`pull_request` on `main`). A cherry-pick or version bump on a release branch ran **zero tests**, and `publish.yml` fires on any `v*` tag regardless of CI — so a patch could publish to PyPI untested.
- The patch runbook still used plain `bump-my-version bump patch`, which hits the same `uv-lock` pre-commit abort the minor flow was already fixed for.
- No security disclosure path or supported-versions policy.
- Backporting relied entirely on remembering to cherry-pick.

## Changes
- **`ci.yml`** — run the full matrix on `release/**` for both `push` and `pull_request`. (The same trigger change is also applied directly on `release/0.16.x`, since that branch was cut from `v0.16.0` and carries its own workflow file.)
- **`SECURITY.md`** (new) — private disclosure path + supported-versions / maintenance policy (latest minor line only, pre-1.0).
- **`backport.yml`** (new) — a merged PR labeled `backport release/0.X.x` auto-opens a cherry-pick PR onto that branch (via `korthout/backport-action`).
- **Release runbook** — patch flow now mirrors the minor flow (`--no-commit` / `uv lock` / manual commit + tag); documents the backport-label convention.

## Notes
- No changelog fragment: CI/security/tooling changes with no user-facing framework impact.
- The `backport release/0.16.x` label is created alongside this PR so the workflow has a label to match once merged.
