### PR TITLE
Uplift function-local imports to module top across the codebase

### DIFF
--- a/src/protean/adapters/repository/elasticsearch.py
+++ b/src/protean/adapters/repository/elasticsearch.py
@@ -2,6 +2,9 @@
 
 import json
 import logging
+import types
+import typing
+from datetime import date as _date, datetime as _datetime
 from typing import Any
 from uuid import UUID
 
@@ -32,7 +35,7 @@ from protean.exceptions import (
     ObjectNotFoundError,
 )
 from protean.port.dao import BaseDAO, BaseLookup
-from protean.port.provider import BaseProvider, DatabaseCapabilities
+from protean.port.provider import BaseProvider, DatabaseCapabilities, registry
 from protean.utils import IdentityStrategy, IdentityType, fully_qualified_name
 from protean.utils.container import Options
 from protean.utils.globals import current_domain, current_uow
@@ -58,9 +61,6 @@ _PYTHON_TYPE_TO_ES = {
 
 def _resolve_python_type(field_obj: ResolvedField):
     """Unwrap Optional/Union and generic aliases to get the base Python type."""
-    import types
-    import typing
-
     python_type = field_obj._python_type
     origin = typing.get_origin(python_type)
     if origin is types.UnionType or origin is typing.Union:
@@ -84,9 +84,6 @@ def _es_field_mapping_for(field_obj) -> elasticsearch_dsl.Field | None:
     Elasticsearch's dynamic mapping (List, Dict). For ES-specific tuning
     (analyzers, multi-fields, etc.), users should define a custom @domain.model.
     """
-    from datetime import date as _date
-    from datetime import datetime as _datetime
-
     # ShadowField (flattened ValueObject attribute): delegate to inner field
     if isinstance(field_obj, _ShadowField):
         return _es_field_mapping_for(field_obj.field_obj)
@@ -1342,8 +1339,6 @@ class IsNull(DefaultLookup):
 
 def register() -> None:
     """Register Elasticsearch provider with Protean if elasticsearch is available."""
-    from protean.port.provider import registry
-
     try:
         import elasticsearch  # noqa: F401
 

--- a/src/protean/adapters/repository/memory.py
+++ b/src/protean/adapters/repository/memory.py
@@ -14,7 +14,7 @@ from protean.core.database_model import BaseDatabaseModel
 from protean.core.queryset import ResultSet
 from protean.exceptions import ExpectedVersionError, ObjectNotFoundError
 from protean.port.dao import BaseDAO, BaseLookup
-from protean.port.provider import BaseProvider, DatabaseCapabilities
+from protean.port.provider import BaseProvider, DatabaseCapabilities, registry
 from protean.utils import fully_qualified_name
 from protean.utils.container import Options
 from protean.utils.globals import current_uow
@@ -849,6 +849,4 @@ def register() -> None:
 
     MemoryProvider is always available as it has no external dependencies.
     """
-    from protean.port.provider import registry
-
     registry.register("memory", "protean.adapters.repository.memory.MemoryProvider")

--- a/src/protean/adapters/repository/sqlalchemy.py
+++ b/src/protean/adapters/repository/sqlalchemy.py
@@ -4,6 +4,8 @@ import copy
 import json
 import logging
 import time
+import types
+import typing
 import uuid
 from abc import abstractmethod
 from datetime import date as _date, datetime as _datetime
@@ -54,7 +56,7 @@ from protean.fields.association import Reference, _ReferenceField
 from protean.fields.basic import ValueObjectList
 from protean.fields.embedded import ValueObject, _ShadowField
 from protean.port.dao import BaseDAO, BaseLookup
-from protean.port.provider import BaseProvider, DatabaseCapabilities
+from protean.port.provider import BaseProvider, DatabaseCapabilities, registry
 from protean.utils import IdentityType, fully_qualified_name
 from protean.utils.container import Options
 from protean.utils.globals import current_domain, current_uow
@@ -273,14 +275,11 @@ def _resolve_python_type(shim: ResolvedField) -> type | None:
     Unwraps Optional/Union, and normalises generic aliases
     (``list[X]`` → ``list``, ``dict[K,V]`` → ``dict``).
     """
-    import types as _types_mod
-    import typing
-
     python_type = shim._python_type
 
     # Unwrap Optional/Union: str | None → str
     origin = typing.get_origin(python_type)
-    if origin is _types_mod.UnionType or origin is typing.Union:
+    if origin is types.UnionType or origin is typing.Union:
         args = [a for a in typing.get_args(python_type) if a is not type(None)]
         if args:
             python_type = args[0]
@@ -540,8 +539,6 @@ class SqlalchemyModel(orm.DeclarativeBase, BaseDatabaseModel):
     def __init_subclass__(cls, **kwargs):  # noqa: C901
         def field_mapping_for(field_obj):
             """Return SQLAlchemy-equivalent type for Protean's field"""
-            from protean.core.value_object import BaseValueObject
-
             # Handle ResolvedField: resolve Python type → SA type
             if isinstance(field_obj, ResolvedField):
                 if field_obj.increment:
@@ -611,8 +608,6 @@ class SqlalchemyModel(orm.DeclarativeBase, BaseDatabaseModel):
                                 #
                                 # `ValueObject` instances are essentially treated as `Dict`. If not pickled,
                                 #   they are persisted as JSON.
-                                from protean.core.value_object import BaseValueObject
-
                                 _is_vo = isinstance(content_type, ValueObject) or (
                                     isinstance(content_type, type)
                                     and issubclass(content_type, BaseValueObject)
@@ -626,18 +621,15 @@ class SqlalchemyModel(orm.DeclarativeBase, BaseDatabaseModel):
                                     # FieldSpec from Dict() / String() etc.
                                     # Resolve the underlying python_type
                                     # to pick the right SA column type.
-                                    import types as _types
-                                    import typing as _typing
-
                                     ct_type = content_type.python_type
                                     # Unwrap Union types (e.g. dict | list
                                     # from Dict()) to the first branch.
-                                    origin = _typing.get_origin(ct_type)
+                                    origin = typing.get_origin(ct_type)
                                     if (
-                                        origin is _types.UnionType
-                                        or origin is _typing.Union
+                                        origin is types.UnionType
+                                        or origin is typing.Union
                                     ):
-                                        ct_type = _typing.get_args(ct_type)[0]
+                                        ct_type = typing.get_args(ct_type)[0]
                                     field_mapping_type = _PYTHON_TYPE_TO_SA.get(
                                         ct_type, sa_types.String
                                     )
@@ -1991,8 +1983,6 @@ class MSSQLEndswith(MSSQLStringLookupMixin, DefaultLookup):
 
 def register_postgresql() -> None:
     """Register PostgreSQL provider with Protean if sqlalchemy is available."""
-    from protean.port.provider import registry
-
     try:
         import sqlalchemy  # noqa: F401
 
@@ -2009,8 +1999,6 @@ def register_postgresql() -> None:
 
 def register_sqlite() -> None:
     """Register SQLite provider with Protean if sqlalchemy is available."""
-    from protean.port.provider import registry
-
     try:
         import sqlalchemy  # noqa: F401
 
@@ -2027,8 +2015,6 @@ def register_sqlite() -> None:
 
 def register_mssql() -> None:
     """Register MSSQL provider with Protean if sqlalchemy is available."""
-    from protean.port.provider import registry
-
     try:
         import sqlalchemy  # noqa: F401
 

--- a/src/protean/cli/__init__.py
+++ b/src/protean/cli/__init__.py
@@ -24,6 +24,7 @@ import typer
 from rich import print
 from typing_extensions import Annotated
 
+from protean import __version__
 from protean.cli._helpers import CTX_LOG_CONFIGURED  # noqa: F401 — re-exported
 from protean.cli._helpers import cli_exception_handler  # noqa: F401 — re-exported
 from protean.cli._helpers import handle_cli_exceptions  # noqa: F401 — re-exported
@@ -79,8 +80,6 @@ _LOG_FORMATS = ("auto", "console", "json")
 
 def version_callback(value: bool) -> None:
     if value:
-        from protean import __version__
-
         typer.echo(f"Protean {__version__}")
         raise typer.Exit()
 

--- a/src/protean/cli/dlq.py
+++ b/src/protean/cli/dlq.py
@@ -27,6 +27,7 @@ Usage::
 from __future__ import annotations
 
 import json
+from datetime import datetime
 from typing import TYPE_CHECKING
 
 import typer
@@ -114,8 +115,6 @@ def _format_time(raw: str | None) -> str:
     if not raw:
         return "-"
     try:
-        from datetime import datetime
-
         return datetime.fromisoformat(raw).strftime("%Y-%m-%d %H:%M:%S")
     except (ValueError, TypeError):
         return raw

--- a/src/protean/cli/hooks.py
+++ b/src/protean/cli/hooks.py
@@ -58,8 +58,13 @@ import argparse
 import json
 import subprocess
 import sys
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
+
+from protean.exceptions import NoDomainException
+from protean.ir.diff import classify_changes, diff_ir
+from protean.ir.git import GitError
+from protean.ir.staleness import StalenessStatus, check_staleness
 
 
 # ---------------------------------------------------------------------------
@@ -97,7 +102,6 @@ def _resolve_domains(
 
 def _load_live_ir(domain_path: str) -> dict:
     """Load live IR from a domain module without depending on typer."""
-    from protean.exceptions import NoDomainException
     from protean.utils.domain_discovery import derive_domain
 
     try:
@@ -186,9 +190,6 @@ def _check_staleness_single(
     config: Any,
 ) -> bool:
     """Check staleness for a single domain.  Returns ``True`` if OK."""
-    from protean.exceptions import NoDomainException
-    from protean.ir.staleness import StalenessStatus, check_staleness
-
     try:
         result = check_staleness(domain_module, protean_dir, config=config)
     except NoDomainException as exc:
@@ -334,10 +335,7 @@ def _check_compat_single(
     config: Any,
 ) -> bool:
     """Check compat for a single domain.  Returns ``True`` if OK (no block)."""
-    from pathlib import PurePosixPath
-
-    from protean.ir.diff import classify_changes, diff_ir
-    from protean.ir.git import GitError, load_ir_from_commit
+    from protean.ir.git import load_ir_from_commit
 
     ir_path = PurePosixPath(protean_dir, "ir.json").as_posix()
     try:

--- a/src/protean/cli/ir.py
+++ b/src/protean/cli/ir.py
@@ -27,6 +27,7 @@ Usage::
 """
 
 import json
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 import typer
@@ -36,6 +37,11 @@ from rich.table import Table
 from typing_extensions import Annotated
 
 from protean.cli._ir_utils import load_domain_ir, load_ir_file
+from protean.exceptions import NoDomainException
+from protean.ir.config import load_config
+from protean.ir.diff import classify_changes, diff_ir
+from protean.ir.git import GitError
+from protean.ir.staleness import StalenessStatus, check_staleness, load_stored_ir
 
 app = typer.Typer(no_args_is_help=True)
 
@@ -145,9 +151,6 @@ def diff(
       1 — breaking changes found
       2 — non-breaking changes only
     """
-    from protean.ir.config import load_config
-    from protean.ir.diff import classify_changes, diff_ir
-
     # ------------------------------------------------------------------ #
     # Load config                                                          #
     # ------------------------------------------------------------------ #
@@ -250,9 +253,7 @@ def diff(
 
 def _load_ir_from_git(commit: str, protean_dir: str) -> dict[str, Any]:
     """Load .protean/ir.json from a git commit, or abort on error."""
-    from pathlib import PurePosixPath
-
-    from protean.ir.git import GitError, load_ir_from_commit
+    from protean.ir.git import load_ir_from_commit
 
     ir_path = PurePosixPath(protean_dir, "ir.json").as_posix()
     try:
@@ -264,10 +265,6 @@ def _load_ir_from_git(commit: str, protean_dir: str) -> dict[str, Any]:
 
 def _load_auto_baseline(protean_dir: str) -> dict[str, Any]:
     """Load .protean/ir.json from disk, or abort if not found."""
-    from pathlib import Path
-
-    from protean.ir.staleness import load_stored_ir
-
     try:
         stored = load_stored_ir(Path(protean_dir))
     except ValueError as exc:
@@ -511,12 +508,6 @@ def check(
       1 — IR is stale (domain has changed)
       2 — No materialized IR found in the given directory
     """
-    from pathlib import Path
-
-    from protean.exceptions import NoDomainException
-    from protean.ir.config import load_config
-    from protean.ir.staleness import StalenessStatus, check_staleness
-
     try:
         config = load_config(dir)
     except ValueError as exc:
@@ -533,15 +524,13 @@ def check(
         raise typer.Exit(code=2)
 
     if format == "json":
-        import json as _json
-
         payload = {
             "status": result.status.value,
             "domain_checksum": result.domain_checksum,
             "stored_checksum": result.stored_checksum,
             "ir_file": str(result.ir_file) if result.ir_file else None,
         }
-        typer.echo(_json.dumps(payload, indent=2, sort_keys=True))
+        typer.echo(json.dumps(payload, indent=2, sort_keys=True))
     else:
         _print_check_text(result, dir)
 
@@ -556,8 +545,6 @@ def check(
 
 def _print_check_text(result: Any, protean_dir: str = ".protean") -> None:
     """Print a human-readable staleness check result."""
-    from protean.ir.staleness import StalenessStatus
-
     if result.status == StalenessStatus.FRESH:
         print("[green]IR is fresh.[/green]")
         if result.domain_checksum:

--- a/src/protean/cli/observatory.py
+++ b/src/protean/cli/observatory.py
@@ -3,6 +3,7 @@
 import warnings
 from typing import List, Optional
 
+import click
 import typer
 from typing_extensions import Annotated
 
@@ -48,8 +49,6 @@ def observatory(
 
     # Check parent context for CLI-level logging configuration.
     # click.get_current_context may fail when called directly (not via CLI).
-    import click
-
     ctx = click.get_current_context(silent=True)
     parent_obj = getattr(ctx, "obj", None) or {} if ctx else {}
     if not parent_obj.get(CTX_LOG_CONFIGURED):

--- a/src/protean/cli/test.py
+++ b/src/protean/cli/test.py
@@ -1,4 +1,5 @@
 import os
+import re
 import subprocess
 import sys
 import time
@@ -8,13 +9,13 @@ from contextlib import suppress
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
-
-if TYPE_CHECKING:
-    from protean.port.provider import DatabaseCapabilities
+from typing import Optional
 
 import typer
 from typing_extensions import Annotated
+
+from protean.domain import Domain
+from protean.port.provider import DatabaseCapabilities, ProviderRegistry
 
 # Configuration constants
 REPORT_PATH = Path("diff_coverage_report.html")
@@ -577,8 +578,6 @@ def _provider_has_capability_for_marker(
     For ``transactional``, the provider needs TRANSACTIONS or SIMULATED_TRANSACTIONS.
     For all other markers, ALL listed capability flags must be present.
     """
-    from protean.port.provider import DatabaseCapabilities
-
     flag_names = CAPABILITY_MARKER_MAP.get(marker_name, [])
     if not flag_names:
         return False
@@ -657,8 +656,6 @@ def _run_pytest_for_marker(
         # Match pytest summary lines like "42 passed", "3 failed, 2 passed"
         if "passed" in line or "failed" in line or "error" in line:
             # This is likely the summary line
-            import re
-
             counts = re.findall(r"(\d+) (\w+)", line)
             for count_str, label in counts:
                 count = int(count_str)
@@ -786,8 +783,6 @@ def test_adapter(
 
         protean test test-adapter --provider=postgresql --uri="postgresql://localhost/test" -v
     """
-    from protean.port.provider import ProviderRegistry
-
     # 1. Verify provider is registered
     try:
         ProviderRegistry.get(provider)
@@ -798,8 +793,6 @@ def test_adapter(
     # 2. Get provider capabilities (instantiate temporarily to access property)
     #    We need a minimal domain to instantiate the provider for capabilities
     try:
-        from protean.domain import Domain
-
         domain = Domain(name="ConformanceTest")
 
         # Configure the provider

--- a/src/protean/cli/test.py
+++ b/src/protean/cli/test.py
@@ -9,13 +9,13 @@ from contextlib import suppress
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import typer
 from typing_extensions import Annotated
 
-from protean.domain import Domain
-from protean.port.provider import DatabaseCapabilities, ProviderRegistry
+if TYPE_CHECKING:
+    from protean.port.provider import DatabaseCapabilities
 
 # Configuration constants
 REPORT_PATH = Path("diff_coverage_report.html")
@@ -578,6 +578,8 @@ def _provider_has_capability_for_marker(
     For ``transactional``, the provider needs TRANSACTIONS or SIMULATED_TRANSACTIONS.
     For all other markers, ALL listed capability flags must be present.
     """
+    from protean.port.provider import DatabaseCapabilities
+
     flag_names = CAPABILITY_MARKER_MAP.get(marker_name, [])
     if not flag_names:
         return False
@@ -783,6 +785,9 @@ def test_adapter(
 
         protean test test-adapter --provider=postgresql --uri="postgresql://localhost/test" -v
     """
+    from protean.domain import Domain
+    from protean.port.provider import ProviderRegistry
+
     # 1. Verify provider is registered
     try:
         ProviderRegistry.get(provider)

--- a/src/protean/core/aggregate.py
+++ b/src/protean/core/aggregate.py
@@ -5,11 +5,16 @@ import inspect
 import logging
 import typing
 from collections import defaultdict
+from enum import Enum
+from functools import partial
 from typing import Any, ClassVar, Optional, TypeVar, cast
 
+from pydantic import Field as PydanticField
 from pydantic import PrivateAttr
+from pydantic_core import PydanticUndefined
 
-from protean.core.entity import BaseEntity
+from protean.core.entity import BaseEntity, _EntityState
+from protean.core.value_object import value_object_from_entity
 from protean.fields.tempdata import AssociationCache
 from protean.core.event import BaseEvent
 from protean.fields.resolved import ResolvedField
@@ -17,6 +22,7 @@ from protean.exceptions import (
     ConfigurationError,
     IncorrectUsageError,
     NotSupportedError,
+    ValidationError,
 )
 from protean.fields import HasMany, HasOne, Reference, ValueObject
 from protean.fields.basic import ValueObjectList
@@ -25,11 +31,20 @@ from protean.utils import (
     Processing,
     derive_element_class,
     fqn,
+    generate_identity,
     inflection,
 )
 from protean.utils.eventing import DomainMeta, MessageEnvelope, MessageHeaders, Metadata
 from protean.utils.globals import current_domain
-from protean.utils.reflection import _FIELDS, _ID_FIELD_NAME, fields
+from protean.utils.reflection import (
+    _FIELDS,
+    _ID_FIELD_NAME,
+    association_fields,
+    fields,
+    reference_fields,
+    value_object_fields,
+)
+from protean.utils.telemetry import inject_traceparent_from_context
 
 logger = logging.getLogger(__name__)
 
@@ -188,8 +203,6 @@ class BaseAggregate(BaseEntity):
             else None
         )
         if traceparent is None:
-            from protean.utils.telemetry import inject_traceparent_from_context
-
             traceparent = inject_traceparent_from_context()
 
         headers = MessageHeaders(
@@ -293,14 +306,6 @@ class BaseAggregate(BaseEntity):
 
         Follows the same pattern as ``BaseEntity.__deepcopy__`` (entity.py).
         """
-        from functools import partial
-
-        from protean.core.entity import _EntityState
-        from protean.utils.reflection import (
-            association_fields,
-            reference_fields,
-            value_object_fields,
-        )
 
         aggregate = cls.__new__(cls)
 
@@ -387,8 +392,6 @@ class BaseAggregate(BaseEntity):
             order = Order._create_new()
             order.raise_(OrderCreated(order_id=str(order.id), ...))
         """
-        from protean.utils import generate_identity
-
         aggregate = cls._create_for_reconstitution()
         aggregate._disable_invariant_checks = False  # Enable for live path
 
@@ -448,11 +451,6 @@ def element_to_fact_event(element_cls):
 
 def _pydantic_element_to_fact_event(element_cls):
     """Pydantic path: create fact events using Pydantic annotations and BaseModel."""
-    from pydantic import Field as PydanticField
-    from pydantic_core import PydanticUndefined
-
-    from protean.core.value_object import value_object_from_entity
-
     if element_cls.element_type == DomainObjects.ENTITY:
         # Entity → Value Object: delegate to the shared utility
         vo_cls = value_object_from_entity(element_cls)
@@ -626,10 +624,6 @@ class atomic_change:
 
     def _validate_status_transitions(self) -> None:
         """Validate start-to-end status transitions within the atomic block."""
-        from enum import Enum
-
-        from protean.exceptions import ValidationError
-
         fields_dict = getattr(self.aggregate.__class__, _FIELDS, {})
 
         for fname, start_value in self._status_snapshots.items():

--- a/src/protean/core/entity.py
+++ b/src/protean/core/entity.py
@@ -1,14 +1,19 @@
 """Entity module providing the base class for entity domain elements."""
 
+import copy
 import functools
 import logging
 import threading
 from collections import defaultdict
+from enum import Enum
 from functools import partial
 from typing import TYPE_CHECKING, Any, ClassVar, Self, TypeVar, dataclass_transform
+from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, PrivateAttr
+from pydantic import Field as PydanticField
 from pydantic import ValidationError as PydanticValidationError
+from pydantic.fields import FieldInfo
 
 from protean.exceptions import (
     ConfigurationError,
@@ -17,7 +22,7 @@ from protean.exceptions import (
     NotSupportedError,
     ValidationError,
 )
-from protean.fields.resolved import ResolvedField
+from protean.fields.resolved import ResolvedField, convert_pydantic_errors
 from protean.integrations.logging import (
     SECURITY_EVENT_INVARIANT_FAILED,
     log_security_event,
@@ -29,7 +34,7 @@ from protean.fields import (
     ValueObject,
 )
 from protean.fields.basic import ValueObjectList
-from protean.fields.spec import FieldSpec
+from protean.fields.spec import FieldSpec, resolve_fieldspecs
 from protean.fields.association import Association, _ReferenceField
 from protean.fields.tempdata import AssociationCache
 from protean.fields.embedded import _ShadowField
@@ -233,8 +238,6 @@ class BaseEntity(BaseModel, OptionsMixin):
 
     @classmethod
     def _resolve_fieldspecs(cls) -> None:
-        from protean.fields.spec import resolve_fieldspecs
-
         # Migrate annotation-style descriptors to the class namespace.
         #
         # Python puts ``field: Descriptor()`` values into ``__annotations__``
@@ -269,9 +272,6 @@ class BaseEntity(BaseModel, OptionsMixin):
           ``__auto_id_handled__``), where id injection is already handled
           and respects the ``auto_add_id_field`` option.
         """
-        from pydantic import Field as PydanticField
-        from pydantic.fields import FieldInfo
-
         # Skip the framework base classes themselves
         if cls.__name__ in ("BaseEntity", "BaseAggregate"):
             return
@@ -311,8 +311,6 @@ class BaseEntity(BaseModel, OptionsMixin):
 
         # No identifier found — inject auto-id
         if "id" not in own_annots:
-            from uuid import UUID
-
             annots = dict(own_annots)
             annots["id"] = str | int | UUID
             cls.__annotations__ = annots
@@ -468,8 +466,6 @@ class BaseEntity(BaseModel, OptionsMixin):
         try:
             super().__init__(**kwargs)
         except PydanticValidationError as e:
-            from protean.fields.resolved import convert_pydantic_errors
-
             collected_errors.update(convert_pydantic_errors(e))
 
         # Check required descriptor fields (ValueObject, Reference, etc.)
@@ -754,7 +750,6 @@ class BaseEntity(BaseModel, OptionsMixin):
         Skipped during ``atomic_change`` (deferred to ``__exit__``),
         ``from_events`` replay, and initial construction.
         """
-        from enum import Enum
 
         fields_dict = getattr(self.__class__, _FIELDS, {})
         field_obj = fields_dict.get(field_name)
@@ -815,7 +810,6 @@ class BaseEntity(BaseModel, OptionsMixin):
             if order.can_transition_to("status", OrderStatus.SHIPPED):
                 order.ship(tracking_number="ABC123")
         """
-        from enum import Enum
 
         fields_dict = getattr(self.__class__, _FIELDS, {})
         field_obj = fields_dict.get(field_name)
@@ -867,8 +861,6 @@ class BaseEntity(BaseModel, OptionsMixin):
             try:
                 super().__setattr__(name, value)
             except PydanticValidationError as e:
-                from protean.fields.resolved import convert_pydantic_errors
-
                 raise ValidationError(convert_pydantic_errors(e))
 
             # Post-check invariants
@@ -1035,8 +1027,6 @@ class BaseEntity(BaseModel, OptionsMixin):
         __pydantic_private__ contains back-references to the entity
         itself (e.g. _root and _owner on aggregate roots).
         """
-        import copy
-
         if memo is None:
             memo = {}
 

--- a/src/protean/core/event.py
+++ b/src/protean/core/event.py
@@ -23,6 +23,7 @@ from protean.utils.eventing import (
     Metadata,
 )
 from protean.utils.globals import g
+from protean.utils.telemetry import inject_traceparent_from_context
 
 logger = logging.getLogger(__name__)
 
@@ -162,8 +163,6 @@ class BaseEvent(BaseMessageType):
         else:
             # Inject the current OTEL span context as traceparent so that
             # events raised during handler execution carry the trace forward.
-            from protean.utils.telemetry import inject_traceparent_from_context
-
             traceparent = inject_traceparent_from_context()
             headers = MessageHeaders(
                 type=self.__class__.__type__,

--- a/src/protean/core/index.py
+++ b/src/protean/core/index.py
@@ -19,6 +19,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from protean.exceptions import IncorrectUsageError
+from protean.utils.reflection import attributes, fields
+
 if TYPE_CHECKING:
     from protean.utils.query import Q
 
@@ -144,9 +147,6 @@ def validate_indexes(element_cls: type) -> None:
 
     :class:`RawIndex` entries are opaque verbatim DDL and are not introspected.
     """
-    from protean.exceptions import IncorrectUsageError
-    from protean.utils.reflection import attributes, fields
-
     meta = getattr(element_cls, "meta_", None)
     indexes = getattr(meta, "indexes", ()) or ()
 

--- a/src/protean/core/process_manager.py
+++ b/src/protean/core/process_manager.py
@@ -32,12 +32,13 @@ from pydantic import BaseModel, ConfigDict, PrivateAttr
 from pydantic_core import PydanticUndefined
 
 from protean.core.event import BaseEvent
+from protean.core.unit_of_work import UnitOfWork
 from protean.exceptions import (
     ConfigurationError,
     NotSupportedError,
 )
 from protean.fields.resolved import ResolvedField
-from protean.fields.spec import FieldSpec
+from protean.fields.spec import FieldSpec, resolve_fieldspecs
 from protean.utils import (
     DomainObjects,
     derive_element_class,
@@ -193,8 +194,6 @@ class BaseProcessManager(BaseModel, HandlerMixin, OptionsMixin):
 
     @classmethod
     def _resolve_fieldspecs(cls) -> None:
-        from protean.fields.spec import resolve_fieldspecs
-
         resolve_fieldspecs(cls)
 
     @classmethod
@@ -306,8 +305,6 @@ class BaseProcessManager(BaseModel, HandlerMixin, OptionsMixin):
         the handler method on that instance, then persists the resulting
         state as a transition event in the PM's own event store stream.
         """
-        from protean.core.unit_of_work import UnitOfWork
-
         # Deserialize
         item = item.to_domain_object() if isinstance(item, Message) else item
 

--- a/src/protean/core/projection.py
+++ b/src/protean/core/projection.py
@@ -17,7 +17,7 @@ from protean.exceptions import (
 )
 from protean.fields import HasMany, HasOne, Reference, ValueObject
 from protean.fields.association import Association
-from protean.fields.spec import FieldSpec
+from protean.fields.spec import FieldSpec, resolve_fieldspecs
 from protean.utils import (
     DomainObjects,
     derive_element_class,
@@ -137,8 +137,6 @@ class BaseProjection(BaseModel, OptionsMixin):
 
     @classmethod
     def _resolve_fieldspecs(cls) -> None:
-        from protean.fields.spec import resolve_fieldspecs
-
         # Migrate annotation-style ValueObject descriptors to the class namespace.
         # Python puts ``field: ValueObject(Email)`` values into __annotations__
         # (not vars(cls)).  Pydantic and __pydantic_init_subclass__ scan vars(cls)

--- a/src/protean/core/query.py
+++ b/src/protean/core/query.py
@@ -20,7 +20,7 @@ from protean.fields.association import Association, Reference
 from protean.fields.base import FieldBase
 from protean.fields.embedded import ValueObject as ValueObjectField
 from protean.fields.resolved import ResolvedField, convert_pydantic_errors
-from protean.fields.spec import FieldSpec
+from protean.fields.spec import FieldSpec, resolve_fieldspecs
 from protean.utils import DomainObjects, derive_element_class
 from protean.utils.container import OptionsMixin
 from protean.utils.reflection import _FIELDS
@@ -145,8 +145,6 @@ class BaseQuery(BaseModel, OptionsMixin):
 
     @classmethod
     def _resolve_fieldspecs(cls) -> None:
-        from protean.fields.spec import resolve_fieldspecs
-
         resolve_fieldspecs(cls)
 
     @classmethod

--- a/src/protean/core/repository.py
+++ b/src/protean/core/repository.py
@@ -2,6 +2,7 @@ import logging
 from functools import lru_cache
 from typing import Any, TYPE_CHECKING, TypeVar
 
+from protean.core.aggregate import BaseAggregate
 from protean.core.unit_of_work import UnitOfWork
 from protean.exceptions import IncorrectUsageError, NotSupportedError
 from protean.fields import HasMany, HasOne
@@ -15,7 +16,7 @@ from protean.utils import (
     fully_qualified_name,
 )
 from protean.utils.container import Element, OptionsMixin
-from protean.utils.globals import current_uow
+from protean.utils.globals import current_uow, g
 from protean.utils.query import Q
 from protean.utils.reflection import association_fields, has_association_fields
 from protean.utils.telemetry import set_span_error
@@ -198,8 +199,6 @@ class BaseRepository(Element, OptionsMixin):
         """
         # Increment access log repo save counter
         try:
-            from protean.utils.globals import g
-
             g._access_log_repo_saves = getattr(g, "_access_log_repo_saves", 0) + 1
         except Exception:
             pass
@@ -411,8 +410,6 @@ class BaseRepository(Element, OptionsMixin):
         """
         # Increment access log repo load counter
         try:
-            from protean.utils.globals import g
-
             g._access_log_repo_loads = getattr(g, "_access_log_repo_loads", 0) + 1
         except Exception:
             pass
@@ -440,8 +437,6 @@ _T = TypeVar("_T")
 
 
 def repository_factory(element_cls: type[_T], domain: Any, **opts: Any) -> type[_T]:
-    from protean.core.aggregate import BaseAggregate
-
     # Pop internal flag before passing opts to derive_element_class,
     # which validates that all options are known element options.
     auto_constructed = opts.pop("_auto_constructed", False)

--- a/src/protean/core/unit_of_work.py
+++ b/src/protean/core/unit_of_work.py
@@ -10,7 +10,8 @@ from protean.exceptions import (
 )
 from protean.port.provider import DatabaseCapabilities
 from protean.utils import Processing
-from protean.utils.globals import _uow_context_stack, current_domain
+from protean.utils.globals import _uow_context_stack, current_domain, g
+from protean.utils.processing import current_priority
 from protean.utils.reflection import id_field
 from protean.utils.telemetry import get_domain_metrics, set_span_error
 
@@ -134,8 +135,6 @@ class UnitOfWork:
             set_status_on_exception=False,
         ) as span:
             # Propagate correlation and causation IDs from the message being processed
-            from protean.utils.globals import g
-
             msg = g.get("message_in_context")
             if msg is not None and hasattr(msg, "metadata") and msg.metadata:
                 domain_meta = getattr(msg.metadata, "domain", None)
@@ -152,9 +151,7 @@ class UnitOfWork:
 
     def _do_commit(self, span: Any) -> None:  # noqa: C901
         """Internal commit logic wrapped by the ``protean.uow.commit`` span."""
-        from protean.utils.globals import g
         from protean.utils.outbox import Outbox
-        from protean.utils.processing import current_priority
 
         # Gather all events from identity map using helper method
         all_events = self._gather_events()
@@ -377,8 +374,6 @@ class UnitOfWork:
 
         # Record UoW outcome for the access log wide event
         try:
-            from protean.utils.globals import g
-
             g._access_log_uow_outcome = "rolled_back"
         except Exception:
             pass
@@ -391,7 +386,7 @@ class UnitOfWork:
                 session.rollback()
 
             logger.debug("uow.rollback_successful")
-        except Exception as exc:
+        except Exception:
             logger.exception("uow.rollback_failed")
 
         self._reset()

--- a/src/protean/core/upcaster.py
+++ b/src/protean/core/upcaster.py
@@ -16,7 +16,9 @@ import logging
 from abc import abstractmethod
 from typing import Any, TypeVar
 
+from protean.core.event import BaseEvent
 from protean.exceptions import IncorrectUsageError, NotSupportedError
+from protean.utils import derive_element_class
 from protean.utils.container import Element, OptionsMixin
 
 logger = logging.getLogger(__name__)
@@ -69,9 +71,6 @@ _T = TypeVar("_T")
 
 def upcaster_factory(element_cls: type[_T], domain: Any, **opts: Any) -> type[_T]:
     """Validate and derive an upcaster class from *element_cls*."""
-    from protean.core.event import BaseEvent
-    from protean.utils import derive_element_class
-
     element_cls = derive_element_class(element_cls, BaseUpcaster, **opts)
 
     # --- Validate required options ---

--- a/src/protean/core/value_object.py
+++ b/src/protean/core/value_object.py
@@ -2,7 +2,7 @@
 
 import logging
 from collections import defaultdict
-from typing import Any, ClassVar, Optional, Self, TypeVar
+from typing import Annotated, Any, ClassVar, Optional, Self, TypeVar
 
 from pydantic import BaseModel, ConfigDict
 from pydantic import Field as PydanticField
@@ -15,9 +15,11 @@ from protean.exceptions import (
     ValidationError,
 )
 from protean.fields.association import HasMany, HasOne, Reference
+from protean.fields.basic import ValueObjectList
+from protean.fields.embedded import ValueObject as ValueObjectDescriptor
 from protean.fields.embedded import ValueObject as ValueObjectField
 from protean.fields.resolved import ResolvedField, convert_pydantic_errors
-from protean.fields.spec import FieldSpec
+from protean.fields.spec import FieldSpec, resolve_fieldspecs
 from protean.utils import DomainObjects, derive_element_class
 from protean.utils.container import OptionsMixin
 from protean.utils.reflection import _FIELDS, fields as get_fields
@@ -92,13 +94,6 @@ class BaseValueObject(BaseModel, OptionsMixin):
 
     @classmethod
     def _resolve_fieldspecs(cls) -> None:
-        from typing import Annotated, Optional
-
-        from pydantic import Field as PydanticField
-
-        from protean.fields.embedded import ValueObject as ValueObjectDescriptor
-        from protean.fields.spec import FieldSpec, resolve_fieldspecs
-
         # Validate VO constraints BEFORE resolving FieldSpecs
         # Check both vars(cls) (assignment style) and __annotations__ (annotation style)
         def _validate_fieldspec(name: str, value: FieldSpec) -> None:
@@ -363,8 +358,6 @@ def value_object_from_entity(
     Returns:
         A new ``BaseValueObject`` subclass.
     """
-    from protean.fields.basic import ValueObjectList
-
     exclude = exclude or set()
     vo_name = name or f"{entity_cls.__name__}ValueObject"
 

--- a/src/protean/core/view.py
+++ b/src/protean/core/view.py
@@ -8,12 +8,12 @@
 import logging
 from typing import TYPE_CHECKING, Any
 
+from protean.core.queryset import ReadOnlyQuerySet
 from protean.exceptions import NotSupportedError, ObjectNotFoundError
 from protean.utils.inflection import underscore
 
 if TYPE_CHECKING:
     from protean.core.projection import BaseProjection
-    from protean.core.queryset import ReadOnlyQuerySet
     from protean.domain import Domain
 
 logger = logging.getLogger(__name__)
@@ -66,8 +66,6 @@ class ReadView:
         Only available for database-backed projections.  Cache-backed
         projections raise ``NotSupportedError``.
         """
-        from protean.core.queryset import ReadOnlyQuerySet
-
         if self._is_cache_backed:
             raise NotSupportedError(
                 f"Querying with filters is not supported for cache-backed "

--- a/src/protean/domain/__init__.py
+++ b/src/protean/domain/__init__.py
@@ -49,9 +49,11 @@ Supporting classes (in the same package):
 * ``DomainContext``     — thread-local context binding (``context.py``)
 """
 
+import importlib.util
 import inspect
 import logging
 import os
+import pathlib
 import sys
 from collections import defaultdict
 from datetime import datetime, timedelta
@@ -73,20 +75,33 @@ from typing import (
 )
 
 if TYPE_CHECKING:
-    from protean.core.view import ReadView
-    from protean.port.event_store import CausationNode
     from protean.utils.projection_rebuilder import RebuildResult
 
 from inflection import parameterize, titleize, transliterate, underscore
 
 from protean.adapters import Brokers, Caches, EmailProviders, Providers
 from protean.adapters.event_store import EventStore
-from protean.core.command import BaseCommand
-from protean.core.command_handler import BaseCommandHandler
-from protean.core.database_model import BaseDatabaseModel
-from protean.core.event import BaseEvent
-from protean.core.projection import BaseProjection
-from protean.core.repository import BaseRepository
+from protean.core.aggregate import aggregate_factory
+from protean.core.application_service import application_service_factory
+from protean.core.command import BaseCommand, command_factory
+from protean.core.command_handler import BaseCommandHandler, command_handler_factory
+from protean.core.database_model import BaseDatabaseModel, database_model_factory
+from protean.core.domain_service import domain_service_factory
+from protean.core.email import email_factory
+from protean.core.entity import entity_factory
+from protean.core.event import BaseEvent, domain_event_factory
+from protean.core.event_handler import event_handler_factory
+from protean.core.event_sourced_repository import event_sourced_repository_factory
+from protean.core.process_manager import process_manager_factory
+from protean.core.projection import BaseProjection, projection_factory
+from protean.core.projector import projector_factory
+from protean.core.query import query_factory
+from protean.core.query_handler import query_handler_factory
+from protean.core.repository import BaseRepository, repository_factory
+from protean.core.subscriber import subscriber_factory
+from protean.core.upcaster import upcaster_factory
+from protean.core.value_object import value_object_factory
+from protean.core.view import ReadView
 from protean.domain.registry import _DomainRegistry
 from protean.exceptions import (
     ConfigurationError,
@@ -112,6 +127,15 @@ from protean.fields import (
     ValueObject,
 )
 from protean.fields.basic import ValueObjectList
+from protean.integrations.logging import (
+    OTelTraceContextFilter,
+    ProteanCorrelationFilter,
+    protean_correlation_processor,
+    protean_otel_processor,
+)
+from protean.ir.builder import IRBuilder
+from protean.port.event_store import CausationNode
+from protean.server.tracing import TraceEmitter
 from protean.utils import (
     DomainObjects,
     Processing as Processing,
@@ -119,7 +143,22 @@ from protean.utils import (
 )
 from protean.utils.container import Element
 from protean.utils.idempotency import IdempotencyStore
+from protean.utils.logging import (
+    TailSamplingFilter,
+    TailSamplingProcessor,
+    access_logger,
+    configure_logging,
+)
+from protean.utils.projection_rebuilder import (
+    rebuild_all_projections,
+    rebuild_projection,
+)
 from protean.utils.reflection import declared_fields, has_fields
+from protean.utils.telemetry import (
+    get_meter,
+    get_tracer,
+    init_telemetry,
+)
 
 from .config import Config2, ConfigAttribute
 from .context import DomainContext, _DomainContextGlobals
@@ -426,8 +465,6 @@ class Domain:
         in the Observatory dashboard.
         """
         if self._trace_emitter is None:
-            from protean.server.tracing import TraceEmitter
-
             observatory_config = self.config.get("observatory", {})
             try:
                 trace_retention_days = int(
@@ -448,8 +485,6 @@ class Domain:
         telemetry is enabled. Returns a no-op tracer when telemetry is
         disabled or the ``opentelemetry`` packages are not installed.
         """
-        from protean.utils.telemetry import get_tracer, init_telemetry
-
         if not self._otel_init_attempted:
             init_telemetry(self)
         return get_tracer(self)
@@ -462,8 +497,6 @@ class Domain:
         telemetry is enabled. Returns a no-op meter when telemetry is
         disabled or the ``opentelemetry`` packages are not installed.
         """
-        from protean.utils.telemetry import get_meter, init_telemetry
-
         if not self._otel_init_attempted:
             init_telemetry(self)
         return get_meter(self)
@@ -696,11 +729,6 @@ class Domain:
         }
 
     def _traverse(self):
-        # Standard Library Imports
-        import importlib.util
-        import os
-        import pathlib
-
         # Ensure root_path is a directory path
         root_path = Path(self.root_path)
         if root_path.is_file():
@@ -903,29 +931,6 @@ class Domain:
         return self._domain_registry
 
     def factory_for(self, domain_object_type):
-        from protean.core.aggregate import aggregate_factory
-        from protean.core.application_service import application_service_factory
-        from protean.core.command import command_factory
-        from protean.core.command_handler import command_handler_factory
-        from protean.core.database_model import database_model_factory
-        from protean.core.domain_service import domain_service_factory
-        from protean.core.email import email_factory
-        from protean.core.entity import entity_factory
-        from protean.core.event import domain_event_factory
-        from protean.core.event_handler import event_handler_factory
-        from protean.core.event_sourced_repository import (
-            event_sourced_repository_factory,
-        )
-        from protean.core.projection import projection_factory
-        from protean.core.projector import projector_factory
-        from protean.core.query import query_factory
-        from protean.core.query_handler import query_handler_factory
-        from protean.core.repository import repository_factory
-        from protean.core.subscriber import subscriber_factory
-        from protean.core.value_object import value_object_factory
-
-        from protean.core.process_manager import process_manager_factory
-
         factories = {
             DomainObjects.AGGREGATE.value: aggregate_factory,
             DomainObjects.APPLICATION_SERVICE.value: application_service_factory,
@@ -1276,8 +1281,6 @@ class Domain:
         The domain must be initialised (``init()`` called) before invoking
         this method.
         """
-        from protean.ir.builder import IRBuilder
-
         return IRBuilder(self).build()
 
     ######################
@@ -1579,7 +1582,6 @@ class Domain:
                     data["currency"] = "USD"
                     return data
         """
-        from protean.core.upcaster import upcaster_factory
 
         def wrap(cls: type) -> type:
             new_cls = upcaster_factory(cls, self, **kwargs)
@@ -1824,8 +1826,6 @@ class Domain:
             order = view.get("order-123")
             results = view.query.filter(status="shipped").all()
         """
-        from protean.core.view import ReadView
-
         if isinstance(projection_cls, str):
             raise IncorrectUsageError(
                 f"Element {projection_cls} is not registered in domain {self.name}"
@@ -2006,8 +2006,6 @@ class Domain:
             return []
 
         # Flatten tree via depth-first pre-order traversal
-        from protean.port.event_store import CausationNode
-
         result: list[CausationNode] = []
 
         def _walk(node: CausationNode) -> None:
@@ -2041,8 +2039,6 @@ class Domain:
         Returns:
             RebuildResult with counts and any errors.
         """
-        from protean.utils.projection_rebuilder import rebuild_projection
-
         return rebuild_projection(self, projection_cls, batch_size)
 
     def rebuild_all_projections(
@@ -2059,8 +2055,6 @@ class Domain:
         Returns:
             Dictionary mapping projection class names to their RebuildResult.
         """
-        from protean.utils.projection_rebuilder import rebuild_all_projections
-
         return rebuild_all_projections(self, batch_size)
 
     #######################
@@ -2154,19 +2148,6 @@ class Domain:
             domain.configure_logging()           # sensible defaults
             domain.configure_logging(level="DEBUG", format="json")
         """
-        from protean.integrations.logging import (
-            OTelTraceContextFilter,
-            ProteanCorrelationFilter,
-            protean_correlation_processor,
-            protean_otel_processor,
-        )
-        from protean.utils.logging import (
-            TailSamplingFilter,
-            TailSamplingProcessor,
-            access_logger,
-            configure_logging,
-        )
-
         # --- Merge domain.toml [logging] with explicit kwargs ---
         logging_config = self.config.get("logging", {})
         telemetry_enabled = bool(self.config.get("telemetry", {}).get("enabled"))

--- a/src/protean/domain/command_processor.py
+++ b/src/protean/domain/command_processor.py
@@ -27,6 +27,7 @@ from protean.integrations.logging import (
 from protean.utils import DomainObjects, Processing, fqn
 from protean.utils.eventing import (
     DomainMeta,
+    Message,
     MessageEnvelope,
     MessageHeaders,
     Metadata,
@@ -34,8 +35,14 @@ from protean.utils.eventing import (
     new_correlation_id,
 )
 from protean.utils.globals import g
+from protean.utils.processing import current_priority, processing_priority
 from protean.utils.reflection import id_field
-from protean.utils.telemetry import get_domain_metrics
+from protean.utils.telemetry import (
+    extract_context_from_traceparent,
+    get_domain_metrics,
+    inject_traceparent_from_context,
+    set_span_error,
+)
 
 if TYPE_CHECKING:
     from protean.domain import Domain
@@ -136,8 +143,6 @@ class CommandProcessor:
         deadline: Optional[datetime] = None,
     ) -> BaseCommand:
         """Enrich a command with metadata (stream, type, headers, etc.)."""
-        from protean.utils.telemetry import inject_traceparent_from_context
-
         tracer = self._domain.tracer
         with tracer.start_as_current_span("protean.command.enrich") as span:
             span.set_attribute("protean.command.type", command.__class__.__type__)
@@ -312,11 +317,6 @@ class CommandProcessor:
         Returns:
             Optional[Any]: Returns either the command handler's return value or nothing, based on preference.
         """
-        from protean.utils.eventing import Message
-        from protean.utils.processing import current_priority, processing_priority
-
-        from protean.utils.telemetry import extract_context_from_traceparent
-
         domain = self._domain
         tracer = domain.tracer
         metrics = get_domain_metrics(domain)
@@ -462,8 +462,6 @@ class CommandProcessor:
                         duration_s = time.monotonic() - process_start
 
                         # Record exception on the OTEL span
-                        from protean.utils.telemetry import set_span_error
-
                         set_span_error(span, exc)
 
                         # Record OTel metrics for failed command

--- a/src/protean/domain/config.py
+++ b/src/protean/domain/config.py
@@ -7,7 +7,7 @@ import tomllib
 
 from protean.exceptions import ConfigurationError
 from protean.integrations.logging import DEFAULT_REDACT_KEYS
-from protean.utils import Processing
+from protean.utils import IdentityStrategy, IdentityType, Processing
 
 logger = logging.getLogger(__name__)
 
@@ -20,8 +20,6 @@ def _default_config():
     directly in tests. Housing it within the main `Domain` class can
     potentially lead to issues because the config can be overwritten by accident.
     """
-    from protean.utils import IdentityStrategy, IdentityType
-
     return {
         "env": None,
         "testing": None,

--- a/src/protean/domain/handler_setup.py
+++ b/src/protean/domain/handler_setup.py
@@ -14,6 +14,8 @@ from typing import TYPE_CHECKING
 
 from protean.core.command import BaseCommand
 from protean.core.event import BaseEvent
+from protean.core.process_manager import _generate_pm_transition_event
+from protean.core.query import BaseQuery
 from protean.exceptions import IncorrectUsageError, NotSupportedError
 from protean.utils import DomainObjects
 
@@ -182,8 +184,6 @@ class HandlerConfigurator:
         """Discover ``@handle``-decorated methods in process managers,
         validate them, generate transition events, and infer stream categories.
         """
-        from protean.core.process_manager import _generate_pm_transition_event
-
         registry = self._domain._domain_registry
         for _, element in registry._elements[
             DomainObjects.PROCESS_MANAGER.value
@@ -325,8 +325,6 @@ class HandlerConfigurator:
         method_name: str, method: object, handler_cls: type
     ) -> None:
         """Validate a single query handler method's target."""
-        from protean.core.query import BaseQuery
-
         if not inspect.isclass(method._target_cls) or not issubclass(
             method._target_cls, BaseQuery
         ):

--- a/src/protean/domain/query_processor.py
+++ b/src/protean/domain/query_processor.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from protean.core.query import BaseQuery
 from protean.exceptions import IncorrectUsageError
 from protean.utils import DomainObjects, fqn
 
@@ -46,8 +47,6 @@ class QueryProcessor:
             IncorrectUsageError: If *query* is not a registered query or
                 no handler is registered.
         """
-        from protean.core.query import BaseQuery
-
         if not isinstance(query, BaseQuery):
             raise IncorrectUsageError(f"`{query.__class__.__name__}` is not a Query")
 

--- a/src/protean/domain/resolver.py
+++ b/src/protean/domain/resolver.py
@@ -11,6 +11,9 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from protean.core.aggregate import BaseAggregate
+from protean.core.command_handler import derive_command_stream_category
+from protean.core.process_manager import BaseProcessManager
 from protean.exceptions import ConfigurationError, NotSupportedError
 from protean.utils import DomainObjects
 
@@ -114,10 +117,6 @@ class ElementResolver:
         """
         element_type = cls.element_type
         if element_type == DomainObjects.COMMAND_HANDLER:
-            # Imported lazily to avoid a core <-> domain import cycle, matching
-            # the function-local imports used elsewhere in this module.
-            from protean.core.command_handler import derive_command_stream_category
-
             cls.meta_.stream_category = derive_command_stream_category(aggregate_cls)
         elif element_type == DomainObjects.EVENT_HANDLER:
             # Respect an explicitly configured stream_category; only derive
@@ -127,9 +126,6 @@ class ElementResolver:
 
     def assign_aggregate_clusters(self) -> None:
         """Assign aggregate clusters to all relevant elements."""
-        from protean.core.aggregate import BaseAggregate
-        from protean.core.process_manager import BaseProcessManager
-
         registry = self._domain._domain_registry
 
         # Assign Aggregates and Process Managers to their own cluster

--- a/src/protean/domain/type_manager.py
+++ b/src/protean/domain/type_manager.py
@@ -15,6 +15,7 @@ from protean.core.command import BaseCommand
 from protean.core.event import BaseEvent
 from protean.exceptions import IncorrectUsageError
 from protean.utils import DomainObjects
+from protean.utils.upcasting import UpcasterChain
 
 if TYPE_CHECKING:
     from protean.domain import Domain
@@ -35,8 +36,6 @@ class TypeManager:
     """
 
     def __init__(self, domain: Domain) -> None:
-        from protean.utils.upcasting import UpcasterChain
-
         self._domain = domain
         self.events_and_commands: Dict[str, Union[BaseCommand, BaseEvent]] = {}
         self.upcasters: list[type] = []

--- a/src/protean/domain/validation.py
+++ b/src/protean/domain/validation.py
@@ -11,6 +11,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from protean.core.index import validate_indexes
+from protean.domain.helpers import get_env
 from protean.exceptions import ConfigurationError, IncorrectUsageError
 from protean.fields import HasMany, HasOne
 from protean.utils import DomainObjects, fqn
@@ -496,8 +497,6 @@ class DomainValidator:
         Skipped when ``PROTEAN_ENV`` is ``development`` or ``testing``,
         where small pools are intentional.
         """
-        from protean.domain.helpers import get_env
-
         env = get_env()
         if env in ("development", "testing"):
             return

--- a/src/protean/ext/mypy_plugin.py
+++ b/src/protean/ext/mypy_plugin.py
@@ -51,6 +51,7 @@ from mypy.nodes import (
     ARG_POS,
     MDEF,
     Argument,
+    AssignmentStmt,
     Block,
     CallExpr,
     FuncDef,
@@ -66,12 +67,15 @@ from mypy.plugin import AnalyzeTypeContext, ClassDefContext, FunctionContext, Pl
 from mypy.types import (
     AnyType,
     CallableType,
+    Instance,
     NoneType,
     RawExpressionType,
     Type,
     TypeOfAny,
+    TypeType,
     UnionType,
 )
+from mypy.types import Type as MypyType
 
 # ---------------------------------------------------------------------------
 # Field factory → Python type mapping
@@ -611,8 +615,6 @@ def _extract_field_factory_from_annotation(stmt: object) -> str | None:
     Returns the canonical fully-qualified name (e.g. ``protean.fields.simple.Float``)
     if found, or None.
     """
-    from mypy.nodes import AssignmentStmt
-
     if not isinstance(stmt, AssignmentStmt):
         return None
 
@@ -658,8 +660,6 @@ def _synthesize_init(ctx: ClassDefContext, decorator_name: str) -> None:
 
     for stmt in ctx.cls.defs.body:
         # Look for assignments like: name = String(required=True)
-        from mypy.nodes import AssignmentStmt
-
         if not isinstance(stmt, AssignmentStmt):
             continue
         if len(stmt.lvalues) != 1:
@@ -707,8 +707,6 @@ def _synthesize_init(ctx: ClassDefContext, decorator_name: str) -> None:
     # Also check for annotation-style fields: name: String(required=True)
     # These produce a RawExpressionType with the field factory name in the note.
     for stmt in ctx.cls.defs.body:
-        from mypy.nodes import AssignmentStmt
-
         if not isinstance(stmt, AssignmentStmt):
             continue
         if len(stmt.lvalues) != 1:
@@ -914,8 +912,6 @@ def _synthesize_has_many_methods(ctx: ClassDefContext) -> None:
     has_many_fields: list[str] = []
 
     for stmt in ctx.cls.defs.body:
-        from mypy.nodes import AssignmentStmt
-
         if not isinstance(stmt, AssignmentStmt):
             continue
         if len(stmt.lvalues) != 1:
@@ -1034,9 +1030,6 @@ def _association_field_hook(ctx: FunctionContext, kind: str) -> Type:
     When the target class cannot be resolved (e.g. a forward-reference
     string), falls back to the default return type.
     """
-    from mypy.types import Instance, TypeType
-    from mypy.types import Type as MypyType
-
     # The target class is always the first positional argument
     if not ctx.args or not ctx.args[0]:
         return ctx.default_return_type

--- a/src/protean/fields/containers.py
+++ b/src/protean/fields/containers.py
@@ -3,8 +3,12 @@
 These work alongside the simple field factories in ``simple.py``.
 """
 
+import types as _types
+import typing
 from typing import TYPE_CHECKING, Any
 
+from protean.exceptions import ValidationError
+from protean.fields.embedded import ValueObject as VODescriptor
 from protean.fields.spec import FieldSpec
 
 
@@ -19,9 +23,6 @@ def List(content_type: Any = None, pickled: bool = False, **kwargs: Any) -> Fiel
 
     The ``pickled`` flag is a legacy parameter kept for backward compatibility.
     """
-    from protean.exceptions import ValidationError
-    from protean.fields.embedded import ValueObject as VODescriptor
-
     # If content_type is a FieldSpec factory function (e.g. ``Integer`` rather
     # than ``Integer()``), call it to obtain a FieldSpec instance.
     if callable(content_type) and not isinstance(
@@ -36,9 +37,6 @@ def List(content_type: Any = None, pickled: bool = False, **kwargs: Any) -> Fiel
     if isinstance(content_type, FieldSpec):
         # Use the resolved type to preserve Literal/choices constraints.
         # Strip Optional wrapping since list elements don't need it.
-        import types as _types
-        import typing
-
         resolved = content_type.resolve_type()
         origin = typing.get_origin(resolved)
         if origin is _types.UnionType or origin is typing.Union:

--- a/src/protean/fields/resolved.py
+++ b/src/protean/fields/resolved.py
@@ -15,11 +15,15 @@ layer all consume ``ResolvedField`` instances via the
 ``__container_fields__`` dict.
 """
 
+import types as _types
+import typing
 from collections import defaultdict
 from datetime import datetime
+from enum import Enum
 from typing import Any
 
 from pydantic import ValidationError as PydanticValidationError
+from pydantic_core import PydanticUndefined
 
 from protean.exceptions import ValidationError
 
@@ -53,8 +57,6 @@ class ResolvedField:
     def __init__(
         self, field_name: str, field_info: Any, python_type: type | None
     ) -> None:
-        from pydantic_core import PydanticUndefined
-
         self.field_name = field_name
         self.attribute_name = field_name
         self._python_type = python_type
@@ -150,9 +152,6 @@ class ResolvedField:
         This allows the SQLAlchemy adapter to determine the correct ARRAY
         element type (e.g., list[int] → int → ARRAY(Integer)).
         """
-        import types as _types
-        import typing
-
         python_type = self._python_type
 
         # Unwrap Optional/Union: list[str] | None → list[str]
@@ -174,8 +173,6 @@ class ResolvedField:
 
     def as_dict(self, value: Any) -> Any:
         """Return JSON-compatible value of self."""
-        from enum import Enum
-
         if value is None:
             return None
         # Prefer custom to_dict() over Pydantic model_dump() — our VOs

--- a/src/protean/fields/simple.py
+++ b/src/protean/fields/simple.py
@@ -11,8 +11,10 @@ during class creation.
 """
 
 import datetime
+from enum import Enum as _Enum
 from typing import TYPE_CHECKING, Any, Callable
 
+from protean.exceptions import IncorrectUsageError
 from protean.fields.spec import FieldSpec
 
 
@@ -144,10 +146,6 @@ def Status(
             OrderStatus.PLACED: [OrderStatus.CONFIRMED],
         })
     """
-    from enum import Enum as _Enum
-
-    from protean.exceptions import IncorrectUsageError
-
     if not (isinstance(enum_cls, type) and issubclass(enum_cls, _Enum)):
         raise IncorrectUsageError(
             "Status() requires an Enum class as the first argument"

--- a/src/protean/fields/spec.py
+++ b/src/protean/fields/spec.py
@@ -6,9 +6,18 @@ It is consumed during class creation and translated into Pydantic-compatible
 Pydantic's native machinery remains — FieldSpec itself is not stored on the class.
 """
 
+import datetime as _dt
 import warnings
 from enum import Enum
-from typing import Any, Callable, Iterable
+from typing import Annotated, Any, Callable, Iterable, Literal, Optional
+from uuid import uuid4
+
+from pydantic import AfterValidator, BeforeValidator
+from pydantic import Field as PydanticField
+
+from protean.exceptions import ValidationError as ProteanValidationError
+from protean.fields.base import normalize_field_deprecated
+from protean.utils import generate_identity
 
 
 # ---------------------------------------------------------------------------
@@ -100,8 +109,6 @@ class FieldSpec:
             self._normalize_transitions(transitions) if transitions else None
         )
         self._auto_generated = False
-        from protean.fields.base import normalize_field_deprecated
-
         self.deprecated = normalize_field_deprecated(deprecated)
 
         # Warn if required=True with an explicit default
@@ -120,8 +127,6 @@ class FieldSpec:
 
         Handles choices → Literal, and optional wrapping.
         """
-        from typing import Literal, Optional
-
         resolved = self.python_type
 
         # If choices is set, replace with Literal
@@ -147,8 +152,6 @@ class FieldSpec:
 
     def resolve_field_kwargs(self) -> dict[str, Any]:
         """Return the kwargs dict for ``pydantic.Field(...)``."""
-        from uuid import uuid4
-
         kwargs: dict[str, Any] = {}
         json_extra: dict[str, Any] = {}
 
@@ -181,8 +184,6 @@ class FieldSpec:
                     _id_strategy = getattr(self, "_identity_strategy", None)
                     _id_function = getattr(self, "_identity_function", None)
                     _id_type = getattr(self, "_identity_type", None)
-
-                    from protean.utils import generate_identity
 
                     kwargs["default_factory"] = (
                         lambda s=_id_strategy, f=_id_function, t=_id_type: (
@@ -261,11 +262,6 @@ class FieldSpec:
         corresponding ``AfterValidator`` wrappers are appended to the
         ``Annotated`` metadata.
         """
-        from typing import Annotated
-
-        from pydantic import AfterValidator, BeforeValidator
-        from pydantic import Field as PydanticField
-
         resolved_type = self.resolve_type()
         field_kwargs = self.resolve_field_kwargs()
         pydantic_field = PydanticField(**field_kwargs)
@@ -301,8 +297,6 @@ class FieldSpec:
                 v: Any,
                 validators: list[Callable] = captured_validators,
             ) -> Any:
-                from protean.exceptions import ValidationError as ProteanValidationError
-
                 for validator_fn in validators:
                     try:
                         validator_fn(v)
@@ -345,8 +339,6 @@ class FieldSpec:
         return normalized
 
     def __repr__(self) -> str:
-        import datetime as _dt
-
         # Map (python_type, field_kind) to user-friendly factory name
         _FACTORY_NAMES: dict[tuple[type, str], str] = {
             (str, "standard"): "String",

--- a/src/protean/integrations/fastapi/telemetry.py
+++ b/src/protean/integrations/fastapi/telemetry.py
@@ -20,6 +20,13 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from protean.utils.telemetry import (
+    get_meter_provider,
+    get_tracer_provider,
+    init_telemetry,
+    instrument_fastapi_app,
+)
+
 if TYPE_CHECKING:
     from fastapi import FastAPI
 
@@ -66,13 +73,6 @@ def instrument_app(
             "FastAPI app is already instrumented with OpenTelemetry, skipping."
         )
         return False
-
-    from protean.utils.telemetry import (
-        get_meter_provider,
-        get_tracer_provider,
-        init_telemetry,
-        instrument_fastapi_app,
-    )
 
     # Ensure domain telemetry providers are initialized
     if not getattr(domain, "_otel_init_attempted", False):

--- a/src/protean/integrations/pytest/adapter_conformance.py
+++ b/src/protean/integrations/pytest/adapter_conformance.py
@@ -46,6 +46,7 @@ from typing import Any
 
 import pytest
 
+from protean.domain import Domain
 from protean.port.provider import DatabaseCapabilities
 
 # ---------------------------------------------------------------------------
@@ -267,8 +268,6 @@ def test_domain(
     if "no_test_domain" in request.keywords:
         yield
         return
-
-    from protean.domain import Domain
 
     domain = Domain(name="AdapterConformanceTest")
 

--- a/src/protean/integrations/pytest/plugin.py
+++ b/src/protean/integrations/pytest/plugin.py
@@ -7,8 +7,6 @@ at import time.  Also registers standard test-category markers.
 
 import os
 
-import protean.testing as _testing
-
 
 def pytest_addoption(parser):
     """Add ``--protean-env`` and ``--update-snapshots`` CLI options."""
@@ -39,6 +37,8 @@ def pytest_configure(config):
 
     # Propagate --update-snapshots to the testing module
     if config.getoption("--update-snapshots", default=False):
+        import protean.testing as _testing
+
         _testing._update_snapshots = True
 
     # Register standard markers so --strict-markers doesn't complain

--- a/src/protean/integrations/pytest/plugin.py
+++ b/src/protean/integrations/pytest/plugin.py
@@ -7,6 +7,8 @@ at import time.  Also registers standard test-category markers.
 
 import os
 
+import protean.testing as _testing
+
 
 def pytest_addoption(parser):
     """Add ``--protean-env`` and ``--update-snapshots`` CLI options."""
@@ -37,8 +39,6 @@ def pytest_configure(config):
 
     # Propagate --update-snapshots to the testing module
     if config.getoption("--update-snapshots", default=False):
-        import protean.testing as _testing
-
         _testing._update_snapshots = True
 
     # Register standard markers so --strict-markers doesn't complain

--- a/src/protean/integrations/pytest/testbed.py
+++ b/src/protean/integrations/pytest/testbed.py
@@ -3,6 +3,7 @@
 from contextlib import contextmanager
 
 from protean.domain import Domain
+from protean.utils.globals import current_domain
 
 
 class DomainFixture:
@@ -62,8 +63,6 @@ class DomainFixture:
         try:
             yield self.domain
         finally:
-            from protean.utils.globals import current_domain
-
             for _, provider in current_domain.providers.items():
                 provider._data_reset()
 

--- a/src/protean/ir/builder.py
+++ b/src/protean/ir/builder.py
@@ -10,12 +10,27 @@ Usage::
 
 from __future__ import annotations
 
+import datetime as _dt
 import hashlib
+import importlib
 import json
+import logging
+import types as _types
+import typing
 from datetime import datetime, timezone
+from enum import Enum
 from typing import TYPE_CHECKING, Any
 
+from protean.core.aggregate import BaseAggregate
+from protean.core.index import Index, RawIndex
+from protean.fields.association import HasMany, HasOne, Reference
+from protean.fields.basic import ValueObjectList
+from protean.fields.embedded import ValueObject
+from protean.fields.resolved import ResolvedField
+from protean.fields.spec import _UNSET
 from protean.ir import SCHEMA_VERSION
+from protean.utils import fqn
+from protean.utils.reflection import _ID_FIELD_NAME, declared_fields
 
 if TYPE_CHECKING:
     from protean.domain import Domain
@@ -98,13 +113,6 @@ class IRBuilder:
 
         Returns a dict keyed by field name, each value a sparse IR field dict.
         """
-
-        from protean.fields.association import HasMany, HasOne, Reference
-        from protean.fields.basic import ValueObjectList
-        from protean.fields.embedded import ValueObject
-        from protean.fields.resolved import ResolvedField
-        from protean.utils import fqn
-        from protean.utils.reflection import declared_fields
 
         result: dict[str, Any] = {}
         field_meta: dict[str, Any] = getattr(cls, "__protean_field_meta__", {})
@@ -214,8 +222,6 @@ class IRBuilder:
 
         # Choices — from the original FieldSpec
         if spec is not None and getattr(spec, "choices", None) is not None:
-            from enum import Enum
-
             choices = spec.choices
             if isinstance(choices, type) and issubclass(choices, Enum):
                 choices_list = sorted(item.value for item in choices)
@@ -233,8 +239,6 @@ class IRBuilder:
 
         # Default — from FieldSpec for accurate representation
         if spec is not None:
-            from protean.fields.spec import _UNSET
-
             if spec.default is not _UNSET:
                 if callable(spec.default):
                     entry["default"] = "<callable>"
@@ -259,9 +263,6 @@ class IRBuilder:
             ``list[str]``  → ``list[str]``  (unchanged)
             ``Literal['A','B'] | None``  → ``str``  (first Literal arg type)
         """
-        import types as _types
-        import typing
-
         if python_type is None:
             return None
 
@@ -287,8 +288,6 @@ class IRBuilder:
     @staticmethod
     def _is_list_type(python_type: type | None) -> bool:
         """Check if a (possibly unwrapped) type is a list origin."""
-        import typing
-
         if python_type is None:
             return False
         return typing.get_origin(python_type) is list
@@ -299,9 +298,6 @@ class IRBuilder:
 
         Handles both ``dict`` and ``dict | list`` (from Dict() field).
         """
-        import types as _types
-        import typing
-
         if base_type is dict:
             return True
         # Dict() field creates `dict | list` annotation
@@ -315,8 +311,6 @@ class IRBuilder:
     @staticmethod
     def _resolve_type_name(python_type: type | None, kind: str) -> str:
         """Map a Python type + field kind to the IR type name."""
-        import datetime as _dt
-
         _TYPE_MAP: dict[tuple[type, str], str] = {
             (str, "standard"): "String",
             (str, "text"): "Text",
@@ -339,8 +333,6 @@ class IRBuilder:
     @staticmethod
     def _python_type_name(python_type: type | None) -> str:
         """Map a Python type to its IR content_type name."""
-        import datetime as _dt
-
         _CONTENT_TYPE_MAP: dict[type, str] = {
             str: "String",
             int: "Integer",
@@ -373,8 +365,6 @@ class IRBuilder:
         rather than serialized; the rendered DDL (via ``protean schema render
         --indexes``) carries the exact predicate.
         """
-        from protean.core.index import Index, RawIndex
-
         declared = getattr(getattr(cls, "meta_", None), "indexes", ()) or ()
         result: list[dict[str, Any]] = []
         for idx in declared:
@@ -405,9 +395,6 @@ class IRBuilder:
 
     def _extract_aggregate(self, cls: type, record: Any) -> dict[str, Any]:
         """Extract aggregate IR dict."""
-        from protean.utils import fqn
-        from protean.utils.reflection import _ID_FIELD_NAME
-
         entry: dict[str, Any] = {}
 
         # Sparse: only emit deprecated when set
@@ -461,9 +448,6 @@ class IRBuilder:
 
     def _extract_entity(self, cls: type, record: Any) -> dict[str, Any]:
         """Extract entity IR dict."""
-        from protean.utils import fqn
-        from protean.utils.reflection import _ID_FIELD_NAME
-
         entry: dict[str, Any] = {}
 
         deprecated = self._extract_deprecated(cls)
@@ -508,8 +492,6 @@ class IRBuilder:
         self, cls: type, record: Any, aggregate_fqn: str | None = None
     ) -> dict[str, Any]:
         """Extract value object IR dict."""
-        from protean.utils import fqn
-
         entry: dict[str, Any] = {}
 
         deprecated = self._extract_deprecated(cls)
@@ -534,8 +516,6 @@ class IRBuilder:
 
     def _extract_command(self, cls: type, record: Any) -> dict[str, Any]:
         """Extract command IR dict."""
-        from protean.utils import fqn
-
         entry: dict[str, Any] = {}
         entry["__type__"] = getattr(cls, "__type__", "")
         entry["__version__"] = getattr(cls, "__version__", 1)
@@ -562,8 +542,6 @@ class IRBuilder:
 
     def _extract_event(self, cls: type, record: Any) -> dict[str, Any]:
         """Extract event IR dict."""
-        from protean.utils import fqn
-
         entry: dict[str, Any] = {}
         entry["__type__"] = getattr(cls, "__type__", "")
         entry["__version__"] = getattr(cls, "__version__", 1)
@@ -618,8 +596,6 @@ class IRBuilder:
 
     def _extract_command_handler(self, cls: type, record: Any) -> dict[str, Any]:
         """Extract command handler IR dict."""
-        from protean.utils import fqn
-
         entry: dict[str, Any] = {}
 
         deprecated = self._extract_deprecated(cls)
@@ -647,8 +623,6 @@ class IRBuilder:
 
     def _extract_event_handler(self, cls: type, record: Any) -> dict[str, Any]:
         """Extract event handler IR dict."""
-        from protean.utils import fqn
-
         entry: dict[str, Any] = {}
 
         deprecated = self._extract_deprecated(cls)
@@ -677,8 +651,6 @@ class IRBuilder:
 
     def _extract_application_service(self, cls: type, record: Any) -> dict[str, Any]:
         """Extract application service IR dict."""
-        from protean.utils import fqn
-
         entry: dict[str, Any] = {}
 
         deprecated = self._extract_deprecated(cls)
@@ -702,8 +674,6 @@ class IRBuilder:
 
     def _extract_repository(self, cls: type, record: Any) -> dict[str, Any]:
         """Extract repository IR dict."""
-        from protean.utils import fqn
-
         entry: dict[str, Any] = {}
 
         deprecated = self._extract_deprecated(cls)
@@ -732,8 +702,6 @@ class IRBuilder:
 
     def _extract_database_model(self, cls: type, record: Any) -> dict[str, Any]:
         """Extract database model IR dict."""
-        from protean.utils import fqn
-
         entry: dict[str, Any] = {}
 
         database = getattr(cls.meta_, "database", None)
@@ -769,9 +737,6 @@ class IRBuilder:
 
     def _extract_projection(self, cls: type, record: Any) -> dict[str, Any]:
         """Extract projection IR dict."""
-        from protean.utils import fqn
-        from protean.utils.reflection import _ID_FIELD_NAME
-
         entry: dict[str, Any] = {}
 
         deprecated = self._extract_deprecated(cls)
@@ -811,8 +776,6 @@ class IRBuilder:
 
     def _extract_projector(self, cls: type, record: Any) -> dict[str, Any]:
         """Extract projector IR dict."""
-        from protean.utils import fqn
-
         entry: dict[str, Any] = {}
 
         aggregates = getattr(cls.meta_, "aggregates", [])
@@ -843,8 +806,6 @@ class IRBuilder:
 
     def _extract_query(self, cls: type, record: Any) -> dict[str, Any]:
         """Extract query IR dict."""
-        from protean.utils import fqn
-
         entry: dict[str, Any] = {}
         entry["__type__"] = getattr(cls, "__type__", "")
 
@@ -870,8 +831,6 @@ class IRBuilder:
 
     def _extract_query_handler(self, cls: type, record: Any) -> dict[str, Any]:
         """Extract query handler IR dict."""
-        from protean.utils import fqn
-
         entry: dict[str, Any] = {}
 
         deprecated = self._extract_deprecated(cls)
@@ -896,8 +855,6 @@ class IRBuilder:
 
     def _build_projections(self) -> dict[str, Any]:
         """Build projections dict keyed by projection FQN."""
-        from protean.utils import fqn
-
         registry = self._domain._domain_registry
         projections: dict[str, Any] = {}
 
@@ -958,8 +915,6 @@ class IRBuilder:
 
     def _extract_domain_service(self, cls: type, record: Any) -> dict[str, Any]:
         """Extract domain service IR dict."""
-        from protean.utils import fqn
-
         entry: dict[str, Any] = {}
 
         deprecated = self._extract_deprecated(cls)
@@ -987,9 +942,6 @@ class IRBuilder:
 
     def _extract_process_manager(self, cls: type, record: Any) -> dict[str, Any]:
         """Extract process manager IR dict."""
-        from protean.utils import fqn
-        from protean.utils.reflection import _ID_FIELD_NAME
-
         entry: dict[str, Any] = {}
 
         deprecated = self._extract_deprecated(cls)
@@ -1042,8 +994,6 @@ class IRBuilder:
 
     def _extract_subscriber(self, cls: type, record: Any) -> dict[str, Any]:
         """Extract subscriber IR dict."""
-        from protean.utils import fqn
-
         entry: dict[str, Any] = {}
         entry["broker"] = getattr(cls.meta_, "broker", "default")
 
@@ -1065,8 +1015,6 @@ class IRBuilder:
 
     def _build_flows(self) -> dict[str, Any]:
         """Build flows dict with domain_services, process_managers, subscribers."""
-        from protean.utils import fqn
-
         registry = self._domain._domain_registry
         flows: dict[str, Any] = {
             "domain_services": {},
@@ -1108,7 +1056,6 @@ class IRBuilder:
         commands, events), then falls back to traversing ``part_of``
         (needed for fact events generated after cluster assignment).
         """
-        from protean.core.aggregate import BaseAggregate
 
         agg = getattr(cls.meta_, "aggregate_cluster", None)
         if agg is not None:
@@ -1128,11 +1075,6 @@ class IRBuilder:
         so we derive it from which aggregate/entity embeds them via
         ``ValueObject`` or ``ValueObjectList`` fields.
         """
-        from protean.fields.basic import ValueObjectList
-        from protean.fields.embedded import ValueObject
-        from protean.utils import fqn
-        from protean.utils.reflection import declared_fields
-
         registry = self._domain._domain_registry
         vo_map: dict[str, type] = {}
 
@@ -1168,8 +1110,6 @@ class IRBuilder:
 
     def _build_clusters(self) -> dict[str, Any]:
         """Build cluster dict keyed by aggregate FQN."""
-        from protean.utils import fqn
-
         registry = self._domain._domain_registry
         clusters: dict[str, Any] = {}
 
@@ -1261,8 +1201,6 @@ class IRBuilder:
 
     def _build_elements_index(self) -> dict[str, list[str]]:
         """Build elements index: {element_type: sorted([FQN, ...])}."""
-        from protean.utils import fqn
-
         registry = self._domain._domain_registry
         # Element types to include (skip internal types)
         element_types = [
@@ -1306,8 +1244,6 @@ class IRBuilder:
         consumers (schema generators, contract checkers) have everything
         they need without reaching into element-level IR.
         """
-        from protean.utils import fqn
-
         registry = self._domain._domain_registry
         published_events: list[dict[str, Any]] = []
 
@@ -1735,7 +1671,6 @@ class IRBuilder:
         results are logged and skipped.  Exceptions in rules are caught so
         they never crash ``protean check``.
         """
-        import logging
 
         logger = logging.getLogger(__name__)
 
@@ -1794,7 +1729,6 @@ class IRBuilder:
     @staticmethod
     def _import_callable(dotted_path: str) -> Any:
         """Import a callable from a dotted path like ``'my_app.lint.check_names'``."""
-        import importlib
 
         module_path, _, attr_name = dotted_path.rpartition(".")
         if not module_path:

--- a/src/protean/ir/staleness.py
+++ b/src/protean/ir/staleness.py
@@ -22,6 +22,10 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from protean.ir.builder import IRBuilder
+from protean.ir.config import load_config
+from protean.utils.domain_discovery import derive_domain
+
 if TYPE_CHECKING:
     from protean.ir.config import CompatConfig
 
@@ -113,10 +117,6 @@ def check_staleness(
         - ``status=STALE`` — checksums differ.
         - ``status=NO_IR`` — no ``ir.json`` found in *protean_dir*.
     """
-    from protean.ir.builder import IRBuilder
-    from protean.ir.config import load_config
-    from protean.utils.domain_discovery import derive_domain
-
     if config is None:
         config = load_config(protean_dir)
 

--- a/src/protean/server/dlq_maintenance.py
+++ b/src/protean/server/dlq_maintenance.py
@@ -22,6 +22,7 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any, Callable
 
+from protean.port.broker import BrokerCapabilities
 from protean.utils.dlq import discover_subscriptions
 from protean.utils.telemetry import get_domain_metrics
 
@@ -206,8 +207,6 @@ class DLQMaintenanceTask:
 
     def _get_broker(self):
         """Return the first broker that supports DLQ, or None."""
-        from protean.port.broker import BrokerCapabilities
-
         for broker in self.domain.brokers.values():
             if broker.has_capability(BrokerCapabilities.DEAD_LETTER_QUEUE):
                 return broker

--- a/src/protean/server/engine.py
+++ b/src/protean/server/engine.py
@@ -11,6 +11,7 @@ from protean.core.event_handler import BaseEventHandler
 from protean.core.process_manager import BaseProcessManager
 from protean.core.subscriber import BaseSubscriber
 from protean.exceptions import ConfigurationError
+from protean.port.broker import BrokerCapabilities
 from protean.utils.globals import g
 from protean.utils.eventing import (
     DomainMeta,
@@ -370,8 +371,6 @@ class Engine:
 
     def _has_dlq_capable_broker(self) -> bool:
         """Return True if any configured broker supports DLQ."""
-        from protean.port.broker import BrokerCapabilities
-
         for broker in self.domain.brokers.values():
             if broker.has_capability(BrokerCapabilities.DEAD_LETTER_QUEUE):
                 return True

--- a/src/protean/server/observatory/api.py
+++ b/src/protean/server/observatory/api.py
@@ -8,12 +8,14 @@ dashboard and can be consumed by external monitoring tools.
 import json
 import logging
 import time
+from datetime import datetime
 from typing import List, Optional, Tuple
 
 from fastapi import APIRouter, Query
 from fastapi.responses import JSONResponse
 
 from protean.domain import Domain
+from protean.port.broker import BrokerCapabilities
 
 from ..tracing import TRACE_STREAM
 
@@ -864,8 +866,6 @@ def create_api_router(domains: List[Domain]) -> APIRouter:
         # Determine time range
         if start and end:
             # Custom range: parse ISO 8601 timestamps
-            from datetime import datetime
-
             try:
                 start_dt = datetime.fromisoformat(start.replace("Z", "+00:00"))
                 end_dt = datetime.fromisoformat(end.replace("Z", "+00:00"))
@@ -1022,7 +1022,6 @@ def create_api_router(domains: List[Domain]) -> APIRouter:
 
         Supports offset-based pagination via offset/limit params.
         """
-        from protean.port.broker import BrokerCapabilities
         from protean.utils.dlq import collect_dlq_streams, discover_subscriptions
 
         domain = domains[0]
@@ -1089,7 +1088,6 @@ def create_api_router(domains: List[Domain]) -> APIRouter:
     @router.get("/dlq/{dlq_id}")
     async def dlq_inspect(dlq_id: str):
         """Inspect a single DLQ message with full payload."""
-        from protean.port.broker import BrokerCapabilities
         from protean.utils.dlq import collect_dlq_streams
 
         domain = domains[0]
@@ -1142,7 +1140,6 @@ def create_api_router(domains: List[Domain]) -> APIRouter:
     @router.post("/dlq/{dlq_id}/replay")
     async def dlq_replay(dlq_id: str):
         """Replay a single DLQ message back to its original stream."""
-        from protean.port.broker import BrokerCapabilities
         from protean.utils.dlq import collect_dlq_streams
 
         domain = domains[0]
@@ -1191,7 +1188,6 @@ def create_api_router(domains: List[Domain]) -> APIRouter:
         subscription: str = Query(..., description="Stream category (required)"),
     ):
         """Replay all DLQ messages for a subscription."""
-        from protean.port.broker import BrokerCapabilities
         from protean.utils.dlq import discover_subscriptions
 
         domain = domains[0]
@@ -1243,7 +1239,6 @@ def create_api_router(domains: List[Domain]) -> APIRouter:
         subscription: str = Query(..., description="Stream category (required)"),
     ):
         """Purge all DLQ messages for a subscription."""
-        from protean.port.broker import BrokerCapabilities
         from protean.utils.dlq import discover_subscriptions
 
         domain = domains[0]

--- a/src/protean/server/observatory/metrics.py
+++ b/src/protean/server/observatory/metrics.py
@@ -52,6 +52,13 @@ from typing import Any, Callable, List
 from fastapi import Response
 
 from protean.domain import Domain
+from protean.utils.telemetry import (
+    _TELEMETRY_INIT_KEY,
+    create_observation,
+    get_meter,
+    get_meter_provider,
+    get_prometheus_text,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -235,13 +242,6 @@ def _register_infrastructure_gauges(domains: List[Domain]) -> None:
     """
     if not domains:
         return
-
-    from protean.utils.telemetry import (
-        _TELEMETRY_INIT_KEY,
-        create_observation,
-        get_meter,
-        get_meter_provider,
-    )
 
     # Find the first domain that went through init_telemetry() and has a meter provider.
     # The init flag check prevents MagicMock/test doubles from matching.
@@ -812,8 +812,6 @@ def create_metrics_endpoint(domains: List[Domain]):
         if not gauges_attempted:
             _register_infrastructure_gauges(domains)
             gauges_attempted = True
-
-        from protean.utils.telemetry import get_prometheus_text
 
         # Try OTel-powered path first
         for domain in domains:

--- a/src/protean/server/observatory/routes/domain.py
+++ b/src/protean/server/observatory/routes/domain.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 
+from protean.ir.builder import IRBuilder
 from protean.ir.generators.base import (
     build_cmd_type_to_fqn,
     build_evt_type_to_fqn,
@@ -556,8 +557,6 @@ def create_domain_router(domains: list["Domain"]) -> APIRouter:
     topology is immutable at runtime and cannot change without a
     server restart.
     """
-    from protean.ir.builder import IRBuilder
-
     router = APIRouter()
 
     # Pre-compute the D3 graph at startup (topology is static).

--- a/src/protean/server/outbox_processor.py
+++ b/src/protean/server/outbox_processor.py
@@ -1,9 +1,11 @@
 import asyncio
+import datetime
 import logging
 from typing import List, Optional
 
 from protean.core.unit_of_work import UnitOfWork
 from protean.port.broker import BaseBroker
+from protean.utils import ensure_utc_aware
 from protean.utils.eventing import Message
 from protean.utils.outbox import Outbox, OutboxRepository
 from protean.utils.telemetry import get_domain_metrics, get_tracer, set_span_error
@@ -412,10 +414,6 @@ class OutboxProcessor(BaseSubscription):
                         metrics.outbox_published.add(1)
                         # Compute outbox latency from created_at to now
                         if hasattr(message, "created_at") and message.created_at:
-                            import datetime
-
-                            from protean.utils import ensure_utc_aware
-
                             now = datetime.datetime.now(datetime.timezone.utc)
                             created = ensure_utc_aware(message.created_at)
                             latency_s = (now - created).total_seconds()

--- a/src/protean/testing.py
+++ b/src/protean/testing.py
@@ -83,18 +83,23 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
-from protean.exceptions import ProteanExceptionWithMessage
+from protean.core.process_manager import (
+    BaseProcessManager,
+    _resolve_correlation_value,
+)
+from protean.exceptions import ObjectNotFoundError, ProteanExceptionWithMessage
 
 if TYPE_CHECKING:
     from protean.core.event import BaseEvent
     from protean.port.event_store import CausationNode
-from protean.utils import fqn
+from protean.utils import Processing, fqn
 from protean.utils.eventing import (
     DomainMeta,
     MessageEnvelope,
     MessageHeaders,
     Metadata,
 )
+from protean.utils.globals import current_domain
 from protean.utils.reflection import _ID_FIELD_NAME
 
 
@@ -127,8 +132,6 @@ def given(
         given(registered_event, transacted_event)
     """
     if isinstance(cls_or_event, type):
-        from protean.core.process_manager import BaseProcessManager
-
         if issubclass(cls_or_event, BaseProcessManager):
             return ProcessManagerResult(cls_or_event, list(events))
         return AggregateResult(cls_or_event, list(events))
@@ -281,8 +284,6 @@ class AggregateResult:
 
         Returns self for chaining.
         """
-        from protean.utils.globals import current_domain
-
         domain = current_domain
         self._processed = True
         self._rejection = None  # Reset for this command
@@ -428,8 +429,6 @@ class AggregateResult:
 
         Returns the aggregate identifier.
         """
-        from protean.utils import Processing
-
         event_store = domain.event_store.store
 
         # Reconstitute aggregate to discover its identity
@@ -533,9 +532,6 @@ class EventSequence:
             ProjectionResult: Result object with ``.has()``, ``.found``,
             and ``.projection`` for assertions.
         """
-        from protean.exceptions import ObjectNotFoundError
-        from protean.utils.globals import current_domain
-
         if not identity:
             raise ValueError(
                 "then() requires at least one keyword argument to identify "
@@ -640,8 +636,6 @@ class ProcessManagerResult:
 
     def _load_pm(self) -> None:
         """Load the PM instance from the event store after processing."""
-        from protean.utils.globals import current_domain
-
         # Determine correlation value from the first event's matching handler
         correlation_value = self._correlation_value
         if correlation_value is None:
@@ -670,8 +664,6 @@ class ProcessManagerResult:
         Inspects the PM's handler methods to find the correlate spec,
         then extracts the correlation value from the first event.
         """
-        from protean.core.process_manager import _resolve_correlation_value
-
         if not self._events:
             return None
 

--- a/src/protean/upgrade.py
+++ b/src/protean/upgrade.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable
 
+from protean.utils.outbox import Outbox
+
 if TYPE_CHECKING:
     from protean.domain import Domain
 
@@ -145,8 +147,6 @@ def _outbox_string_bounds() -> dict[str, int]:
     The Outbox bounds are declared with ``Annotated[str, Field(max_length=N)]``,
     so they surface as ``MaxLen`` constraints in the pydantic field metadata.
     """
-    from protean.utils.outbox import Outbox
-
     bounds: dict[str, int] = {}
     for fname, field_info in Outbox.model_fields.items():
         for meta in getattr(field_info, "metadata", []):

--- a/src/protean/utils/__init__.py
+++ b/src/protean/utils/__init__.py
@@ -5,14 +5,30 @@ to the maximum extent possible.
 """
 
 import importlib
+import keyword
 import logging
 import types
 from datetime import UTC, datetime
 from enum import Enum, StrEnum
-from typing import TYPE_CHECKING, Any, Callable, Optional, Type, TypeVar
+from typing import (
+    TYPE_CHECKING,
+    Annotated,
+    Any,
+    Callable,
+    ClassVar,
+    Optional,
+    Type,
+    TypeVar,
+    get_args,
+    get_origin,
+)
 from uuid import UUID, uuid4
 
+from pydantic import BaseModel, Field as PydanticField
+from pydantic.fields import FieldInfo
+
 from protean.exceptions import ConfigurationError
+from protean.utils.container import Options
 from protean.utils.globals import current_domain
 from protean.utils.reflection import _FIELDS, _ID_FIELD_NAME
 
@@ -279,13 +295,6 @@ def _prepare_pydantic_namespace(
        and ``auto_add_id_field`` is not False, inject a Pydantic-compatible
        auto-id annotation + default.
     """
-    from typing import Annotated, ClassVar, get_args, get_origin
-
-    from pydantic import Field as PydanticField
-    from pydantic.fields import FieldInfo
-
-    from protean.utils.container import Options
-
     annots = new_dict.get("__annotations__", {}).copy()
 
     # 1. Annotate meta_ as ClassVar so Pydantic ignores it
@@ -423,10 +432,6 @@ def derive_element_class(
     base_cls: type,
     **opts: dict[str, str | bool],
 ) -> type[_T]:
-    from pydantic import BaseModel
-
-    from protean.utils.container import Options
-
     # Extract and normalize the universal `deprecated` option before
     # checking against element-specific known options.
     raw_deprecated = opts.pop("deprecated", None)
@@ -475,8 +480,6 @@ def derive_element_class(
         # ensure meta_ has a ClassVar annotation so that Pydantic ignores it
         # during clone_class and other dynamic class operations.
         if issubclass(base_cls, BaseModel):
-            from typing import ClassVar
-
             annots = element_cls.__annotations__.copy()
             annots["meta_"] = ClassVar[Options]
             element_cls.__annotations__ = annots
@@ -578,9 +581,6 @@ def clone_class(cls: "Element", new_name: str) -> Type["Element"]:
     if not new_name.isidentifier():
         raise ValueError(f"'{new_name}' is not a valid Python identifier")
 
-    # Import keyword module to check for reserved keywords
-    import keyword
-
     if keyword.iskeyword(new_name):
         raise ValueError(f"'{new_name}' is a reserved Python keyword")
 
@@ -598,8 +598,6 @@ def clone_class(cls: "Element", new_name: str) -> Type["Element"]:
     # re-creating the class from __dict__.  Pydantic internalises field
     # defaults into model_fields during class creation, so a dict-copy
     # clone loses them.  A subclass inherits everything through the MRO.
-    from pydantic import BaseModel
-
     if isinstance(cls, type) and issubclass(cls, BaseModel):
         new_cls = type(type(cls))(new_name, (cls,), {"__annotations__": {}})
         new_cls.__qualname__ = new_name

--- a/src/protean/utils/dlq.py
+++ b/src/protean/utils/dlq.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from protean.utils import DomainObjects
+from protean.utils import DomainObjects, fqn
 
 if TYPE_CHECKING:
     from protean.domain import Domain
@@ -57,8 +57,6 @@ def discover_subscriptions(domain: "Domain") -> list[SubscriptionInfo]:
     Inspects event handlers, command handlers, and projectors to derive
     their stream categories and DLQ stream names.
     """
-    from protean.utils import fqn
-
     server_config = domain.config.get("server", {})
     lanes_config = server_config.get("priority_lanes", {})
     lanes_enabled = lanes_config.get("enabled", False)

--- a/src/protean/utils/eventing.py
+++ b/src/protean/utils/eventing.py
@@ -20,7 +20,7 @@ from protean.exceptions import (
 from protean.fields.association import Association, Reference
 from protean.fields.base import FieldBase
 from protean.fields.embedded import ValueObject as ValueObjectField
-from protean.fields.spec import FieldSpec
+from protean.fields.spec import FieldSpec, resolve_fieldspecs
 from protean.utils.container import OptionsMixin
 from protean.utils.reflection import _FIELDS, _ID_FIELD_NAME
 from protean.utils.globals import current_domain
@@ -373,8 +373,6 @@ class BaseMessageType(BaseModel, OptionsMixin):
 
     @classmethod
     def _resolve_fieldspecs(cls) -> None:
-        from protean.fields.spec import resolve_fieldspecs
-
         resolve_fieldspecs(cls)
 
     @classmethod

--- a/src/protean/utils/logging.py
+++ b/src/protean/utils/logging.py
@@ -45,9 +45,12 @@ from typing import Any, Callable, Iterable, Iterator, Optional, TypeVar, Union
 
 import structlog
 
+from protean.domain.context import has_domain_context
 from protean.integrations.logging import (
     LOG_RECORD_RESERVED_ATTRS as _RESERVED_LOG_RECORD_ATTRS,
+    make_redaction_processor,
 )
+from protean.utils.globals import current_domain, g
 
 _T = TypeVar("_T")
 
@@ -200,8 +203,6 @@ def configure_logging(
     # processors (correlation, OTel, custom enrichment), guaranteeing that
     # sensitive fields added anywhere upstream are masked before the renderer.
     if redact:
-        from protean.integrations.logging import make_redaction_processor
-
         redaction_proc = make_redaction_processor(redact)
         extra_processors = list(extra_processors or []) + [redaction_proc]
 
@@ -344,8 +345,6 @@ def _http_wide_event_extras() -> Optional[dict[str, Any]]:
     same as "no middleware in play".
     """
     try:
-        from protean.utils.globals import g
-
         extras = g.get("_http_wide_event_extras")
     except (AttributeError, RuntimeError):
         return None
@@ -355,8 +354,6 @@ def _http_wide_event_extras() -> Optional[dict[str, Any]]:
 def _reset_access_log_counters() -> None:
     """Reset per-handler access log counters on g."""
     try:
-        from protean.utils.globals import g
-
         g._access_log_repo_loads = 0
         g._access_log_repo_saves = 0
         g._access_log_events_raised = []
@@ -368,8 +365,6 @@ def _reset_access_log_counters() -> None:
 def _get_correlation_context() -> tuple[str, str]:
     """Extract correlation_id and causation_id from the current message context."""
     try:
-        from protean.utils.globals import g
-
         msg = g.get("message_in_context")
         if msg is None:
             return ("", "")
@@ -425,8 +420,6 @@ def _read_access_log_counters() -> tuple[list[str], dict[str, int], str]:
         Tuple of (events_raised, repo_operations, uow_outcome)
     """
     try:
-        from protean.utils.globals import g
-
         events_raised = getattr(g, "_access_log_events_raised", []) or []
         repo_loads = getattr(g, "_access_log_repo_loads", 0) or 0
         repo_saves = getattr(g, "_access_log_repo_saves", 0) or 0
@@ -450,9 +443,6 @@ def get_logging_config_value(key: str, default: _T) -> _T:
     path (e.g. per-query instrumentation) can safely swallow it.
     """
     try:
-        from protean.domain.context import has_domain_context
-        from protean.utils.globals import current_domain
-
         if has_domain_context():
             return current_domain.config.get("logging", {}).get(key, default)
     except Exception:

--- a/src/protean/utils/mixins.py
+++ b/src/protean/utils/mixins.py
@@ -17,6 +17,9 @@ from protean.exceptions import (
 )
 from protean.utils import DomainObjects
 from protean.utils.eventing import Message
+from protean.utils.globals import current_domain, g
+from protean.utils.logging import access_log_handler
+from protean.utils.telemetry import get_domain_metrics, set_span_error
 
 logger = logging.getLogger(__name__)
 
@@ -59,8 +62,6 @@ def _get_version_retry_config() -> dict:
     that call handlers directly without a domain context).
     """
     try:
-        from protean.utils.globals import current_domain
-
         if current_domain:
             server_config = current_domain.config.get("server", {})
             cfg = server_config.get("version_retry", {})
@@ -180,8 +181,6 @@ def _get_transient_retry_config(instance: Any = None) -> dict:
 
     # --- Domain-level configuration ---
     try:
-        from protean.utils.globals import current_domain
-
         if current_domain:
             raw = current_domain.config.get("server", {}).get("transient_retry", {})
             if raw:
@@ -250,11 +249,8 @@ def _transient_backoff_delay(
 def _record_handler_retry(instance: Any, exc: BaseException) -> None:
     """Increment the ``protean.handler.retried`` counter for a transient retry."""
     try:
-        from protean.utils.globals import current_domain
-
         if not current_domain:
             return
-        from protean.utils.telemetry import get_domain_metrics
 
         element_type = getattr(instance, "element_type", None)
         get_domain_metrics(current_domain).handler_retried.add(
@@ -283,8 +279,6 @@ def _deadline_exceeded_after(delay: float) -> bool:
     the retry path is left unconstrained rather than raising.
     """
     try:
-        from protean.utils.globals import g
-
         msg = g.get("message_in_context")
     except Exception:
         # No active domain/message context -> no deadline to honor.
@@ -490,8 +484,6 @@ class HandlerMixin:
         Returns:
             Any: Return value from the handler method (for command and query handlers)
         """
-        from protean.utils.globals import current_domain
-
         # Convert Message to object if necessary
         item = item.to_domain_object() if isinstance(item, Message) else item
 
@@ -507,8 +499,6 @@ class HandlerMixin:
             # No domain context — execute without tracing
             return cls._dispatch_handlers(handlers, item)
 
-        from protean.utils.telemetry import get_domain_metrics
-
         metrics = get_domain_metrics(current_domain)
         handler_start = time.monotonic()
 
@@ -521,8 +511,6 @@ class HandlerMixin:
             span.set_attribute("protean.handler.type", handler_type)
 
             # Propagate correlation/causation IDs from the message being handled
-            from protean.utils.globals import g
-
             msg = g.get("message_in_context")
             if msg is not None and hasattr(msg, "metadata") and msg.metadata:
                 domain_meta = getattr(msg.metadata, "domain", None)
@@ -539,8 +527,6 @@ class HandlerMixin:
             try:
                 result = cls._dispatch_handlers(handlers, item)
             except Exception as exc:
-                from protean.utils.telemetry import set_span_error
-
                 set_span_error(span, exc)
 
                 # Record handler metrics on error
@@ -570,8 +556,6 @@ class HandlerMixin:
         cls, handlers: set, item: Union[BaseCommand, BaseEvent, BaseQuery]
     ) -> Any:
         """Dispatch item to registered handler methods."""
-        from protean.utils.logging import access_log_handler
-
         # Map element_type to access log kind
         _KIND_MAP = {
             DomainObjects.COMMAND_HANDLER: "command",

--- a/src/protean/utils/projection_rebuilder.py
+++ b/src/protean/utils/projection_rebuilder.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING
 
 from protean.exceptions import ConfigurationError
 from protean.utils import DomainObjects
+from protean.utils.eventing import Message
 from protean.utils.inflection import underscore
 
 if TYPE_CHECKING:
@@ -185,8 +186,6 @@ def _replay_projector(
     Returns:
         Tuple of (events_dispatched, events_skipped).
     """
-    from protean.utils.eventing import Message
-
     logger.info(
         "Replaying categories %s through `%s`",
         stream_categories,

--- a/src/protean/utils/telemetry.py
+++ b/src/protean/utils/telemetry.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from protean.utils.eventing import TraceParent
+
 if TYPE_CHECKING:
     from protean.domain import Domain
 
@@ -331,8 +333,6 @@ def inject_traceparent_from_context() -> Any:
     w3c_header = carrier.get("traceparent")
     if not w3c_header:
         return None
-
-    from protean.utils.eventing import TraceParent
 
     return TraceParent.build(w3c_header)
 


### PR DESCRIPTION
## Summary
- Moved **258** function-local (mid-code) imports to module top, where it is safe to do so (`348 → 90` remaining), trimming ~265 lines of churn across 55 files.
- The 90 imports kept function-local are each justified: optional adapter deps (`redis`, `sqlalchemy`, `elasticsearch`, `opentelemetry`, `bleach`, ...), **monkeypatch test seams** that rely on call-time late binding, deliberate lazy-CLI startup imports, PEP-562 `__getattr__` lazy exports, genuine circular-import breakers, and dynamically-loaded domain modules (`from profiles import ...`).
- **No public API or behavior change** — imports were only relocated within their own modules; no signatures, module paths, or exports changed.

## Why some imports stayed local
The interesting cases were not circular imports — they were *test seams*. Tests `patch("src_module.func")` and the code must re-read the symbol at call time, which only a function-local import provides. Hoisting those bound the real object at import time and broke the patch. Those were reverted to local (e.g. observatory collectors, `load_ir_from_commit`, `load_config`, `derive_domain`). Import **style** (relative vs absolute) has no bearing on circular imports, so it was not used to "solve" them.

## Test plan
- [x] Core tests pass (`protean test`) — **9667 passed, 0 failed**
- [x] Every `protean.*` submodule imports cleanly (no circular regressions)
- [x] `ruff check` / `ruff format` clean on all 55 changed files