### PR TITLE
Docs: console-logs-to-stderr (#1010) and deprecated testing helpers (#1011)

### DIFF
--- a/docs/guides/domain-behavior/error-handling.md
+++ b/docs/guides/domain-behavior/error-handling.md
@@ -199,6 +199,14 @@ def test_order_requires_items():
     assert "must contain at least one item" in str(exc.value)
 ```
 
+!!! warning "Deprecated: `assert_valid` / `assert_invalid`"
+    The `protean.testing.assert_valid` and `assert_invalid` helpers still exist
+    but are deprecated and will be removed in v0.18.0. Prefer
+    `pytest.raises(ValidationError, match=...)` as shown above. Replace
+    `assert_invalid(lambda: op(), message="X")` with
+    `with pytest.raises(ValidationError, match="X"): op()`, and
+    `assert_valid(lambda: op())` with a plain call to `op()`.
+
 ---
 
 !!! tip "See also"

--- a/docs/guides/domain-behavior/error-handling.md
+++ b/docs/guides/domain-behavior/error-handling.md
@@ -201,9 +201,8 @@ def test_order_requires_items():
 
 !!! warning "Deprecated: `assert_valid` / `assert_invalid`"
     The `protean.testing.assert_valid` and `assert_invalid` helpers still exist
-    but are deprecated and will be removed in v0.18.0. Prefer
-    `pytest.raises(ValidationError, match=...)` as shown above. Replace
-    `assert_invalid(lambda: op(), message="X")` with
+    but are deprecated and will be removed in v0.18.0. Prefer `pytest.raises`.
+    Replace `assert_invalid(lambda: op(), message="X")` with
     `with pytest.raises(ValidationError, match="X"): op()`, and
     `assert_valid(lambda: op())` with a plain call to `op()`.
 

--- a/docs/reference/cli/ir.md
+++ b/docs/reference/cli/ir.md
@@ -44,6 +44,9 @@ sections: `domain`, `clusters`, `projections`, `flows`, `elements`, and
 `diagnostics`. See the [IR specification](../../concepts/internals/ir-specification.md)
 for the complete structure reference.
 
+Logs are written to stderr, so the JSON on stdout is safe to pipe (`protean ir
+show ... | jq`) or redirect to a file without log lines corrupting it.
+
 **Summary output**
 
 A compact overview showing:

--- a/docs/reference/cli/schema.md
+++ b/docs/reference/cli/schema.md
@@ -91,6 +91,9 @@ protean schema show OrderPlaced --domain=my_app.domain --raw
 protean schema show OrderPlaced --ir=domain-ir.json --raw
 ```
 
+With `--raw`, the JSON is written to stdout while logs go to stderr, so the
+output is safe to pipe (`protean schema show ... --raw | jq`).
+
 **Options**
 
 | Option | Description | Default |

--- a/docs/reference/logging.md
+++ b/docs/reference/logging.md
@@ -32,7 +32,7 @@ redact = ["password", "token", "secret", "api_key", "authorization", "cookie", "
 |-----|------|---------|-------------|
 | `level` | str | `""` (environment default) | Root log level. `DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL`. Empty = use the environment-based default. |
 | `format` | str | `"auto"` | Output format. `"json"` forces JSON; `"console"` forces colored console; `"auto"` picks based on `PROTEAN_ENV`. |
-| `log_dir` | str | `""` | Directory for rotating file handlers. Empty disables file logging (stdout only). |
+| `log_dir` | str | `""` | Directory for rotating file handlers. Empty disables file logging, leaving only the console handler. |
 | `log_file_prefix` | str | `"protean"` | Prefix for log file names. Produces `<prefix>.log` and `<prefix>_error.log`. |
 | `max_bytes` | int | `10485760` (10 MB) | Max size per rotating log file before rotation. |
 | `backup_count` | int | `5` | Number of rotated files to retain. |
@@ -41,6 +41,13 @@ redact = ["password", "token", "secret", "api_key", "authorization", "cookie", "
 | `slow_query_truncate_chars` | int | `500` | Max SQL statement length in the slow-query log event. Trailing characters are replaced with `...`. `0` disables truncation. |
 | `redact` | list[str] | see [Redaction](#redaction) | Additional keys (case-insensitive) to mask with `[REDACTED]`. Unioned with the built-in defaults — never replaces them. |
 | `per_logger` | table | `{}` | Map of logger name → level. Applied after the global setup so individual loggers can be tuned. |
+
+!!! note "Console logs go to stderr"
+    The console handler writes to **stderr**, not stdout. This keeps stdout
+    clean for the machine-readable output that CLI commands emit there (for
+    example the JSON from `protean ir show` and `protean schema show --raw`), so
+    that output stays safe to pipe. Container runtimes capture stderr alongside
+    stdout, so server log collection is unaffected.
 
 ### `[logging.sampling]`
 


### PR DESCRIPTION
Documentation follow-ups for two already-merged 0.16.1 fixes that shipped without doc coverage (found in the post-v0.16.0 docs cross-check).

## #1010 — console logs now go to stderr
- **Fixes an inaccurate statement:** `reference/logging.md` said an empty `log_dir` means "stdout only" — the console handler now writes to **stderr**.
- Adds a note that console logs go to stderr so stdout stays clean for machine-readable CLI output.
- Documents the stdout/stderr split for `protean ir show` and `protean schema show --raw`, so their JSON is noted as pipe-safe.

## #1011 — restored testing helpers are deprecated
- Adds a deprecation admonition for `protean.testing.assert_valid` / `assert_invalid` (removal in v0.18.0) in the error-handling guide, with the `pytest.raises(ValidationError, match=...)` migration.

Docs-only; no changelog fragment (the #1010/#1011 fixes already carry theirs). The `$any` docs for #1023 ship in PR #1024 with that fix.

Labeled `backport release/0.16.x` so the docs land on the maintenance branch alongside the fixes they describe.
