### PR TITLE
Serialize Date fields to ISO strings in payloads (#1046)

### DIFF
--- a/changes/1046.fixed.md
+++ b/changes/1046.fixed.md
@@ -1,0 +1,1 @@
+Fix a `Date` (`datetime.date`) field on a command or event raising `TypeError: Object of type date is not JSON serializable` when the message is processed. `ResolvedField.as_dict` now serializes plain `date` values to ISO-8601 strings; previously only `datetime` had a branch, so a raw `date` reached `MessageEnvelope.compute_checksum`'s `json.dumps` and failed.

--- a/src/protean/fields/resolved.py
+++ b/src/protean/fields/resolved.py
@@ -19,7 +19,7 @@ import decimal
 import types as _types
 import typing
 from collections import defaultdict
-from datetime import datetime
+from datetime import date, datetime
 from enum import Enum
 from typing import Any
 
@@ -192,6 +192,11 @@ class ResolvedField:
             # naive/aware distinction and the UTC offset are preserved, so the
             # instant round-trips unchanged (a named zone is serialized as its
             # fixed offset, not the original tzinfo object). See #1039.
+            return value.isoformat()
+        # ``datetime`` subclasses ``date``, so this must come *after* the
+        # datetime check. Without it a plain ``date`` flows unserialized into
+        # ``json.dumps`` (e.g. checksum computation) and raises. See #1046.
+        if isinstance(value, date):
             return value.isoformat()
         # Decimals are string-encoded so JSON/event payloads never round-trip
         # through a binary float and lose precision.

--- a/tests/adapters/repository/generic/test_complex_fields.py
+++ b/tests/adapters/repository/generic/test_complex_fields.py
@@ -5,11 +5,12 @@ Uses separate aggregates per field type to isolate List and Dict behavior.
 """
 
 import decimal
+from datetime import date
 
 import pytest
 
 from protean.core.aggregate import BaseAggregate
-from protean.fields import Decimal, Dict, List, String
+from protean.fields import Date, Decimal, Dict, List, String
 
 
 class TaggedItem(BaseAggregate):
@@ -33,12 +34,18 @@ class Money(BaseAggregate):
     amount: Decimal(precision=19, scale=4)
 
 
+class Campaign(BaseAggregate):
+    label: String(max_length=100, required=True)
+    starts_on: Date()
+
+
 @pytest.fixture(autouse=True)
 def register_elements(test_domain):
     test_domain.register(TaggedItem)
     test_domain.register(MetadataHolder)
     test_domain.register(Config)
     test_domain.register(Money)
+    test_domain.register(Campaign)
     test_domain.init(traverse=False)
 
 
@@ -196,3 +203,27 @@ class TestDecimalFieldPersistence:
         repo.add(retrieved)
 
         assert repo.get(money.id).amount == decimal.Decimal("7.2500")
+
+
+@pytest.mark.basic_storage
+class TestDateFieldPersistence:
+    """Persist a Date field and verify it round-trips on every database
+    provider (#1046)."""
+
+    def test_persist_and_retrieve_date(self, test_domain):
+        campaign = Campaign(label="summer", starts_on=date(2024, 6, 1))
+        test_domain.repository_for(Campaign).add(campaign)
+
+        retrieved = test_domain.repository_for(Campaign).get(campaign.id)
+        assert retrieved.starts_on == date(2024, 6, 1)
+
+    def test_update_date(self, test_domain):
+        repo = test_domain.repository_for(Campaign)
+        campaign = Campaign(label="update", starts_on=date(2024, 6, 1))
+        repo.add(campaign)
+
+        retrieved = repo.get(campaign.id)
+        retrieved.starts_on = date(2024, 7, 15)
+        repo.add(retrieved)
+
+        assert repo.get(campaign.id).starts_on == date(2024, 7, 15)

--- a/tests/event/test_serialization.py
+++ b/tests/event/test_serialization.py
@@ -1,12 +1,12 @@
 import json
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from uuid import UUID, uuid4
 
 import pytest
 
 from protean.core.aggregate import BaseAggregate
 from protean.core.event import BaseEvent
-from protean.fields import DateTime, Identifier, String
+from protean.fields import Date, DateTime, Identifier, String
 from protean.utils.eventing import Message
 
 from tests.event.elements import Person, PersonAdded
@@ -25,12 +25,20 @@ class PersonRegisteredWithDate(BaseEvent):
     registered_at: DateTime()
 
 
+class PersonScheduled(BaseEvent):
+    id: Identifier(required=True)
+    first_name: String(max_length=50, required=True)
+    last_name: String(max_length=50, required=True)
+    scheduled_on: Date()
+
+
 @pytest.fixture(autouse=True)
 def register_elements(test_domain):
     test_domain.register(Person)
     test_domain.register(PersonAdded, part_of=Person)
     test_domain.register(PersonWithDates)
     test_domain.register(PersonRegisteredWithDate, part_of=PersonWithDates)
+    test_domain.register(PersonScheduled, part_of=PersonWithDates)
     test_domain.init(traverse=False)
 
 
@@ -134,3 +142,33 @@ def test_that_dates_in_message_are_serialized_and_deserialized():
 
     assert isinstance(reconstructed, PersonRegisteredWithDate)
     assert reconstructed.registered_at == now
+
+
+def test_that_date_field_in_message_is_serialized_and_deserialized():
+    # Regression for #1046: a Date field used to raise "Object of type date is
+    # not JSON serializable" because as_dict had no branch for plain dates, so
+    # the raw date reached compute_checksum's json.dumps.
+    scheduled_on = date(2024, 1, 2)
+    event = PersonScheduled(
+        id=str(uuid4()),
+        first_name="John",
+        last_name="Doe",
+        scheduled_on=scheduled_on,
+    )
+
+    # Date serializes to an ISO string in the payload (not a raw date object)
+    assert event.payload["scheduled_on"] == scheduled_on.isoformat()
+
+    # The message must be JSON-serializable — the bug raised inside
+    # MessageEnvelope.compute_checksum, which Message.from_domain_object calls.
+    message = Message.from_domain_object(event)
+
+    # to_dict() is JSON-clean too: a json round-trip keeps the date as its
+    # ISO string.
+    parsed = json.loads(json.dumps(event.to_dict()))
+    assert parsed["scheduled_on"] == scheduled_on.isoformat()
+
+    # Round-trip through Message should preserve the date
+    reconstructed = message.to_domain_object()
+    assert isinstance(reconstructed, PersonScheduled)
+    assert reconstructed.scheduled_on == scheduled_on

--- a/tests/field/test_resolved_field.py
+++ b/tests/field/test_resolved_field.py
@@ -229,6 +229,14 @@ class TestResolvedFieldAsDict:
         dt = datetime.datetime(2024, 1, 1, 12, 0)
         assert rf.as_dict(dt) == dt.isoformat()
 
+    def test_as_dict_with_date(self):
+        # A plain date must serialize to an ISO string (#1046); datetime
+        # subclasses date, so the date branch sits after the datetime one.
+        rf = self._make_field()
+        d = datetime.date(2024, 1, 2)
+        assert rf.as_dict(d) == "2024-01-02"
+        assert isinstance(rf.as_dict(d), str)
+
     def test_as_dict_with_enum(self):
         """Enum value extraction."""
         rf = self._make_field()


### PR DESCRIPTION
## Summary
- A `Date` (`datetime.date`) field on a command or event raised `TypeError: Object of type date is not JSON serializable` when the message was processed.
- `ResolvedField.as_dict` serialized `datetime` but had no branch for plain `date`, so a raw `date` object flowed into `MessageEnvelope.compute_checksum`'s `json.dumps` (which has no `default=` encoder) and crashed.
- Adds `if isinstance(value, date): return value.isoformat()` **after** the `datetime` branch — `datetime` subclasses `date`, so order matters. `as_dict` is the single serialization chokepoint feeding every `json.dumps` site (payload, checksum, `to_dict`), so one branch fixes all of them.

## Test plan
- [x] Field unit test: `as_dict(date)` → ISO string.
- [x] End-to-end regression: an event with a `Date` field serializes through `Message.from_domain_object` (the crash path) and round-trips.
- [x] Generic cross-database `Date` persist/retrieve/update (memory, SQLite, PostgreSQL, MSSQL, Elasticsearch).
- [x] Core suite 9710 passed; full adapter suite 10400 passed (one unrelated pre-existing flaky broker-timing test, passes on re-run); ruff + mypy clean; /simplify clean; pr-reviewer: ship.

Closes #1046
