### PR TITLE
[Backport release/0.16.x] Serialize Date fields to ISO strings in payloads (#1046)

### DIFF
--- a/changes/1046.fixed.md
+++ b/changes/1046.fixed.md
@@ -1,0 +1,1 @@
+Fix a `Date` (`datetime.date`) field on a command or event raising `TypeError: Object of type date is not JSON serializable` when the message is processed. `ResolvedField.as_dict` now serializes plain `date` values to ISO-8601 strings; previously only `datetime` had a branch, so a raw `date` reached `MessageEnvelope.compute_checksum`'s `json.dumps` and failed.

--- a/src/protean/fields/resolved.py
+++ b/src/protean/fields/resolved.py
@@ -16,7 +16,7 @@ layer all consume ``ResolvedField`` instances via the
 """
 
 from collections import defaultdict
-from datetime import datetime
+from datetime import date, datetime
 from typing import Any
 
 from pydantic import ValidationError as PydanticValidationError
@@ -186,6 +186,11 @@ class ResolvedField:
             return value.model_dump()
         if isinstance(value, datetime):
             return str(value)
+        # ``datetime`` subclasses ``date``, so this must come *after* the
+        # datetime check. Without it a plain ``date`` flows unserialized into
+        # ``json.dumps`` (e.g. checksum computation) and raises. See #1046.
+        if isinstance(value, date):
+            return value.isoformat()
         if isinstance(value, Enum):
             return value.value
         # Handle lists/tuples of VOs or datetime values

--- a/tests/adapters/repository/generic/test_complex_fields.py
+++ b/tests/adapters/repository/generic/test_complex_fields.py
@@ -4,10 +4,12 @@ Covers List and Dict field persistence, retrieval, and update operations.
 Uses separate aggregates per field type to isolate List and Dict behavior.
 """
 
+from datetime import date
+
 import pytest
 
 from protean.core.aggregate import BaseAggregate
-from protean.fields import Dict, List, String
+from protean.fields import Date, Dict, List, String
 
 
 class TaggedItem(BaseAggregate):
@@ -26,11 +28,17 @@ class Config(BaseAggregate):
     metadata_field: Dict()
 
 
+class Campaign(BaseAggregate):
+    label: String(max_length=100, required=True)
+    starts_on: Date()
+
+
 @pytest.fixture(autouse=True)
 def register_elements(test_domain):
     test_domain.register(TaggedItem)
     test_domain.register(MetadataHolder)
     test_domain.register(Config)
+    test_domain.register(Campaign)
     test_domain.init(traverse=False)
 
 
@@ -154,3 +162,27 @@ class TestComplexFieldUpdate:
         updated = test_domain.repository_for(Config).get(config.id)
         assert updated.tags == ["new"]
         assert updated.metadata_field == {"new_key": "new_value"}
+
+
+@pytest.mark.basic_storage
+class TestDateFieldPersistence:
+    """Persist a Date field and verify it round-trips on every database
+    provider (#1046)."""
+
+    def test_persist_and_retrieve_date(self, test_domain):
+        campaign = Campaign(label="summer", starts_on=date(2024, 6, 1))
+        test_domain.repository_for(Campaign).add(campaign)
+
+        retrieved = test_domain.repository_for(Campaign).get(campaign.id)
+        assert retrieved.starts_on == date(2024, 6, 1)
+
+    def test_update_date(self, test_domain):
+        repo = test_domain.repository_for(Campaign)
+        campaign = Campaign(label="update", starts_on=date(2024, 6, 1))
+        repo.add(campaign)
+
+        retrieved = repo.get(campaign.id)
+        retrieved.starts_on = date(2024, 7, 15)
+        repo.add(retrieved)
+
+        assert repo.get(campaign.id).starts_on == date(2024, 7, 15)

--- a/tests/event/test_serialization.py
+++ b/tests/event/test_serialization.py
@@ -1,12 +1,12 @@
 import json
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from uuid import UUID, uuid4
 
 import pytest
 
 from protean.core.aggregate import BaseAggregate
 from protean.core.event import BaseEvent
-from protean.fields import DateTime, Identifier, String
+from protean.fields import Date, DateTime, Identifier, String
 from protean.utils.eventing import Message
 
 from tests.event.elements import Person, PersonAdded
@@ -25,12 +25,20 @@ class PersonRegisteredWithDate(BaseEvent):
     registered_at: DateTime()
 
 
+class PersonScheduled(BaseEvent):
+    id: Identifier(required=True)
+    first_name: String(max_length=50, required=True)
+    last_name: String(max_length=50, required=True)
+    scheduled_on: Date()
+
+
 @pytest.fixture(autouse=True)
 def register_elements(test_domain):
     test_domain.register(Person)
     test_domain.register(PersonAdded, part_of=Person)
     test_domain.register(PersonWithDates)
     test_domain.register(PersonRegisteredWithDate, part_of=PersonWithDates)
+    test_domain.register(PersonScheduled, part_of=PersonWithDates)
     test_domain.init(traverse=False)
 
 
@@ -134,3 +142,33 @@ def test_that_dates_in_message_are_serialized_and_deserialized():
 
     assert isinstance(reconstructed, PersonRegisteredWithDate)
     assert reconstructed.registered_at == now
+
+
+def test_that_date_field_in_message_is_serialized_and_deserialized():
+    # Regression for #1046: a Date field used to raise "Object of type date is
+    # not JSON serializable" because as_dict had no branch for plain dates, so
+    # the raw date reached compute_checksum's json.dumps.
+    scheduled_on = date(2024, 1, 2)
+    event = PersonScheduled(
+        id=str(uuid4()),
+        first_name="John",
+        last_name="Doe",
+        scheduled_on=scheduled_on,
+    )
+
+    # Date serializes to an ISO string in the payload (not a raw date object)
+    assert event.payload["scheduled_on"] == scheduled_on.isoformat()
+
+    # The message must be JSON-serializable — the bug raised inside
+    # MessageEnvelope.compute_checksum, which Message.from_domain_object calls.
+    message = Message.from_domain_object(event)
+
+    # to_dict() is JSON-clean too: a json round-trip keeps the date as its
+    # ISO string.
+    parsed = json.loads(json.dumps(event.to_dict()))
+    assert parsed["scheduled_on"] == scheduled_on.isoformat()
+
+    # Round-trip through Message should preserve the date
+    reconstructed = message.to_domain_object()
+    assert isinstance(reconstructed, PersonScheduled)
+    assert reconstructed.scheduled_on == scheduled_on

--- a/tests/field/test_resolved_field.py
+++ b/tests/field/test_resolved_field.py
@@ -229,6 +229,14 @@ class TestResolvedFieldAsDict:
         dt = datetime.datetime(2024, 1, 1, 12, 0)
         assert rf.as_dict(dt) == str(dt)
 
+    def test_as_dict_with_date(self):
+        # A plain date must serialize to an ISO string (#1046); datetime
+        # subclasses date, so the date branch sits after the datetime one.
+        rf = self._make_field()
+        d = datetime.date(2024, 1, 2)
+        assert rf.as_dict(d) == "2024-01-02"
+        assert isinstance(rf.as_dict(d), str)
+
     def test_as_dict_with_enum(self):
         """Enum value extraction."""
         rf = self._make_field()


### PR DESCRIPTION
## Backport of #1049 (#1046) to `release/0.16.x` for the 0.16.2 patch

Manual backport — the auto-backport could not cherry-pick cleanly because `release/0.16.x` lacks the 0.17.0-only context the commit was rebased on (#1039's `datetime` isoformat change and #1045's Decimal branch in `as_dict`).

This backport applies **only** the #1046 fix: a `date` branch in `ResolvedField.as_dict` so a plain `datetime.date` on a command/event no longer raises `TypeError: Object of type date is not JSON serializable`. The release branch keeps its existing `datetime → str()` behavior (the #1039 isoformat change is **not** backported), and no Decimal/Money test scaffolding (#1038) is pulled in.

## Test plan
- [x] 59 serialization tests pass on `release/0.16.x` (date branch + regression + generic Date persistence; datetime tests still assert the branch's `str()` form).

Backports #1049 / closes #1046 for 0.16.2.
