### PR TITLE
Add externally_populated projection option (fix PROJECTION_WITHOUT_PROJECTOR false positive) (#1013)

### DIFF
--- a/changes/1013.fixed.md
+++ b/changes/1013.fixed.md
@@ -1,0 +1,1 @@
+Fix `protean check` raising a `PROJECTION_WITHOUT_PROJECTOR` false positive for projections populated by a subscriber or event handler (the anti-corruption-layer / cross-domain pattern) rather than a co-located `@projector`. Declare such projections with `@domain.projection(externally_populated=True)` to record that they are populated externally and suppress the warning.

--- a/docs/guides/consume-state/projections.md
+++ b/docs/guides/consume-state/projections.md
@@ -33,6 +33,7 @@ and schema behavior:
 | `limit` | `100` | Default maximum number of results returned by queries |
 | `abstract` | `False` | When `True`, the projection cannot be instantiated — use as a base class |
 | `database_model` | `None` | Custom database model class for advanced schema control |
+| `externally_populated` | `False` | When `True`, declares that a subscriber or event handler populates this projection (the anti-corruption-layer / cross-domain pattern) rather than a co-located `@projector`. Suppresses the `PROJECTION_WITHOUT_PROJECTOR` check warning |
 
 !!! warning "Default `limit=100` caps query results"
     All projection queries are capped at `limit` results by default. If your

--- a/src/protean/core/projection.py
+++ b/src/protean/core/projection.py
@@ -117,6 +117,10 @@ class BaseProjection(BaseModel, OptionsMixin):
             ("abstract", False),
             ("cache", None),
             ("database_model", None),
+            # When True, the projection is populated by a subscriber or event
+            # handler (the anti-corruption-layer / cross-domain pattern) rather
+            # than a co-located @projector. Suppresses PROJECTION_WITHOUT_PROJECTOR.
+            ("externally_populated", False),
             ("indexes", ()),
             ("order_by", ()),
             ("provider", "default"),

--- a/src/protean/ir/builder.py
+++ b/src/protean/ir/builder.py
@@ -765,6 +765,9 @@ class IRBuilder:
             sorted(
                 {
                     "cache": getattr(cls.meta_, "cache", None),
+                    "externally_populated": getattr(
+                        cls.meta_, "externally_populated", False
+                    ),
                     "limit": getattr(cls.meta_, "limit", 100),
                     "order_by": list(order_by) if order_by else [],
                     "provider": getattr(cls.meta_, "provider", "default"),
@@ -1452,8 +1455,13 @@ class IRBuilder:
     def _diagnose_projection_without_projector(self, ir: dict[str, Any]) -> None:
         """PROJECTION_WITHOUT_PROJECTOR: projection with no projector to populate it."""
         for proj_entry in ir["projections"].values():
+            proj = proj_entry["projection"]
+            # Projections populated by a subscriber/event handler (the
+            # anti-corruption-layer / cross-domain pattern) opt out via
+            # @domain.projection(externally_populated=True).
+            if proj.get("options", {}).get("externally_populated"):
+                continue
             if not proj_entry["projectors"]:
-                proj = proj_entry["projection"]
                 self._diagnostics.append(
                     {
                         "code": "PROJECTION_WITHOUT_PROJECTOR",

--- a/tests/ir/test_elements_contracts_diagnostics.py
+++ b/tests/ir/test_elements_contracts_diagnostics.py
@@ -638,6 +638,56 @@ class TestProjectionWithoutProjector:
         codes = [d["code"] for d in ir["diagnostics"]]
         assert "PROJECTION_WITHOUT_PROJECTOR" not in codes
 
+    def test_no_warning_when_externally_populated(self):
+        """A projection marked externally_populated (subscriber/handler-written,
+        the ACL pattern) must not be flagged even with no co-located projector."""
+        domain = Domain(name="AclProjTest", root_path=".")
+
+        @domain.aggregate
+        class Order:
+            name = String(max_length=100)
+
+        @domain.projection(externally_populated=True)
+        class VerifiedPurchases:
+            order_id = Identifier(identifier=True)
+            name = String(max_length=100)
+
+        domain.init(traverse=False)
+        ir = IRBuilder(domain).build()
+
+        proj_warnings = [
+            d
+            for d in ir["diagnostics"]
+            if d["code"] == "PROJECTION_WITHOUT_PROJECTOR"
+            and "VerifiedPurchases" in d["element"]
+        ]
+        assert proj_warnings == []
+
+    def test_externally_populated_false_still_warns(self):
+        """The opt-out is explicit: a plain projection with no projector still
+        warns (guards against the flag defaulting on)."""
+        domain = Domain(name="PlainProjTest", root_path=".")
+
+        @domain.aggregate
+        class Order:
+            name = String(max_length=100)
+
+        @domain.projection
+        class PlainView:
+            order_id = Identifier(identifier=True)
+            name = String(max_length=100)
+
+        domain.init(traverse=False)
+        ir = IRBuilder(domain).build()
+
+        proj_warnings = [
+            d
+            for d in ir["diagnostics"]
+            if d["code"] == "PROJECTION_WITHOUT_PROJECTOR"
+            and "PlainView" in d["element"]
+        ]
+        assert len(proj_warnings) == 1
+
 
 # ── AGGREGATE_TOO_LARGE ─────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- `protean check` emitted a `PROJECTION_WITHOUT_PROJECTOR` false positive for projections legitimately populated by a **subscriber or event handler** (the anti-corruption-layer / cross-domain pattern) rather than a co-located `@projector`.
- Adds an `externally_populated` projection option (default `False`). The IR rule `_diagnose_projection_without_projector` skips projections that set it, so operators declare external population explicitly instead of seeing a false positive.
- Wired through `meta_` → IR (`_extract_projection`) → the rule. No breaking change — the default leaves every existing projection flagged exactly as before.

```python
@domain.projection(externally_populated=True)
class VerifiedPurchases:   # written by a cross-domain subscriber, not a @projector
    ...
```

## Test plan
- [x] `externally_populated=True` + no projector → **not** flagged.
- [x] Plain projection + no projector → **still** flagged (guards against the flag defaulting on).
- [x] 1337 IR/projection/projector tests pass; core suite 9715 passed; ruff + format clean; /simplify + pr-reviewer (ship).
- [x] Docs: added the option to the projection configuration table.

## Out of scope
The issue's *secondary* note — `protean check` exiting non-zero on warnings-only (trips `&&` scripting) — is a separate CLI-contract change (distinct exit code / `--warnings-as-errors`) and is deliberately left for a follow-up.

Closes #1013
