### PR TITLE
CI: let fork PRs run their tests; document engine-agnostic container setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,14 @@ jobs:
 
     steps:
       - name: Log in to Docker Hub
+        # Repository secrets are not exposed to workflows from forked PRs, so
+        # the login cannot run there. Skip it for forks (the service images
+        # still pull anonymously) and never let an absent/failed login abort
+        # the job — otherwise every fork PR's tests are skipped. The login only
+        # exists to avoid Docker Hub's anonymous pull rate limit on same-repo
+        # runs.
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        continue-on-error: true
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/docs/community/contributing/setup.md
+++ b/docs/community/contributing/setup.md
@@ -105,7 +105,7 @@ $ protean test -c FULL
 ```
 
 !!! note "Any OCI container engine works, not just Docker"
-    These services run on any Docker-API-compatible container engine. Protean's
+    These services run on any OCI-compatible container engine. Protean's
     test harness connects to the service ports on `localhost`, so it is agnostic
     to what starts the containers. [OrbStack](https://orbstack.dev),
     [Podman](https://podman.io), [Colima](https://github.com/abiosoft/colima),

--- a/docs/community/contributing/setup.md
+++ b/docs/community/contributing/setup.md
@@ -104,6 +104,15 @@ $ protean test -c FULL
 ...
 ```
 
+!!! note "Any OCI container engine works, not just Docker"
+    These services run on any Docker-API-compatible container engine. Protean's
+    test harness connects to the service ports on `localhost`, so it is agnostic
+    to what starts the containers. [OrbStack](https://orbstack.dev),
+    [Podman](https://podman.io), [Colima](https://github.com/abiosoft/colima),
+    and Rancher Desktop all work with the same `docker-compose.yml`. For Podman,
+    run `podman compose` directly or point `docker compose` at the Podman socket
+    via `DOCKER_HOST`.
+
 Running a full test will also generate a coverage report as part of test
 output. Writing tests for lines that do not have coverage is a great way to
 start contributing.

--- a/docs/community/contributing/setup.md
+++ b/docs/community/contributing/setup.md
@@ -110,7 +110,7 @@ $ protean test -c FULL
     to what starts the containers. [OrbStack](https://orbstack.dev),
     [Podman](https://podman.io), [Colima](https://github.com/abiosoft/colima),
     and Rancher Desktop all work with the same `docker-compose.yml`. For Podman,
-    run `podman compose` directly or point `docker compose` at the Podman socket
+    run `podman compose` directly or point `docker-compose` (or `docker compose`) at the Podman socket
     via `DOCKER_HOST`.
 
 Running a full test will also generate a coverage report as part of test


### PR DESCRIPTION
## Summary
- **Fork PRs couldn't run their tests.** "Log in to Docker Hub" is the first step of every test job, but GitHub doesn't expose repository secrets to fork PRs, so the login failed and **every subsequent step (including the tests) was skipped** — that's why community PR #1044's CI showed all-red with no test output.
- Guard the login to run only for **pushes and same-repo PRs**; fork PRs skip it and pull the service images anonymously (fine at this volume; mssql comes from mcr.microsoft.com and needs no Docker Hub auth anyway). Also `continue-on-error: true` so a missing/failed login can never abort the job.
- Document that **any OCI-compatible container engine** (Docker, OrbStack, Podman, Colima, Rancher Desktop) works for the local test services — Protean's harness connects to `localhost` ports and is agnostic to what starts the containers.

## Verification
- The login still runs on same-repo PRs (this PR) and pushes; the fork path is exercised by the next fork PR (e.g. re-running #1044 once merged).
- `check yaml` pre-commit hook passes (workflow is valid YAML).

## Follow-up
The durable fix — mirroring service images to GHCR so fork PRs pull with `GITHUB_TOKEN` and Docker Hub drops out entirely — is tracked in #1053.
