### PR TITLE
Include handler resilience policy in the IR

### DIFF
--- a/changes/1015.fixed.md
+++ b/changes/1015.fixed.md
@@ -1,0 +1,1 @@
+Handler resilience options (`timeout`, `retries`, `backoff`, `retry_exceptions`) now appear in the materialized IR under a `resilience` key, making them visible to `protean ir diff` and the Observatory.

--- a/src/protean/ir/builder.py
+++ b/src/protean/ir/builder.py
@@ -602,8 +602,13 @@ class IRBuilder:
             for exc in retry_exceptions:
                 if isinstance(exc, str):
                     names.append(exc)
-                else:
+                elif isinstance(exc, type):
                     names.append(fqn(exc))
+                else:
+                    # Misconfigured entry (e.g. an exception instance rather
+                    # than its class) — serialize its class instead of
+                    # crashing IR materialization with an opaque AttributeError.
+                    names.append(fqn(type(exc)))
             policy["retry_exceptions"] = sorted(names)
 
         return dict(sorted(policy.items())) if policy else None

--- a/src/protean/ir/builder.py
+++ b/src/protean/ir/builder.py
@@ -575,6 +575,39 @@ class IRBuilder:
 
         return dict(sorted(entry.items()))
 
+    @staticmethod
+    def _extract_resilience_policy(cls: type) -> dict[str, Any] | None:
+        """Extract the handler's deadline/retry policy as a sparse IR dict.
+
+        Returns ``None`` when no resilience options are set (sparse IR).
+        """
+        meta = getattr(cls, "meta_", None)
+        policy: dict[str, Any] = {}
+
+        timeout = getattr(meta, "timeout", None)
+        if timeout is not None:
+            if isinstance(timeout, _dt.timedelta):
+                policy["timeout"] = timeout.total_seconds()
+            else:
+                policy["timeout"] = float(timeout)
+
+        for key in ("backoff", "retries"):
+            value = getattr(meta, key, None)
+            if value is not None:
+                policy[key] = value
+
+        retry_exceptions = getattr(meta, "retry_exceptions", None)
+        if retry_exceptions is not None:
+            names: list[str] = []
+            for exc in retry_exceptions:
+                if isinstance(exc, str):
+                    names.append(exc)
+                else:
+                    names.append(fqn(exc))
+            policy["retry_exceptions"] = sorted(names)
+
+        return dict(sorted(policy.items())) if policy else None
+
     def _extract_handler_map(self, cls: type) -> dict[str, list[str]]:
         """Extract handler map as {__type__: sorted([method_names])}."""
         handlers = getattr(cls, "_handlers", {})
@@ -617,6 +650,10 @@ class IRBuilder:
         if agg_cls is not None:
             entry["part_of"] = fqn(agg_cls)
 
+        resilience = self._extract_resilience_policy(cls)
+        if resilience is not None:
+            entry["resilience"] = resilience
+
         entry["stream_category"] = getattr(cls.meta_, "stream_category", None)
         entry["subscription"] = self._extract_subscription(cls)
 
@@ -643,6 +680,10 @@ class IRBuilder:
         agg_cls = self._resolve_aggregate_cls(cls)
         if agg_cls is not None:
             entry["part_of"] = fqn(agg_cls)
+
+        resilience = self._extract_resilience_policy(cls)
+        if resilience is not None:
+            entry["resilience"] = resilience
 
         entry["source_stream"] = getattr(cls.meta_, "source_stream", None)
         entry["stream_category"] = getattr(cls.meta_, "stream_category", None)

--- a/src/protean/ir/schema/v0.1.0/schema.json
+++ b/src/protean/ir/schema/v0.1.0/schema.json
@@ -128,6 +128,32 @@
       "additionalProperties": true
     },
 
+    "resilience": {
+      "type": "object",
+      "description": "Deadline/retry policy for a handler (sparse; only declared options appear)",
+      "properties": {
+        "timeout": {
+          "type": "number",
+          "description": "Default command validity window, in seconds"
+        },
+        "retries": {
+          "type": "integer",
+          "description": "Max retry attempts on transient exceptions"
+        },
+        "backoff": {
+          "type": "string",
+          "enum": ["exponential", "linear", "fixed"]
+        },
+        "retry_exceptions": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Fully-qualified names of exception types treated as transient"
+        }
+      },
+      "minProperties": 1,
+      "additionalProperties": false
+    },
+
     "fields_map": {
       "type": "object",
       "description": "Map of field name to field definition",
@@ -509,6 +535,7 @@
             "element_type": { "const": "COMMAND_HANDLER" },
             "part_of": { "type": "string", "minLength": 1 },
             "stream_category": { "type": "string", "minLength": 1 },
+            "resilience": { "$ref": "#/$defs/resilience" },
             "subscription": { "$ref": "#/$defs/subscription" },
             "handlers": { "$ref": "#/$defs/standard_handler_map" }
           },
@@ -533,6 +560,7 @@
                 { "type": "null" }
               ]
             },
+            "resilience": { "$ref": "#/$defs/resilience" },
             "subscription": { "$ref": "#/$defs/subscription" },
             "handlers": { "$ref": "#/$defs/standard_handler_map" }
           },

--- a/tests/ir/elements.py
+++ b/tests/ir/elements.py
@@ -205,6 +205,51 @@ def build_handler_test_domain() -> Domain:
     return domain
 
 
+def build_resilient_handler_test_domain() -> Domain:
+    """Build a domain with handlers that declare resilience options."""
+    from datetime import timedelta
+
+    domain = Domain(name="ResilientTest", root_path=".")
+
+    @domain.command(part_of="Order")
+    class PlaceOrder:
+        customer_name = String(max_length=100, required=True)
+
+    @domain.event(part_of="Order")
+    class OrderPlaced:
+        order_id = Identifier(required=True)
+
+    @domain.aggregate
+    class Order:
+        customer_name = String(max_length=100, required=True)
+
+    @domain.command_handler(
+        part_of=Order,
+        timeout=timedelta(minutes=15),
+        retries=3,
+        backoff="exponential",
+        retry_exceptions=[ValueError, "myapp.errors.TransientError"],
+    )
+    class OrderCommandHandler:
+        @handle(PlaceOrder)
+        def handle_place_order(self, command):
+            pass
+
+    @domain.event_handler(
+        part_of=Order,
+        retries=5,
+        backoff="linear",
+        retry_exceptions=[RuntimeError],
+    )
+    class OrderEventHandler:
+        @handle(OrderPlaced)
+        def on_order_placed(self, event):
+            pass
+
+    domain.init(traverse=False)
+    return domain
+
+
 def build_es_aggregate_domain() -> Domain:
     """Build a domain with an event-sourced aggregate and @apply handlers."""
     domain = Domain(name="Banking", root_path=".")

--- a/tests/ir/test_handler_extraction.py
+++ b/tests/ir/test_handler_extraction.py
@@ -240,6 +240,46 @@ class TestHandlerTimeoutAsSeconds:
 
 
 @pytest.mark.no_test_domain
+class TestHandlerRetryExceptionInstanceEntry:
+    """A misconfigured non-class retry_exceptions entry must not crash the IR."""
+
+    def test_instance_entry_serialized_as_class_fqn(self):
+        from protean import Domain, handle
+        from protean.fields.simple import Identifier, String
+        from protean.ir.builder import IRBuilder
+
+        domain = Domain(name="RetryInstanceTest", root_path=".")
+
+        @domain.command(part_of="Order")
+        class PlaceOrder:
+            order_id = Identifier(required=True)
+
+        @domain.aggregate
+        class Order:
+            customer_name = String(max_length=100, required=True)
+
+        # An exception *instance* rather than its class — a misconfiguration
+        # that previously raised an opaque AttributeError from fqn().
+        @domain.command_handler(part_of=Order, retry_exceptions=[ValueError("boom")])
+        class OrderCommandHandler:
+            @handle(PlaceOrder)
+            def handle_place_order(self, command):
+                pass
+
+        domain.init(traverse=False)
+        ir = IRBuilder(domain).build()
+
+        for cluster in ir["clusters"].values():
+            for ch in cluster["command_handlers"].values():
+                if ch["name"] == "OrderCommandHandler":
+                    assert ch["resilience"]["retry_exceptions"] == [
+                        "builtins.ValueError"
+                    ]
+                    return
+        pytest.fail("OrderCommandHandler not found")
+
+
+@pytest.mark.no_test_domain
 class TestApplicationServiceExtraction:
     """Verify application service IR dict structure."""
 

--- a/tests/ir/test_handler_extraction.py
+++ b/tests/ir/test_handler_extraction.py
@@ -4,7 +4,7 @@ import pytest
 
 from protean.ir.builder import IRBuilder
 
-from .elements import build_handler_test_domain
+from .elements import build_handler_test_domain, build_resilient_handler_test_domain
 
 
 @pytest.fixture
@@ -16,6 +16,17 @@ def account_cluster():
         if cluster["aggregate"]["name"] == "Account":
             return cluster
     pytest.fail("Account cluster not found")
+
+
+@pytest.fixture
+def resilient_order_cluster():
+    """Return the Order aggregate's cluster from the resilient handler domain."""
+    domain = build_resilient_handler_test_domain()
+    ir = IRBuilder(domain).build()
+    for _key, cluster in ir["clusters"].items():
+        if cluster["aggregate"]["name"] == "Order":
+            return cluster
+    pytest.fail("Order cluster not found")
 
 
 @pytest.mark.no_test_domain
@@ -107,6 +118,125 @@ class TestEventHandlerExtraction:
         eh = next(iter(account_cluster["event_handlers"].values()))
         keys = list(eh.keys())
         assert keys == sorted(keys)
+
+
+@pytest.mark.no_test_domain
+class TestCommandHandlerResilienceInIR:
+    """Verify that command handler resilience options appear in the IR."""
+
+    def test_resilience_present(self, resilient_order_cluster):
+        ch = next(iter(resilient_order_cluster["command_handlers"].values()))
+        assert "resilience" in ch
+
+    def test_timeout_in_seconds(self, resilient_order_cluster):
+        ch = next(iter(resilient_order_cluster["command_handlers"].values()))
+        assert ch["resilience"]["timeout"] == 900.0
+
+    def test_retries(self, resilient_order_cluster):
+        ch = next(iter(resilient_order_cluster["command_handlers"].values()))
+        assert ch["resilience"]["retries"] == 3
+
+    def test_backoff(self, resilient_order_cluster):
+        ch = next(iter(resilient_order_cluster["command_handlers"].values()))
+        assert ch["resilience"]["backoff"] == "exponential"
+
+    def test_retry_exceptions_sorted(self, resilient_order_cluster):
+        ch = next(iter(resilient_order_cluster["command_handlers"].values()))
+        exc_list = ch["resilience"]["retry_exceptions"]
+        assert len(exc_list) == 2
+        assert exc_list == sorted(exc_list)
+        assert "builtins.ValueError" in exc_list
+        assert "myapp.errors.TransientError" in exc_list
+
+    def test_resilience_keys_sorted(self, resilient_order_cluster):
+        ch = next(iter(resilient_order_cluster["command_handlers"].values()))
+        keys = list(ch["resilience"].keys())
+        assert keys == sorted(keys)
+
+    def test_handler_keys_still_sorted(self, resilient_order_cluster):
+        ch = next(iter(resilient_order_cluster["command_handlers"].values()))
+        keys = list(ch.keys())
+        assert keys == sorted(keys)
+
+
+@pytest.mark.no_test_domain
+class TestEventHandlerResilienceInIR:
+    """Verify that event handler resilience options appear in the IR."""
+
+    def test_resilience_present(self, resilient_order_cluster):
+        eh = next(iter(resilient_order_cluster["event_handlers"].values()))
+        assert "resilience" in eh
+
+    def test_no_timeout_for_event_handler(self, resilient_order_cluster):
+        eh = next(iter(resilient_order_cluster["event_handlers"].values()))
+        assert "timeout" not in eh["resilience"]
+
+    def test_retries(self, resilient_order_cluster):
+        eh = next(iter(resilient_order_cluster["event_handlers"].values()))
+        assert eh["resilience"]["retries"] == 5
+
+    def test_backoff(self, resilient_order_cluster):
+        eh = next(iter(resilient_order_cluster["event_handlers"].values()))
+        assert eh["resilience"]["backoff"] == "linear"
+
+    def test_retry_exceptions(self, resilient_order_cluster):
+        eh = next(iter(resilient_order_cluster["event_handlers"].values()))
+        assert eh["resilience"]["retry_exceptions"] == ["builtins.RuntimeError"]
+
+    def test_handler_keys_still_sorted(self, resilient_order_cluster):
+        eh = next(iter(resilient_order_cluster["event_handlers"].values()))
+        keys = list(eh.keys())
+        assert keys == sorted(keys)
+
+
+@pytest.mark.no_test_domain
+class TestHandlerResilienceOmittedWhenDefault:
+    """Verify that handlers without resilience options omit the key."""
+
+    def test_command_handler_no_resilience_key(self, account_cluster):
+        ch = next(iter(account_cluster["command_handlers"].values()))
+        assert "resilience" not in ch
+
+    def test_event_handler_no_resilience_key(self, account_cluster):
+        eh = next(iter(account_cluster["event_handlers"].values()))
+        assert "resilience" not in eh
+
+
+@pytest.mark.no_test_domain
+class TestHandlerTimeoutAsSeconds:
+    """Verify a numeric-seconds timeout is captured in the IR."""
+
+    def test_numeric_timeout_captured_as_float(self):
+        from protean import Domain, handle
+        from protean.fields.simple import Identifier, String
+        from protean.ir.builder import IRBuilder
+
+        domain = Domain(name="NumericTimeoutTest", root_path=".")
+
+        @domain.command(part_of="Order")
+        class PlaceOrder:
+            order_id = Identifier(required=True)
+
+        @domain.aggregate
+        class Order:
+            customer_name = String(max_length=100, required=True)
+
+        @domain.command_handler(part_of=Order, timeout=30)
+        class OrderCommandHandler:
+            @handle(PlaceOrder)
+            def handle_place_order(self, command):
+                pass
+
+        domain.init(traverse=False)
+        ir = IRBuilder(domain).build()
+
+        for cluster in ir["clusters"].values():
+            for ch in cluster["command_handlers"].values():
+                if ch["name"] == "OrderCommandHandler":
+                    assert ch["resilience"]["timeout"] == 30.0
+                    assert isinstance(ch["resilience"]["timeout"], float)
+                    return
+        pytest.fail("OrderCommandHandler not found")
 
 
 @pytest.mark.no_test_domain

--- a/tests/ir/test_schema_validation.py
+++ b/tests/ir/test_schema_validation.py
@@ -20,6 +20,7 @@ from .elements import (
     build_handler_test_domain,
     build_integration_domain,
     build_process_manager_domain,
+    build_resilient_handler_test_domain,
     build_status_field_domain,
     build_via_and_min_length_domain,
 )
@@ -42,6 +43,7 @@ _DOMAIN_BUILDERS = [
     pytest.param(build_cluster_test_domain, id="cluster_test"),
     pytest.param(build_command_event_test_domain, id="command_event_test"),
     pytest.param(build_handler_test_domain, id="handler_test"),
+    pytest.param(build_resilient_handler_test_domain, id="resilient_handler_test"),
     pytest.param(build_es_aggregate_domain, id="es_aggregate"),
     pytest.param(build_domain_service_domain, id="domain_service"),
     pytest.param(build_process_manager_domain, id="process_manager"),


### PR DESCRIPTION
## Summary

The handler resilience options introduced in 0.16.0 — `timeout`, `retries`, `backoff`, `retry_exceptions` on `@command_handler`/`@event_handler` — were not surfaced in the materialized IR, so `protean ir diff`, staleness checks, and the Observatory could not detect or display a handler's deadline/retry policy.

This adds a shared `IRBuilder._extract_resilience_policy` helper that emits these options under a sparse `resilience` key on each command-/event-handler IR node:

- `timeout` is normalized to seconds (`float`) whether declared as a `timedelta` or a raw number.
- `retry_exceptions` are serialized to sorted, fully-qualified names (via the existing `fqn()` helper), so exception classes and dotted-path strings both produce stable, diffable output.
- The `resilience` key is **omitted entirely** when a handler declares no resilience options, keeping the IR sparse.
- Event handlers, which have no `timeout` option, correctly omit `timeout` while still capturing `retries`/`backoff`/`retry_exceptions`.

Only command and event handlers define these options; process managers, projectors, and subscribers do not, so the extraction is scoped to those two element types.

## Test plan
- [x] Core tests pass (`protean test`) — 9743 passed (1 pre-existing, environment-only failure in `test_new.py` unrelated to this change)
- [x] Full IR suite passes — 1127 passed
- [x] New positive tests (options captured) and negative tests (key omitted when unset, no `timeout` on event handlers)
- [x] Patch coverage 100% of executable lines (the only lines diff-cover reports missing are the `@staticmethod`/`def` signature lines — a pre-existing coverage artifact affecting every method in `builder.py`)
- [ ] Full adapter suite — not run (Docker unavailable in this environment); change is pure IR logic with no adapter dependencies

Closes #1015