### PR TITLE
Reflect Auto(increment=True) value onto the aggregate in repository.add()

### DIFF
--- a/changes/1056.fixed.md
+++ b/changes/1056.fixed.md
@@ -1,0 +1,1 @@
+`repository.add()` now reflects an `Auto(increment=True)` value generated during create back onto the aggregate instance — previously it stayed `None`, so an auto-increment identity was unusable after `add()`. This restores parity with `dao.create()` for stores that assign the value during the create (e.g. the in-memory provider).

--- a/src/protean/port/dao.py
+++ b/src/protean/port/dao.py
@@ -570,6 +570,26 @@ class BaseDAO(metaclass=ABCMeta):
         # Invokes the __bool__ method on `ResultSet`.
         return bool(results)
 
+    def _reflect_auto_fields(self, entity_obj: Any, model_obj: Any) -> None:
+        """Copy store-generated auto-increment values back onto the entity.
+
+        An ``Auto(increment=True)`` field's value is produced by the
+        persistence store during the create, not by the entity. After the
+        record is created, reflect that value back onto the in-memory instance
+        so the caller holds the same identity that was persisted. Only fields
+        still unset on the entity are updated, so a caller-supplied value is
+        never overwritten.
+        """
+        for field_name, field_obj in declared_fields(entity_obj).items():
+            is_auto = getattr(field_obj, "increment", False)
+            if is_auto and getattr(entity_obj, field_name) is None:
+                if isinstance(model_obj, dict):
+                    field_val = model_obj[field_name]
+                else:
+                    field_val = getattr(model_obj, field_name)
+
+                setattr(entity_obj, field_name, field_val)
+
     def create(self, *args, **kwargs) -> "BaseEntity":
         """Create a new record in the data store.
 
@@ -597,16 +617,8 @@ class BaseDAO(metaclass=ABCMeta):
             # Build the model object and persist into data store
             model_obj = self._create(self.database_model_cls.from_entity(entity_obj))
 
-            # Reverse update auto fields into entity
-            for field_name, field_obj in declared_fields(entity_obj).items():
-                is_auto = getattr(field_obj, "increment", False)
-                if is_auto and not getattr(entity_obj, field_name):
-                    if isinstance(model_obj, dict):
-                        field_val = model_obj[field_name]
-                    else:
-                        field_val = getattr(model_obj, field_name)
-
-                    setattr(entity_obj, field_name, field_val)
+            # Reflect store-generated auto-increment values back onto the entity
+            self._reflect_auto_fields(entity_obj, model_obj)
 
             # Set Entity status to saved to let everybody know it has been persisted
             entity_obj.state_.mark_saved()
@@ -670,7 +682,17 @@ class BaseDAO(metaclass=ABCMeta):
                 # Perform unique checks. Raises validation errors if unique constraints are violated.
                 self._validate_unique(entity_obj)
 
-                self._create(self.database_model_cls.from_entity(entity_obj))
+                model_obj = self._create(
+                    self.database_model_cls.from_entity(entity_obj)
+                )
+
+                # Reflect store-generated auto-increment values back onto the
+                # entity — save() previously dropped this, so an
+                # Auto(increment=True) field stayed None after repository.add().
+                # Stores that assign the value during _create (e.g. memory) are
+                # reflected here; relational adapters assign it at flush, which
+                # lands after this point — tracked separately (#1059).
+                self._reflect_auto_fields(entity_obj, model_obj)
 
             # Set Entity status to saved to let everybody know it has been persisted
             entity_obj.state_.mark_saved()

--- a/tests/adapters/repository/memory/test_memory_auto_fields.py
+++ b/tests/adapters/repository/memory/test_memory_auto_fields.py
@@ -76,6 +76,80 @@ def test_auto_field_increment_with_identifier_field(test_domain):
     assert saved_entities[1].id == 2
 
 
+def test_add_reflects_auto_increment_value_onto_original_instance(test_domain):
+    """repository.add() must reflect the generated auto-increment value back
+    onto the *same* instance the caller passed in — not just onto a re-fetched
+    copy. Regression test for the save() path dropping the reverse-update.
+    """
+    entity = AutoEntity(name="Reflected")
+    assert entity.sequence is None  # not generated until persisted
+
+    test_domain.repository_for(AutoEntity).add(entity)
+
+    # The original instance now carries the store-generated value.
+    assert entity.sequence == 1
+
+
+def test_add_reflects_auto_increment_identifier_onto_original_instance(test_domain):
+    """The identifier case from the issue: an Auto(increment=True) identifier
+    must be usable after add() — the instance's id can't stay None, or the
+    aggregate can't be referenced or re-fetched by that id.
+    """
+    entity = AutoIdentifierEntity(name="Reflected")
+    assert entity.id is None
+
+    test_domain.repository_for(AutoIdentifierEntity).add(entity)
+
+    assert entity.id == 1
+    # And the reflected id actually resolves the persisted record.
+    assert test_domain.repository_for(AutoIdentifierEntity).get(entity.id).name == (
+        "Reflected"
+    )
+
+
+def test_add_reflects_multiple_auto_increment_fields_onto_original_instance(
+    test_domain,
+):
+    """All auto-increment fields on the instance are reflected, not just the
+    identifier."""
+    entity = MultipleAutoEntity(name="Reflected")
+    assert entity.seq1 is None
+    assert entity.seq2 is None
+
+    test_domain.repository_for(MultipleAutoEntity).add(entity)
+
+    assert entity.seq1 == 1
+    assert entity.seq2 == 1
+
+
+def test_reflect_auto_fields_reads_object_model_via_getattr(test_domain):
+    """_reflect_auto_fields handles two model shapes: dict (in-memory adapter)
+    and object (SQLAlchemy/Elasticsearch). The in-memory tests cover the dict
+    branch; this exercises the object branch directly, since the memory adapter
+    never yields an object model.
+    """
+    from types import SimpleNamespace
+
+    dao = test_domain.repository_for(AutoEntity)._dao
+    entity = AutoEntity(name="ObjectModel")
+    assert entity.sequence is None
+
+    # An object (non-dict) model whose generated value is read via getattr.
+    dao._reflect_auto_fields(entity, SimpleNamespace(sequence=7))
+
+    assert entity.sequence == 7
+
+
+def test_create_reflects_auto_increment_value_onto_returned_instance(test_domain):
+    """dao.create() reflects the generated value onto the entity it returns —
+    the other caller of the shared reverse-update helper. Guards the extraction
+    from drifting away from the save()/add() path.
+    """
+    created = test_domain.repository_for(AutoEntity)._dao.create(name="Created")
+
+    assert created.sequence == 1
+
+
 def test_auto_field_not_overwritten_when_already_set(test_domain):
     """Test that Auto field is not overwritten when value is already present"""
     # Create entity with sequence already set


### PR DESCRIPTION
## Summary

`repository.add(aggregate)` did **not** reflect an `Auto(increment=True)` field's generated value back onto the aggregate instance — it stayed `None` — even though the value was generated and persisted. `dao.create()` handled this correctly, so an auto-increment identifier was effectively unusable through the repository (the returned aggregate's id was `None`, so it couldn't be referenced or re-fetched).

**Root cause:** `BaseDAO.save()` (the `repository.add()` path) called `_create()` but discarded its return value and omitted the reverse-update that `create()` performs.

**Fix:** extract the reverse-update into a shared `_reflect_auto_fields()` helper on `BaseDAO`, called from both `create()` and `save()`. The guard is `is None` (not falsy) so a caller-supplied value — including `0` — is never clobbered.

## Scope

- Fully fixes stores that assign the value **during** `_create` — the in-memory provider (the reported case).
- Relational adapters (SQLAlchemy → Postgres/SQLite/MSSQL) assign the DB primary key at **flush**, which lands *after* `save()`'s reverse-update (and, under an outer `UnitOfWork`, after `add()` returns). Reflecting it there requires a flush-before-reflection, which is the `_flush()` seam being added by #1044 — so it's deferred to **#1059** (blocked by #1044) and documented in-code and in the changelog.

## Tests (in-memory)

- Reflection onto the **original instance** (the gap existing tests missed — they only checked re-fetched copies) for single, identifier, and multiple auto-increment fields.
- The `create()` caller after the extraction, and the object-model (`getattr`) branch of the helper.

## Test plan
- [x] Core tests pass (9733 passed)
- [x] Full adapter suite: all DB/document categories green (SQLite, PostgreSQL, MSSQL, Elasticsearch, MessageDB); the combined-run blip was a load-induced broker timing flake, unrelated to this DB-only change (all broker categories pass in isolation)
- [x] 100% patch coverage (vs `origin/main`)

Closes #1056