### PR TITLE
Accept transient-retry options on projectors (#1076)

### DIFF
--- a/changes/1076.fixed.md
+++ b/changes/1076.fixed.md
@@ -1,0 +1,1 @@
+Projectors now accept the `retries`, `backoff`, and `retry_exceptions` options for per-projector transient-failure retry, mirroring event and command handlers. The shared handler wrapper already honored these options; the projector factory previously rejected them with `Unknown option(s)`.

--- a/docs/guides/consume-state/projectors.md
+++ b/docs/guides/consume-state/projectors.md
@@ -227,6 +227,46 @@ Keep three boundaries in mind:
   Renaming a projector method changes its `handler` identity, orphaning its old
   markers, which the same cleanup eventually removes.
 
+## Transient-failure retries
+
+A projector can retry a handler method *in place* when it fails with a
+transient exception, before the message is ever re-delivered or routed to the
+DLQ. Set `retries` (and optionally `backoff` / `retry_exceptions`) on the
+projector, exactly as on [event handlers](event-handlers.md#transient-failure-retries):
+
+```python
+@domain.projector(
+    projector_for=LowStockReport,
+    aggregates=[InventoryItem],
+    retries=8,
+    backoff="exponential",
+    retry_exceptions=["protean.exceptions.TransactionError"],
+)
+class LowStockReportProjector:
+    @on(StockDepleted)
+    def on_stock_depleted(self, event: StockDepleted):
+        ...
+```
+
+Each attempt runs in a fresh Unit of Work, so a partial read-model write from a
+failed attempt is rolled back before the next one begins. This is the natural
+fix for a concurrency race where a level-triggered event is delivered twice and
+both runs take the create path for the same read-model key: the loser hits a
+primary-key conflict (a `TransactionError`, which the version/OCC retry does
+*not* cover). Adding `TransactionError` to `retry_exceptions` lets the losing
+run retry instead of aborting the command under `event_processing=sync`.
+
+The retry re-runs the *same* handler, so convergence is only automatic if the
+handler re-checks existence each time — write it as an idempotent upsert
+(get-or-create, as under [Idempotency](#idempotency) above) rather than an
+unconditional `repo.add(...)`. On the retry the winning run's record is now
+visible, so the handler takes the update path and commits cleanly.
+
+The behaviour is identical to event and command handlers: it is opt-in and
+disabled unless `retries` is set or `server.transient_retry` is enabled. See
+[`server.transient_retry`](../../reference/configuration/index.md) for
+domain-wide defaults.
+
 ## Event Ordering
 
 Be aware that events may not always arrive in the expected order. Design

--- a/src/protean/core/projector.py
+++ b/src/protean/core/projector.py
@@ -25,6 +25,9 @@ class BaseProjector(Element, HandlerMixin, OptionsMixin):
     | ``projector_for`` | ``type`` | The projection class this projector maintains. Required. |
     | ``aggregates`` | ``list`` | Aggregate classes whose events this projector listens to. |
     | ``stream_categories`` | ``list`` | Explicit stream categories to subscribe to. Overrides ``aggregates``. |
+    | ``retries`` | ``int`` | Max retry attempts on transient exceptions. Overrides ``server.transient_retry``; ``None`` defers to it. |
+    | ``backoff`` | ``str`` | Retry delay strategy: ``"exponential"``, ``"linear"``, or ``"fixed"``. |
+    | ``retry_exceptions`` | ``list`` | Exception types (classes or dotted paths) treated as transient for retry. |
 
     Example::
 
@@ -50,7 +53,7 @@ class BaseProjector(Element, HandlerMixin, OptionsMixin):
     element_type = DomainObjects.PROJECTOR
 
     @classmethod
-    def _default_options(cls):
+    def _default_options(cls) -> list[tuple[str, Any]]:
         projector_for = (
             getattr(cls.meta_, "projector_for")
             if hasattr(cls.meta_, "projector_for")
@@ -82,6 +85,17 @@ class BaseProjector(Element, HandlerMixin, OptionsMixin):
             ("projector_for", projector_for),
             ("aggregates", aggregates),
             ("stream_categories", stream_categories),
+            # Transient-failure retry policy (parity with event handlers and
+            # command handlers). ``retries`` (int) sets the max retry attempts
+            # on transient exceptions and overrides the domain-level
+            # ``server.transient_retry`` config; ``None`` defers to it.
+            # ``backoff`` selects the delay strategy ("exponential" | "linear"
+            # | "fixed"). ``retry_exceptions`` overrides which exception types
+            # are treated as transient (classes or dotted paths). The shared
+            # handler wrapper (``protean.utils.mixins``) already consumes these.
+            ("retries", None),
+            ("backoff", None),
+            ("retry_exceptions", None),
             # Subscription configuration options (parity with event handlers and PMs)
             ("subscription_type", None),
             ("subscription_profile", None),

--- a/tests/projector/test_projector_options.py
+++ b/tests/projector/test_projector_options.py
@@ -92,6 +92,50 @@ class TestAggregatesOption:
         assert DummyProjector.meta_.aggregates == [DummyAggregate1, DummyAggregate2]
 
 
+class TestTransientRetryOptions:
+    """Projectors accept the same transient-retry options as event and command
+    handlers; the shared handler wrapper (``protean.utils.mixins``) consumes
+    them. See issue #1076."""
+
+    def test_retry_options_default_to_none(self, test_domain):
+        test_domain.register(
+            DummyProjector,
+            projector_for=DummyProjection,
+            stream_categories=["dummy_stream_1"],
+        )
+        assert DummyProjector.meta_.retries is None
+        assert DummyProjector.meta_.backoff is None
+        assert DummyProjector.meta_.retry_exceptions is None
+
+    def test_retry_options_are_accepted_and_stored(self, test_domain):
+        test_domain.register(
+            DummyProjector,
+            projector_for=DummyProjection,
+            stream_categories=["dummy_stream_1"],
+            retries=8,
+            backoff="exponential",
+            retry_exceptions=["protean.exceptions.TransactionError"],
+        )
+        assert DummyProjector.meta_.retries == 8
+        assert DummyProjector.meta_.backoff == "exponential"
+        assert DummyProjector.meta_.retry_exceptions == [
+            "protean.exceptions.TransactionError"
+        ]
+
+    def test_retry_options_via_annotation(self, test_domain):
+        @test_domain.projector(
+            projector_for=DummyProjection,
+            stream_categories=["dummy_stream_1"],
+            retries=3,
+            backoff="linear",
+        )
+        class DummyProjectorWithRetry(BaseProjector):
+            pass
+
+        assert DummyProjectorWithRetry.meta_.retries == 3
+        assert DummyProjectorWithRetry.meta_.backoff == "linear"
+
+
 class TestStreamCategoriesOption:
     def test_stream_categories_as_option(self, test_domain):
         test_domain.register(

--- a/tests/projector/test_projector_transient_retry.py
+++ b/tests/projector/test_projector_transient_retry.py
@@ -1,0 +1,195 @@
+"""Behavioral tests proving the shared handler wrapper honors per-projector
+transient-retry options.
+
+The wrapper (``protean.utils.mixins.handle``) already reads ``retries`` /
+``backoff`` / ``retry_exceptions`` off ``meta_`` for any handler. Projectors
+use that exact wrapper, so once the projector factory accepts the options, a
+projector retries transient failures in place — mirroring event and command
+handlers. See issue #1076.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from protean import current_domain
+from protean.core.projection import BaseProjection
+from protean.core.projector import BaseProjector, on
+from protean.exceptions import TransactionError
+from protean.fields import Identifier, String
+
+from .elements import Registered, User
+
+
+class UserReport(BaseProjection):
+    user_id: Identifier(identifier=True)
+    name: String()
+
+
+@pytest.fixture(autouse=True)
+def register(test_domain):
+    test_domain.register(User)
+    test_domain.register(Registered, part_of=User)
+    test_domain.register(UserReport)
+
+
+def _event():
+    return Registered(user_id="1", email="john@example.com", name="John")
+
+
+class TestProjectorTransientRetry:
+    @patch("protean.utils.mixins.time.sleep")
+    def test_projector_retries_on_transient_then_succeeds(
+        self, mock_sleep, test_domain
+    ):
+        """The wrapper fires for a projector: a transient error is retried in
+        place. Previously impossible — the factory rejected ``retries``."""
+        attempts = 0
+
+        class ReportProjector(BaseProjector):
+            @on(Registered)
+            def on_registered(self, event: Registered):
+                nonlocal attempts
+                attempts += 1
+                if attempts == 1:
+                    raise ConnectionError("transient")
+
+        test_domain.register(
+            ReportProjector,
+            projector_for=UserReport,
+            aggregates=[User],
+            retries=2,
+        )
+        test_domain.init(traverse=False)
+
+        ReportProjector._handle(_event())
+
+        assert attempts == 2
+        mock_sleep.assert_called_once()
+
+    @patch("protean.utils.mixins.time.sleep")
+    def test_projector_retries_via_domain_toggle(self, mock_sleep, test_domain):
+        """Parity path: a projector with no explicit ``retries`` still retries
+        when the domain-wide ``server.transient_retry`` toggle is enabled."""
+        test_domain.config["server"]["transient_retry"]["enabled"] = True
+        attempts = 0
+
+        class ReportProjector(BaseProjector):
+            @on(Registered)
+            def on_registered(self, event: Registered):
+                nonlocal attempts
+                attempts += 1
+                if attempts == 1:
+                    raise ConnectionError("transient")
+
+        test_domain.register(
+            ReportProjector, projector_for=UserReport, aggregates=[User]
+        )
+        test_domain.init(traverse=False)
+
+        ReportProjector._handle(_event())
+
+        assert attempts == 2
+        mock_sleep.assert_called_once()
+
+    @patch("protean.utils.mixins.time.sleep")
+    def test_projector_retry_exceptions_cover_transaction_error(
+        self, mock_sleep, test_domain
+    ):
+        """The issue's motivating case: a primary-key conflict surfaces as a
+        ``TransactionError``, which the version/OCC retry does not cover.
+        Listing it in ``retry_exceptions`` lets the losing run retry."""
+        attempts = 0
+
+        class ReportProjector(BaseProjector):
+            @on(Registered)
+            def on_registered(self, event: Registered):
+                nonlocal attempts
+                attempts += 1
+                if attempts == 1:
+                    raise TransactionError("duplicate key")
+
+        test_domain.register(
+            ReportProjector,
+            projector_for=UserReport,
+            aggregates=[User],
+            retries=4,
+            retry_exceptions=["protean.exceptions.TransactionError"],
+        )
+        test_domain.init(traverse=False)
+
+        ReportProjector._handle(_event())
+
+        assert attempts == 2
+        mock_sleep.assert_called_once()
+
+    @patch("protean.utils.mixins.time.sleep")
+    def test_transaction_error_not_retried_without_override(
+        self, mock_sleep, test_domain
+    ):
+        """Negative path: ``TransactionError`` is outside the default transient
+        set, so without adding it to ``retry_exceptions`` it propagates even
+        when ``retries`` is set."""
+        attempts = 0
+
+        class ReportProjector(BaseProjector):
+            @on(Registered)
+            def on_registered(self, event: Registered):
+                nonlocal attempts
+                attempts += 1
+                raise TransactionError("duplicate key")
+
+        test_domain.register(
+            ReportProjector,
+            projector_for=UserReport,
+            aggregates=[User],
+            retries=4,
+        )
+        test_domain.init(traverse=False)
+
+        with pytest.raises(TransactionError):
+            ReportProjector._handle(_event())
+
+        assert attempts == 1
+        mock_sleep.assert_not_called()
+
+    @patch("protean.utils.mixins.time.sleep")
+    def test_failed_attempt_rolls_back_partial_write(self, mock_sleep, test_domain):
+        """End-to-end against a real projection: because each attempt runs in a
+        fresh Unit of Work, a read-model write from a failed attempt is rolled
+        back before the retry. The first attempt writes a *leftover* record and
+        then fails; if the UoW were not rolled back that record would survive
+        alongside the real one, so asserting exactly one record (the real key)
+        is what makes this non-vacuous."""
+        attempts = 0
+
+        class ReportProjector(BaseProjector):
+            @on(Registered)
+            def on_registered(self, event: Registered):
+                nonlocal attempts
+                attempts += 1
+                repo = current_domain.repository_for(UserReport)
+                if attempts == 1:
+                    # Partial write that must NOT survive the failed attempt.
+                    repo.add(UserReport(user_id="leftover", name="partial"))
+                    raise TransactionError("failure after a partial write")
+                repo.add(UserReport(user_id=event.user_id, name=event.name))
+
+        test_domain.register(
+            ReportProjector,
+            projector_for=UserReport,
+            aggregates=[User],
+            retries=3,
+            retry_exceptions=["protean.exceptions.TransactionError"],
+        )
+        test_domain.init(traverse=False)
+
+        ReportProjector._handle(_event())
+
+        assert attempts == 2
+        mock_sleep.assert_called_once()
+
+        reports = current_domain.repository_for(UserReport).query.all().items
+        assert len(reports) == 1  # the "leftover" write was rolled back
+        assert reports[0].user_id == "1"
+        assert reports[0].name == "John"


### PR DESCRIPTION
## Summary

Projectors use the shared handler wrapper (`protean.utils.mixins`), which already reads `retries` / `backoff` / `retry_exceptions` off `meta_` for any handler. But `BaseProjector._default_options` omitted those options, so `derive_element_class` rejected them with `ConfigurationError: Unknown option(s)` — making per-projector transient retry impossible to configure even though the machinery was wired to honor it.

This adds `retries` / `backoff` / `retry_exceptions` to `BaseProjector._default_options`, mirroring `BaseEventHandler` and `BaseCommandHandler`. Projectors can now retry transient failures in place, including a primary-key `TransactionError` from a level-triggered double-delivery (the losing run of a concurrent create), which the version/OCC retry does not cover.

## Changes

- `src/protean/core/projector.py`: add the three retry options to `_default_options` (with a return-type hint); document them in the Meta Options table.
- `docs/guides/consume-state/projectors.md`: new "Transient-failure retries" section, with the fresh-UoW rollback semantics and the existence-check precondition for convergence made explicit.
- Tests: option-parsing tests plus behavioral tests proving the wrapper fires for projectors — retry-then-succeed, domain-toggle parity, `TransactionError` coverage via `retry_exceptions` (positive + negative), and a real-projection test proving a failed attempt's partial write is rolled back in a fresh Unit of Work.

## Test plan

- [x] Core tests pass (`protean test`) — 9855 passed
- [x] Full adapter suite passes (`protean test -c FULL`) — 10549 passed across all adapters
- [x] New tests: 18 added, all green; revert-check confirms the fix-gating tests go red without the change
- [x] `ruff` + `mypy` clean on changed files (pre-existing `projector_factory` mypy notes unchanged from main)
- [x] `mkdocs build --strict` passes

Closes #1076