### PR TITLE
Add GHCR mirror workflow + harden CI container startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,9 +94,16 @@ jobs:
 
       - name: Start service containers
         run: |
-          # Remove any leaked containers from a previous run on this runner so
-          # the host port bindings below are guaranteed to be free.
-          docker rm -f postgres redis message-db mssql elasticsearch 2>/dev/null || true
+          # Free the host ports below before binding them. Remove ALL containers
+          # left over from a previous run on this (potentially reused) runner:
+          # matching only our own names misses a container leaked under a
+          # different name, or one still shutting down, either of which can keep
+          # a port bound (e.g. the 59300 Elasticsearch transport port) and fail
+          # `docker run` with "address already in use".
+          leaked=$(docker ps -aq)
+          if [ -n "$leaked" ]; then
+            docker rm -f $leaked
+          fi
 
           docker run -d --name postgres \
             -p 55432:5432 \

--- a/.github/workflows/mirror-images.yml
+++ b/.github/workflows/mirror-images.yml
@@ -34,7 +34,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          # Always the org, regardless of who/what triggered the run.
+          # The owner of the repo running this workflow (this org for the
+          # canonical repo). Any username works with GITHUB_TOKEN.
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
@@ -43,7 +44,8 @@ jobs:
 
       - name: Mirror images
         env:
-          # Always the base repo's org, even when dispatched from a fork.
+          # GHCR namespace of the repo running this workflow, i.e. the
+          # canonical repo's org (proteanhq) when it runs there.
           MIRROR: ghcr.io/${{ github.repository_owner }}/mirror
         run: |
           set -euo pipefail

--- a/.github/workflows/mirror-images.yml
+++ b/.github/workflows/mirror-images.yml
@@ -1,0 +1,69 @@
+name: Mirror service images to GHCR
+
+# Copies the third-party service images used by CI (and local `make up`) into
+# this org's GitHub Container Registry (GHCR), so CI pulls from GHCR instead of
+# Docker Hub. This removes the Docker Hub login from CI, eliminates anonymous
+# pull rate-limit exposure on GitHub-hosted runners, and lets fork PRs pull the
+# images with zero secrets (public GHCR packages are readable with a fork's
+# GITHUB_TOKEN).
+#
+# One-time manual step after the first successful run: make each mirrored
+# package Public (org -> Packages -> <package> -> Package settings ->
+# visibility -> Public). Public visibility is what lets fork PRs pull anonymously.
+
+on:
+  schedule:
+    # Mondays at 06:00 UTC — refresh floating tags (e.g. :2022-latest) weekly.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: mirror-images
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          # Always the org, regardless of who/what triggered the run.
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up crane
+        uses: imjasonh/setup-crane@v0.4
+
+      - name: Mirror images
+        env:
+          # Always the base repo's org, even when dispatched from a fork.
+          MIRROR: ghcr.io/${{ github.repository_owner }}/mirror
+        run: |
+          set -euo pipefail
+
+          # "<upstream source>|<mirror path>:<tag>" — the mirror path is a flat
+          # basename so refs stay short and registry-agnostic. Keep this list in
+          # sync with the IMAGES array in ci.yml.
+          MAPPINGS=(
+            "postgres:16|postgres:16"
+            "redis:7|redis:7"
+            "elasticsearch:8.7.0|elasticsearch:8.7.0"
+            "ethangarofolo/message-db:1.2.6|message-db:1.2.6"
+            "mcr.microsoft.com/mssql/server:2022-latest|mssql-server:2022-latest"
+          )
+
+          for m in "${MAPPINGS[@]}"; do
+            src="${m%%|*}"
+            dst="${MIRROR}/${m##*|}"
+            echo "Mirroring ${src} -> ${dst}"
+            # crane copy is daemonless and preserves every platform in the
+            # source (multi-arch manifests copied intact).
+            crane copy "${src}" "${dst}"
+          done

--- a/changes/1053.changed.md
+++ b/changes/1053.changed.md
@@ -1,0 +1,1 @@
+Added a weekly `mirror-images` CI workflow that mirrors the service container images (PostgreSQL, Redis, Elasticsearch, Message-DB, MSSQL) into the project's public GHCR namespace, so CI can pull them from GHCR instead of Docker Hub (removing rate-limit exposure and letting fork PRs run the full suite with no secrets).


### PR DESCRIPTION
## Summary

First step of moving CI's service images off Docker Hub (#1053), split out so CI stayed green during rollout. Also fixed a pre-existing CI flake surfaced while validating this work.

1. **`.github/workflows/mirror-images.yml`** (new): weekly (+ `workflow_dispatch`) job that copies the five CI service images (postgres, redis, elasticsearch, message-db, mssql) into this org's GHCR namespace at `ghcr.io/proteanhq/mirror/<name>:<tag>` using `crane copy` (daemonless, multi-arch manifests preserved). Runs in the base repo with `packages: write`; never triggers on `pull_request`, so forks cannot push to GHCR.

2. **`.github/workflows/ci.yml`** — harden container startup: the "Start service containers" cleanup removed leftover containers **by known name only**, so a container leaked under a different name (or still shutting down) could keep a host port bound (e.g. Elasticsearch's `59300`) and fail `docker run` with `address already in use`. Now clears **all** containers on the runner before binding ports. Independent of the mirror (still Docker Hub here) — it just makes CI reliable on reused runners.

This PR did **not** repoint CI at the mirror; that's the follow-up (#1084).

## Rollout status

- [x] Merge this PR (mirror workflow + startup hardening landed).
- [x] Run **Mirror service images to GHCR** — first run failed on a `crane`/GHCR auth bug (`setup-crane` clobbered the login); fixed in **#1085** and re-run succeeded. All 5 packages created.
- [x] Make the 5 GHCR packages **Public** (required an org policy change to allow public packages).
- [ ] **#1084**: repoints `ci.yml` at the mirror, adds `docker-compose.yml` overrides, updates docs. CI now passing against the live public mirror; ready to merge.
- [ ] After #1084 merges: delete the unused `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` secrets.

## Test plan

- [x] Workflow YAML parses
- [x] Mirror run succeeds and populates `ghcr.io/proteanhq/mirror/*` (after #1085)
- [x] CI green (the container-startup hardening fixed the `address already in use` flake)

Refs #1053