### PR TITLE
Repoint CI service images at the GHCR mirror

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,20 +28,9 @@ jobs:
       PYO3_USE_ABI3_FORWARD_COMPATIBILITY: ${{ (matrix.python-version == '3.13' || matrix.python-version == '3.14') && '1' || '' }}
 
     steps:
-      - name: Log in to Docker Hub
-        # Repository secrets are not exposed to workflows from forked PRs, so
-        # the login cannot run there. Skip it for forks (the service images
-        # still pull anonymously) and never let an absent/failed login abort
-        # the job — otherwise every fork PR's tests are skipped. The login only
-        # exists to avoid Docker Hub's anonymous pull rate limit on same-repo
-        # runs.
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-        continue-on-error: true
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
+      # Service images are pulled from this org's public GHCR mirror (populated
+      # by mirror-images.yml), not Docker Hub. Public GHCR packages need no auth,
+      # so there is no login step and fork PRs pull them with zero secrets.
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
@@ -51,16 +40,16 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/docker-images
-          key: docker-images-${{ runner.os }}-v2
+          key: docker-images-${{ runner.os }}-v3
 
       - name: Load or pull Docker images
         run: |
           IMAGES=(
-            "postgres:16"
-            "redis:7"
-            "elasticsearch:8.7.0"
-            "ethangarofolo/message-db:1.2.6"
-            "mcr.microsoft.com/mssql/server:2022-latest"
+            "ghcr.io/proteanhq/mirror/postgres:16"
+            "ghcr.io/proteanhq/mirror/redis:7"
+            "ghcr.io/proteanhq/mirror/elasticsearch:8.7.0"
+            "ghcr.io/proteanhq/mirror/message-db:1.2.6"
+            "ghcr.io/proteanhq/mirror/mssql-server:2022-latest"
           )
 
           if [ "${{ steps.docker-cache.outputs.cache-hit }}" == "true" ]; then
@@ -108,21 +97,21 @@ jobs:
           docker run -d --name postgres \
             -p 55432:5432 \
             -e POSTGRES_PASSWORD=postgres \
-            postgres:16
+            ghcr.io/proteanhq/mirror/postgres:16
 
           docker run -d --name redis \
             -p 56379:6379 \
-            redis:7
+            ghcr.io/proteanhq/mirror/redis:7
 
           docker run -d --name message-db \
             -p 55433:5432 \
-            ethangarofolo/message-db:1.2.6
+            ghcr.io/proteanhq/mirror/message-db:1.2.6
 
           docker run -d --name mssql \
             -p 51433:1433 \
             -e ACCEPT_EULA=Y \
             -e "SA_PASSWORD=Protean123!" \
-            mcr.microsoft.com/mssql/server:2022-latest
+            ghcr.io/proteanhq/mirror/mssql-server:2022-latest
 
           docker run -d --name elasticsearch \
             -p 59200:9200 \
@@ -130,7 +119,7 @@ jobs:
             -e "discovery.type=single-node" \
             -e "xpack.security.enabled=false" \
             -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" \
-            elasticsearch:8.7.0
+            ghcr.io/proteanhq/mirror/elasticsearch:8.7.0
 
       - name: Wait for services
         run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,9 @@
-# Each service image can be overridden to pull from this org's GHCR mirror
-# instead of upstream (see docs/community/contributing/testing.md for the exact
-# mirror refs — the mirror carries CI's tag set, which differs from the defaults
-# below). The defaults keep local `make up` on upstream registries, so no auth
-# or mirror access is required for day-to-day development.
+# The mirrored service images (Elasticsearch, Redis, Postgres, Message-DB,
+# MSSQL) can each be overridden to pull from this org's GHCR mirror instead of
+# upstream (see docs/community/contributing/testing.md for the exact mirror refs
+# — the mirror carries CI's tag set, which differs from the defaults below).
+# The defaults keep local `make up` on upstream registries, so no auth or mirror
+# access is required for day-to-day development. Kibana is not mirrored.
 services:
   elasticsearch:
     image: ${ELASTICSEARCH_IMAGE:-elasticsearch:8.7.0}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,11 @@
+# Each service image can be overridden to pull from this org's GHCR mirror
+# instead of upstream (see docs/community/contributing/testing.md for the exact
+# mirror refs — the mirror carries CI's tag set, which differs from the defaults
+# below). The defaults keep local `make up` on upstream registries, so no auth
+# or mirror access is required for day-to-day development.
 services:
   elasticsearch:
-    image: elasticsearch:8.7.0
+    image: ${ELASTICSEARCH_IMAGE:-elasticsearch:8.7.0}
     environment:
       - xpack.security.enabled=false
       - discovery.type=single-node
@@ -29,14 +34,14 @@ services:
       - elasticsearch
 
   redis:
-    image: redis:7.0.11
+    image: ${REDIS_IMAGE:-redis:7.0.11}
     ports:
       - "56379:6379"
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
 
   postgres:
-    image: postgres:15.2
+    image: ${POSTGRES_IMAGE:-postgres:15.2}
     ports:
       - "55432:5432"
     environment:
@@ -46,12 +51,12 @@ services:
     command: ["postgres", "-c", "max_connections=100"]
 
   message-db:
-    image: ethangarofolo/message-db:1.3.1
+    image: ${MESSAGE_DB_IMAGE:-ethangarofolo/message-db:1.3.1}
     ports:
       - "0.0.0.0:55433:5432"
 
   mssql:
-    image: mcr.microsoft.com/mssql/server:2022-latest
+    image: ${MSSQL_IMAGE:-mcr.microsoft.com/mssql/server:2022-latest}
     ports:
       - "51433:1433"
     environment:

--- a/docs/community/contributing/testing.md
+++ b/docs/community/contributing/testing.md
@@ -76,19 +76,19 @@ Protean uses Docker Compose to provide a consistent development and testing envi
 ```yaml
 services:
   elasticsearch:
-    image: elasticsearch:8.7.0
+    image: ${ELASTICSEARCH_IMAGE:-elasticsearch:8.7.0}
     # configuration...
 
   redis:
-    image: redis:7.0.11
+    image: ${REDIS_IMAGE:-redis:7.0.11}
     # configuration...
 
   postgres:
-    image: postgres:15.2
+    image: ${POSTGRES_IMAGE:-postgres:15.2}
     # configuration...
 
   message-db:
-    image: ethangarofolo/message-db:1.2.6
+    image: ${MESSAGE_DB_IMAGE:-ethangarofolo/message-db:1.3.1}
     # configuration...
 
   ...
@@ -110,6 +110,35 @@ make up
 Refer to `Makefile` for a full list of supported `make` commands.
 
 These containers are also used in CI pipelines to ensure consistent testing across environments.
+
+### Service image mirror (GHCR)
+
+CI does not pull these images from Docker Hub. Instead it pulls them from a
+public mirror in this org's GitHub Container Registry (GHCR), at
+`ghcr.io/proteanhq/mirror/<image>`. This avoids Docker Hub's anonymous pull
+rate limit on shared CI runners and lets pull requests from forks run the full
+suite with no secrets, since public GHCR packages are readable with a fork's
+`GITHUB_TOKEN`. The `.github/workflows/mirror-images.yml` workflow refreshes the
+mirror weekly (and on demand via **Run workflow**).
+
+Local `make up` still pulls from upstream registries by default, so no mirror
+access is needed for day-to-day development. To point a service at the mirror
+instead, override its image via an environment variable before `make up`:
+
+```shell
+POSTGRES_IMAGE=ghcr.io/proteanhq/mirror/postgres:16 make up
+```
+
+The mirror carries the tags CI uses (which differ from the compose defaults), so
+use these exact refs when overriding:
+
+| Override variable | Mirror ref |
+|-------------------|------------|
+| `ELASTICSEARCH_IMAGE` | `ghcr.io/proteanhq/mirror/elasticsearch:8.7.0` |
+| `REDIS_IMAGE` | `ghcr.io/proteanhq/mirror/redis:7` |
+| `POSTGRES_IMAGE` | `ghcr.io/proteanhq/mirror/postgres:16` |
+| `MESSAGE_DB_IMAGE` | `ghcr.io/proteanhq/mirror/message-db:1.2.6` |
+| `MSSQL_IMAGE` | `ghcr.io/proteanhq/mirror/mssql-server:2022-latest` |
 
 ## Tests Organization
 


### PR DESCRIPTION
## Summary

Follow-up to #1083. Moves CI's service image pulls from Docker Hub to the public GHCR mirror and removes the Docker Hub login.

- **`ci.yml`**: drop the "Log in to Docker Hub" step; `IMAGES` array + every `docker run` ref now use `ghcr.io/proteanhq/mirror/<name>:<tag>`; docker-image cache key bumped `v2 → v3`.
- **`docker-compose.yml`**: each mirrored service image overridable (`ELASTICSEARCH_IMAGE`, `REDIS_IMAGE`, `POSTGRES_IMAGE`, `MESSAGE_DB_IMAGE`, `MSSQL_IMAGE`), defaulting to upstream so local `make up` is unchanged.
- **Docs**: new "Service image mirror (GHCR)" section with the exact mirror refs.

## Status

The GHCR mirror is populated (via #1083 + #1085) and the packages are **Public**, so CI now pulls every service image anonymously from `ghcr.io/proteanhq/mirror/*` with no Docker Hub login and no secrets. **CI is green** against the live mirror.

## After merge

Delete the now-unused `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` repo secrets.

## Notes

- The changelog fragment (`changes/1053.changed.md`) shipped in #1083.
- Pre-existing: compose pins slightly different tags than CI (`postgres:15.2` vs `16`, etc.); left as-is, and the docs table lists the exact mirror refs to use when overriding.

## Test plan

- [x] Workflow + compose YAML parse
- [x] `docker compose config` resolves to upstream by default, mirror when overridden
- [x] `mkdocs build --strict` passes
- [x] CI green against the live public mirror (all four Python versions)

Closes #1053