### PR TITLE
Fix GHCR auth in the mirror workflow

### DIFF
--- a/.github/workflows/mirror-images.yml
+++ b/.github/workflows/mirror-images.yml
@@ -30,15 +30,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          # The owner of the repo running this workflow (this org for the
-          # canonical repo). Any username works with GITHUB_TOKEN.
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Set up crane
         uses: imjasonh/setup-crane@v0.4
 
@@ -47,8 +38,17 @@ jobs:
           # GHCR namespace of the repo running this workflow, i.e. the
           # canonical repo's org (proteanhq) when it runs there.
           MIRROR: ghcr.io/${{ github.repository_owner }}/mirror
+          GHCR_USER: ${{ github.repository_owner }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+
+          # Authenticate crane to GHCR here rather than via a separate login
+          # step: setup-crane's install writes a placeholder ghcr.io entry to
+          # the Docker config, which would otherwise shadow the real token and
+          # make `crane copy` fail its blob upload with "permission_denied:
+          # write_package".
+          echo "${GHCR_TOKEN}" | crane auth login ghcr.io -u "${GHCR_USER}" --password-stdin
 
           # "<upstream source>|<mirror path>:<tag>" — the mirror path is a flat
           # basename so refs stay short and registry-agnostic. Keep this list in

--- a/.github/workflows/mirror-images.yml
+++ b/.github/workflows/mirror-images.yml
@@ -39,7 +39,7 @@ jobs:
           # canonical repo's org (proteanhq) when it runs there.
           MIRROR: ghcr.io/${{ github.repository_owner }}/mirror
           GHCR_USER: ${{ github.repository_owner }}
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
## Summary

The first run of **Mirror service images to GHCR** ([run](https://github.com/proteanhq/protean/actions/runs/28685538481)) failed with:

```
Error: PUT https://ghcr.io/v2/proteanhq/mirror/postgres/blobs/upload/...: DENIED: permission_denied: write_package
```

Root cause: `imjasonh/setup-crane`'s install script runs `crane auth login ghcr.io --username dummy --password-stdin`, which **overwrites** the real GHCR credentials written by the earlier `docker/login-action` step in the shared Docker config. `crane copy` then authenticated as that placeholder (no write access) and the blob upload was denied.

Fix: authenticate crane to GHCR **inside the mirror step** (after `setup-crane`), via `crane auth login ... --password-stdin` with the real `GITHUB_TOKEN`, and drop the now-redundant separate login step. This guarantees the real token is what `crane copy` uses.

## After merge

Re-run **Mirror service images to GHCR** on `main`. It should populate `ghcr.io/proteanhq/mirror/*`; then make the 5 packages Public (rollout step 3), and #1084 becomes unblockable.

## Test plan

- [x] Workflow YAML parses
- [ ] Mirror workflow run succeeds and creates the 5 packages (after merge)

Refs #1053