### PR TITLE
[Backport release/0.16.x] Revive Redis broker connection after close (#1055) + DLQ coverage

### DIFF
--- a/changes/1055.fixed.md
+++ b/changes/1055.fixed.md
@@ -1,0 +1,1 @@
+The Redis Streams broker now transparently reconnects if its connection was closed (e.g. `redis_instance` set to `None` by engine shutdown) before a later operation runs, instead of raising `AttributeError: 'NoneType' object has no attribute ...` and killing a subscription's poll loop. This makes `Engine(test_mode=True).run()` against a Redis broker reliable in CI.

--- a/changes/1090.changed.md
+++ b/changes/1090.changed.md
@@ -1,0 +1,1 @@
+Add Redis broker DLQ management tests (`dlq_list`, `dlq_inspect`, `dlq_replay`, `dlq_replay_all`, `dlq_purge`, `dlq_trim`, `dlq_depth`) against real Redis, backfilling coverage for the `_client` accessor refactor in #1086.

--- a/src/protean/adapters/broker/redis.py
+++ b/src/protean/adapters/broker/redis.py
@@ -50,9 +50,8 @@ class RedisBroker(BaseBroker):
         self._pool_kwargs = {
             key: value for key, value in conn_info.items() if key in self._POOL_KEYS
         }
-        self.redis_instance = redis.Redis.from_url(
-            conn_info["URI"], **self._pool_kwargs
-        )
+        self.redis_instance: Optional["redis.Redis"] = None
+        self._connect()
         self._consumer_name = f"consumer-{int(time.time() * 1000)}"
         self._created_groups_set = set()
         self._group_creation_times = {}  # Track creation times for consistency
@@ -63,6 +62,28 @@ class RedisBroker(BaseBroker):
         self._retry_delay = 1.0
         self._message_timeout = 300.0
         self._enable_dlq = False
+
+    def _connect(self) -> "redis.Redis":
+        """Create (or recreate) the underlying synchronous Redis client."""
+        self.redis_instance = redis.Redis.from_url(
+            self.conn_info["URI"], **self._pool_kwargs
+        )
+        return self.redis_instance
+
+    @property
+    def _client(self) -> "redis.Redis":
+        """Return a live Redis client, reconnecting if the connection was closed.
+
+        ``close()`` sets ``redis_instance`` to ``None``; a straggler poll read or
+        a test-teardown ``_data_reset`` running afterwards would otherwise raise
+        ``AttributeError: 'NoneType' object has no attribute ...`` (#1055). Every
+        Redis call inside this broker goes through here so those paths revive
+        instead of crashing the subscription's poll loop.
+        """
+        if self.redis_instance is None:
+            logger.debug("broker.redis.reviving_closed_connection")
+            return self._connect()
+        return self.redis_instance
 
     @property
     def capabilities(self) -> BrokerCapabilities:
@@ -81,7 +102,7 @@ class RedisBroker(BaseBroker):
     def _publish(self, stream: str, message: dict) -> str:
         """Publish a message to Redis Stream using XADD"""
         serialized_message = {DATA_FIELD: json.dumps(message or {})}
-        redis_stream_id = self.redis_instance.xadd(stream, serialized_message)
+        redis_stream_id = self._client.xadd(stream, serialized_message)
         return self._decode_if_bytes(redis_stream_id)
 
     def _get_next(self, stream: str, consumer_group: str) -> Optional[Tuple[str, dict]]:
@@ -96,7 +117,7 @@ class RedisBroker(BaseBroker):
         try:
             # Always try to read new messages first
             # Redis guarantees that each consumer in a group gets different messages
-            response = self.redis_instance.xreadgroup(
+            response = self._client.xreadgroup(
                 consumer_group,
                 self._consumer_name,
                 {stream: NEW_MESSAGES_MARK},
@@ -116,7 +137,7 @@ class RedisBroker(BaseBroker):
 
         except redis.ResponseError as e:
             return self._handle_redis_error(e, stream, consumer_group)
-        except Exception as e:
+        except Exception:
             logger.exception("broker.redis.get_next_failed")
             return None
 
@@ -154,7 +175,7 @@ class RedisBroker(BaseBroker):
         try:
             data_str = self._decode_if_bytes(data_field)
             return json.loads(data_str)
-        except (json.JSONDecodeError, UnicodeDecodeError) as e:
+        except (json.JSONDecodeError, UnicodeDecodeError):
             logger.exception("broker.redis.deserialize_failed")
             return {}
 
@@ -182,7 +203,7 @@ class RedisBroker(BaseBroker):
         try:
             # Read all requested messages at once to maintain order
             # First try to read new messages
-            response = self.redis_instance.xreadgroup(
+            response = self._client.xreadgroup(
                 consumer_group,
                 self._consumer_name,
                 {stream: NEW_MESSAGES_MARK},
@@ -199,7 +220,7 @@ class RedisBroker(BaseBroker):
             # If we didn't get enough messages, try reading pending messages
             if len(messages) < no_of_messages:
                 remaining = no_of_messages - len(messages)
-                response = self.redis_instance.xreadgroup(
+                response = self._client.xreadgroup(
                     consumer_group, self._consumer_name, {stream: "0"}, count=remaining
                 )
 
@@ -215,7 +236,7 @@ class RedisBroker(BaseBroker):
                                 if len(messages) >= no_of_messages:
                                     break
 
-        except redis.ResponseError as e:
+        except redis.ResponseError:
             logger.exception("broker.redis.read_failed")
 
         return messages[:no_of_messages]  # Ensure we don't return more than requested
@@ -249,7 +270,7 @@ class RedisBroker(BaseBroker):
         try:
             # First, try to read pending messages (messages that were delivered but not ACKed)
             # Use "0" to read pending messages for this consumer
-            response = self.redis_instance.xreadgroup(
+            response = self._client.xreadgroup(
                 consumer_group,
                 consumer_name,
                 {stream: "0"},  # "0" means read pending messages
@@ -274,7 +295,7 @@ class RedisBroker(BaseBroker):
             # This allows the event loop to process signals more frequently
             effective_timeout = min(timeout_ms, 1000)
 
-            response = self.redis_instance.xreadgroup(
+            response = self._client.xreadgroup(
                 consumer_group,
                 consumer_name,
                 {stream: NEW_MESSAGES_MARK},
@@ -305,7 +326,7 @@ class RedisBroker(BaseBroker):
                 self._created_groups_set.discard(group_key)
                 self._ensure_group(consumer_group, stream)
                 try:
-                    response = self.redis_instance.xreadgroup(
+                    response = self._client.xreadgroup(
                         consumer_group,
                         consumer_name,
                         {stream: NEW_MESSAGES_MARK},
@@ -321,12 +342,19 @@ class RedisBroker(BaseBroker):
                             message = self._deserialize_message(fields)
                             messages.append((redis_id_str, message))
                     return messages
-                except Exception as retry_err:
+                except Exception:
                     logger.exception("broker.redis.nogroup_retry_failed")
                     return []
             logger.exception("broker.redis.read_blocking_failed")
             return []
         except Exception as e:
+            # A dropped/closed connection (e.g. "Connection closed by server"
+            # under CI load) surfaces here rather than via the base read_blocking
+            # wrapper, which only sees exceptions this method re-raises. Proactively
+            # re-establish the connection so the next poll tick reads from a healthy
+            # socket instead of relying solely on pool internals to self-heal.
+            if self._is_connection_error(e):
+                self._ensure_connection()
             logger.exception("broker.redis.read_blocking_failed")
             return []
 
@@ -337,7 +365,7 @@ class RedisBroker(BaseBroker):
         the pending list and cannot be ACKed again.
         """
         try:
-            result = self.redis_instance.xack(stream, consumer_group, identifier)
+            result = self._client.xack(stream, consumer_group, identifier)
             # result is the number of messages successfully acknowledged
             # 0 means the message was not pending (already ACKed or doesn't exist)
             # 1 means the message was successfully acknowledged
@@ -345,7 +373,7 @@ class RedisBroker(BaseBroker):
         except redis.ResponseError as e:
             logger.warning(f"Failed to ack message {identifier} in {stream}: {e}")
             return False
-        except Exception as e:
+        except Exception:
             logger.exception("broker.redis.ack_failed")
             return False
 
@@ -370,7 +398,7 @@ class RedisBroker(BaseBroker):
             )
             return True
 
-        except Exception as e:
+        except Exception:
             logger.exception("broker.redis.nack_failed")
             return False
 
@@ -379,7 +407,7 @@ class RedisBroker(BaseBroker):
     ) -> bool:
         """Check if message is in pending list for the consumer group"""
         try:
-            pending_info = self.redis_instance.xpending_range(
+            pending_info = self._client.xpending_range(
                 stream, consumer_group, min=identifier, max=identifier, count=1
             )
         except redis.ResponseError as e:
@@ -413,7 +441,7 @@ class RedisBroker(BaseBroker):
         entries: list[DLQEntry] = []
         for dlq_stream in dlq_streams:
             try:
-                raw_messages = self.redis_instance.xrange(dlq_stream)
+                raw_messages = self._client.xrange(dlq_stream)
             except redis.ResponseError:
                 # Stream doesn't exist
                 continue
@@ -430,7 +458,7 @@ class RedisBroker(BaseBroker):
     def _dlq_inspect(self, dlq_stream: str, dlq_id: str) -> DLQEntry | None:
         """Inspect a specific DLQ message by ID."""
         try:
-            raw_messages = self.redis_instance.xrange(
+            raw_messages = self._client.xrange(
                 dlq_stream, min=dlq_id, max=dlq_id, count=1
             )
         except redis.ResponseError:
@@ -445,7 +473,7 @@ class RedisBroker(BaseBroker):
     def _dlq_replay(self, dlq_stream: str, dlq_id: str, target_stream: str) -> bool:
         """Replay a single DLQ message back to its original stream."""
         try:
-            raw_messages = self.redis_instance.xrange(
+            raw_messages = self._client.xrange(
                 dlq_stream, min=dlq_id, max=dlq_id, count=1
             )
         except redis.ResponseError:
@@ -459,14 +487,14 @@ class RedisBroker(BaseBroker):
         # Strip DLQ metadata before republishing
         message.pop("_dlq_metadata", None)
         self._publish(target_stream, message)
-        self.redis_instance.xdel(dlq_stream, self._decode_if_bytes(redis_id))
+        self._client.xdel(dlq_stream, self._decode_if_bytes(redis_id))
         logger.info(f"Replayed DLQ message '{dlq_id}' to stream '{target_stream}'")
         return True
 
     def _dlq_replay_all(self, dlq_stream: str, target_stream: str) -> int:
         """Replay all DLQ messages from a stream."""
         try:
-            raw_messages = self.redis_instance.xrange(dlq_stream)
+            raw_messages = self._client.xrange(dlq_stream)
         except redis.ResponseError:
             return 0
 
@@ -475,18 +503,18 @@ class RedisBroker(BaseBroker):
             message = self._deserialize_message(fields)
             message.pop("_dlq_metadata", None)
             self._publish(target_stream, message)
-            self.redis_instance.xdel(dlq_stream, self._decode_if_bytes(redis_id))
+            self._client.xdel(dlq_stream, self._decode_if_bytes(redis_id))
             replayed += 1
         return replayed
 
     def _dlq_purge(self, dlq_stream: str) -> int:
         """Purge all messages from a DLQ stream."""
         try:
-            count = self.redis_instance.xlen(dlq_stream)
+            count = self._client.xlen(dlq_stream)
         except redis.ResponseError:
             return 0
         if count > 0:
-            self.redis_instance.delete(dlq_stream)
+            self._client.delete(dlq_stream)
         return count
 
     def _parse_dlq_entry(
@@ -523,7 +551,7 @@ class RedisBroker(BaseBroker):
             Number of messages trimmed.
         """
         try:
-            trimmed = self.redis_instance.xtrim(dlq_stream, minid=min_id) or 0
+            trimmed = self._client.xtrim(dlq_stream, minid=min_id) or 0
             if trimmed > 0:
                 logger.info(
                     "broker.redis.dlq_trimmed",
@@ -537,7 +565,7 @@ class RedisBroker(BaseBroker):
     def dlq_depth(self, dlq_stream: str) -> int:
         """Return the number of messages in a DLQ stream."""
         try:
-            return self.redis_instance.xlen(dlq_stream)
+            return self._client.xlen(dlq_stream)
         except redis.ResponseError:
             return 0
 
@@ -549,7 +577,7 @@ class RedisBroker(BaseBroker):
             return
 
         try:
-            self.redis_instance.xgroup_create(
+            self._client.xgroup_create(
                 stream, group_name, id=STREAM_ID_START, mkstream=True
             )
             logger.debug(f"Created consumer group {group_name} for stream {stream}")
@@ -567,7 +595,7 @@ class RedisBroker(BaseBroker):
                 logger.warning(
                     f"Failed to create consumer group {group_name} for stream {stream}: {e}"
                 )
-        except Exception as e:
+        except Exception:
             logger.exception(
                 "broker.redis.ensure_group_failed",
                 extra={"group": group_name, "stream": stream},
@@ -597,7 +625,7 @@ class RedisBroker(BaseBroker):
 
         removed = 0
         try:
-            consumers_info = self.redis_instance.xinfo_consumers(stream, group_name)
+            consumers_info = self._client.xinfo_consumers(stream, group_name)
             for c in consumers_info:
                 if not isinstance(c, dict):
                     continue
@@ -619,7 +647,7 @@ class RedisBroker(BaseBroker):
                     continue
 
                 try:
-                    self.redis_instance.xgroup_delconsumer(stream, group_name, name)
+                    self._client.xgroup_delconsumer(stream, group_name, name)
                     removed += 1
                     logger.debug(f"Removed stale consumer {name} from {group_name}")
                 except Exception as e:
@@ -659,7 +687,7 @@ class RedisBroker(BaseBroker):
             # Add nested structure for Redis-specific tests
             info["consumer_groups"].update(stream_info_nested)
 
-        except Exception as e:
+        except Exception:
             logger.exception("broker.redis.info_failed")
 
         return info
@@ -679,7 +707,7 @@ class RedisBroker(BaseBroker):
     def _get_stream_info(self, stream: str) -> Optional[dict]:
         """Get info for a specific stream"""
         try:
-            groups_info = self.redis_instance.xinfo_groups(stream)
+            groups_info = self._client.xinfo_groups(stream)
             stream_info = {}
 
             for group_info in groups_info:
@@ -712,7 +740,7 @@ class RedisBroker(BaseBroker):
             if group_name is None:
                 return None
 
-            consumers_info = self.redis_instance.xinfo_consumers(stream, group_name)
+            consumers_info = self._client.xinfo_consumers(stream, group_name)
             consumers = self._extract_consumers_data(consumers_info)
 
             return (
@@ -769,7 +797,7 @@ class RedisBroker(BaseBroker):
     def _ping(self) -> bool:
         """Test basic connectivity to Redis broker"""
         try:
-            return self.redis_instance.ping()
+            return self._client.ping()
         except Exception as e:
             logger.debug(f"Redis ping failed: {e}")
             return False
@@ -784,12 +812,12 @@ class RedisBroker(BaseBroker):
             for stream in streams_to_check:
                 try:
                     # Get stream length (total messages)
-                    stream_length = self.redis_instance.xlen(stream)
+                    stream_length = self._client.xlen(stream)
                     total_messages += stream_length
 
                     # Get pending messages for all consumer groups in this stream
                     try:
-                        groups_info = self.redis_instance.xinfo_groups(stream)
+                        groups_info = self._client.xinfo_groups(stream)
                         for group_info in groups_info:
                             if isinstance(group_info, dict):
                                 pending_count = self._get_field_value(
@@ -831,7 +859,7 @@ class RedisBroker(BaseBroker):
             existing_streams = []
             for stream in streams_to_check:
                 try:
-                    if self.redis_instance.xlen(stream) >= 0:  # Stream exists
+                    if self._client.xlen(stream) >= 0:  # Stream exists
                         existing_streams.append(stream)
                 except redis.ResponseError:
                     # Stream doesn't exist, skip it
@@ -864,7 +892,7 @@ class RedisBroker(BaseBroker):
     def _health_stats(self) -> dict:
         """Get Redis-specific health and performance statistics"""
         try:
-            redis_info = self.redis_instance.info()
+            redis_info = self._client.info()
 
             # Calculate message counts across all streams
             message_counts = self._calculate_message_counts()
@@ -966,7 +994,7 @@ class RedisBroker(BaseBroker):
         for attempt in range(max_attempts):
             try:
                 # Test current connection
-                if self.redis_instance.ping():
+                if self._client.ping():
                     if attempt > 0:
                         logger.info(
                             f"Redis connection restored on attempt {attempt + 1}"
@@ -983,13 +1011,13 @@ class RedisBroker(BaseBroker):
                         f"Redis connection failed, attempting to reconnect (attempt {attempt + 1}/{max_attempts})..."
                     )
                     # Create a new Redis instance with the same connection info
-                    self.redis_instance = redis.Redis.from_url(
-                        self.conn_info["URI"], **self._pool_kwargs
-                    )
-                except Exception as reconnect_error:
+                    self._connect()
+                except Exception:
                     logger.exception("broker.redis.reconnect_failed")
 
-        logger.error("broker.redis.connection_exhausted", extra={"max_attempts": max_attempts})
+        logger.error(
+            "broker.redis.connection_exhausted", extra={"max_attempts": max_attempts}
+        )
         return False
 
     def close(self) -> None:
@@ -1005,10 +1033,10 @@ class RedisBroker(BaseBroker):
     def _data_reset(self) -> None:
         """Flush all data in Redis instance for testing"""
         try:
-            self.redis_instance.flushall()
+            self._client.flushall()
             self._created_groups_set.clear()
             self._group_creation_times.clear()
-        except Exception as e:
+        except Exception:
             logger.exception("broker.redis.data_reset_failed")
 
 

--- a/tests/adapters/broker/redis/test_redis_dlq_management.py
+++ b/tests/adapters/broker/redis/test_redis_dlq_management.py
@@ -1,0 +1,213 @@
+"""Tests for the Redis broker DLQ management API.
+
+Backfills coverage for the DLQ methods (`dlq_list`, `dlq_inspect`, `dlq_replay`,
+`dlq_replay_all`, `dlq_purge`, `dlq_trim`, `dlq_depth`), which had no Redis-side
+tests. Covers the core DLQ operations also tested in the inline broker's
+``test_dlq_management.py``, though not all edge cases are replicated here.
+"""
+
+import pytest
+
+from protean.adapters.broker.redis import RedisBroker
+from tests.shared import REDIS_URI
+
+
+def _broker(test_domain) -> RedisBroker:
+    broker = RedisBroker("test_redis", test_domain, {"URI": f"{REDIS_URI}/0"})
+    broker._client.flushdb()  # clean slate — flush only DB 0, not all Redis databases
+    broker._created_groups_set.clear()
+    broker._group_creation_times.clear()
+    return broker
+
+
+def _seed(
+    broker: RedisBroker,
+    dlq_stream: str,
+    payload: dict,
+    *,
+    original_stream: str,
+    original_id: str,
+    consumer_group: str = "group1",
+) -> str:
+    """Publish a DLQ-formatted message and return its DLQ id."""
+    message = {
+        **payload,
+        "_dlq_metadata": {
+            "original_stream": original_stream,
+            "original_id": original_id,
+            "consumer_group": consumer_group,
+            "failed_at": "2026-01-01T00:00:00+00:00",
+            "retry_count": 3,
+        },
+    }
+    return broker.publish(dlq_stream, message)
+
+
+@pytest.mark.redis
+class TestRedisDLQManagement:
+    def test_dlq_list_returns_entries_across_streams(self, test_domain):
+        broker = _broker(test_domain)
+        _seed(
+            broker,
+            "orders:dlq",
+            {"data": "one"},
+            original_stream="orders",
+            original_id="o1",
+        )
+        _seed(
+            broker,
+            "payments:dlq",
+            {"data": "two"},
+            original_stream="payments",
+            original_id="p1",
+        )
+
+        entries = broker.dlq_list(["orders:dlq", "payments:dlq"])
+        assert len(entries) == 2
+        assert {e.stream for e in entries} == {"orders", "payments"}
+
+    def test_dlq_list_empty_returns_empty(self, test_domain):
+        broker = _broker(test_domain)
+        assert broker.dlq_list(["nonexistent:dlq"]) == []
+
+    def test_dlq_list_filters_by_stream(self, test_domain):
+        broker = _broker(test_domain)
+        _seed(
+            broker,
+            "orders:dlq",
+            {"data": "one"},
+            original_stream="orders",
+            original_id="o1",
+        )
+        _seed(
+            broker,
+            "payments:dlq",
+            {"data": "two"},
+            original_stream="payments",
+            original_id="p1",
+        )
+
+        entries = broker.dlq_list(["orders:dlq"])
+        assert len(entries) == 1
+        assert entries[0].stream == "orders"
+
+    def test_dlq_list_respects_limit(self, test_domain):
+        broker = _broker(test_domain)
+        for i in range(5):
+            _seed(
+                broker,
+                "orders:dlq",
+                {"i": i},
+                original_stream="orders",
+                original_id=f"o{i}",
+            )
+        assert len(broker.dlq_list(["orders:dlq"], limit=3)) == 3
+
+    def test_dlq_inspect_found(self, test_domain):
+        broker = _broker(test_domain)
+        dlq_id = _seed(
+            broker,
+            "orders:dlq",
+            {"key": "value"},
+            original_stream="orders",
+            original_id="o1",
+            consumer_group="g1",
+        )
+
+        entry = broker.dlq_inspect("orders:dlq", dlq_id)
+        assert entry is not None
+        assert entry.dlq_id == dlq_id
+        assert entry.original_id == "o1"
+        assert entry.stream == "orders"
+        assert entry.consumer_group == "g1"
+        assert entry.payload["key"] == "value"
+
+    def test_dlq_inspect_not_found(self, test_domain):
+        broker = _broker(test_domain)
+        _seed(
+            broker, "orders:dlq", {"k": "v"}, original_stream="orders", original_id="o1"
+        )
+        assert broker.dlq_inspect("orders:dlq", "9999999999999-0") is None
+
+    def test_dlq_replay_moves_message_to_target(self, test_domain):
+        broker = _broker(test_domain)
+        dlq_id = _seed(
+            broker,
+            "orders:dlq",
+            {"amount": 10},
+            original_stream="orders",
+            original_id="o1",
+        )
+
+        assert broker.dlq_replay("orders:dlq", dlq_id, "orders") is True
+        # Removed from the DLQ...
+        assert broker.dlq_inspect("orders:dlq", dlq_id) is None
+        # ...and republished (without DLQ metadata) to the target stream.
+        messages = broker.read("orders", "replay-group", no_of_messages=10)
+        assert len(messages) == 1
+        _, replayed_payload = messages[0]
+        assert replayed_payload["amount"] == 10
+        assert "_dlq_metadata" not in replayed_payload
+
+    def test_dlq_replay_all(self, test_domain):
+        broker = _broker(test_domain)
+        for i in range(3):
+            _seed(
+                broker,
+                "orders:dlq",
+                {"i": i},
+                original_stream="orders",
+                original_id=f"o{i}",
+            )
+
+        assert broker.dlq_replay_all("orders:dlq", "orders") == 3
+        assert broker.dlq_depth("orders:dlq") == 0
+        assert len(broker.read("orders", "replay-group", no_of_messages=10)) == 3
+
+    def test_dlq_purge(self, test_domain):
+        broker = _broker(test_domain)
+        for i in range(2):
+            _seed(
+                broker,
+                "orders:dlq",
+                {"i": i},
+                original_stream="orders",
+                original_id=f"o{i}",
+            )
+
+        assert broker.dlq_purge("orders:dlq") == 2
+        assert broker.dlq_depth("orders:dlq") == 0
+
+    def test_dlq_purge_empty_stream(self, test_domain):
+        broker = _broker(test_domain)
+        assert broker.dlq_purge("nonexistent:dlq") == 0
+
+    def test_dlq_depth(self, test_domain):
+        broker = _broker(test_domain)
+        assert broker.dlq_depth("orders:dlq") == 0
+        for i in range(2):
+            _seed(
+                broker,
+                "orders:dlq",
+                {"i": i},
+                original_stream="orders",
+                original_id=f"o{i}",
+            )
+        assert broker.dlq_depth("orders:dlq") == 2
+
+    def test_dlq_trim_removes_entries_below_cutoff(self, test_domain):
+        broker = _broker(test_domain)
+        for i in range(3):
+            _seed(
+                broker,
+                "orders:dlq",
+                {"i": i},
+                original_stream="orders",
+                original_id=f"o{i}",
+            )
+        assert broker.dlq_depth("orders:dlq") == 3
+
+        # dlq_trim uses an approximate XTRIM MINID (whole-node trimming). A
+        # far-future cutoff makes every entry eligible, so all are removed.
+        assert broker.dlq_trim("orders:dlq", "9999999999999-0") == 3
+        assert broker.dlq_depth("orders:dlq") == 0

--- a/tests/adapters/broker/redis/test_redis_edge_cases.py
+++ b/tests/adapters/broker/redis/test_redis_edge_cases.py
@@ -631,3 +631,70 @@ def test_read_blocking_connection_error_with_successful_retry(test_domain, caplo
         # Restore original methods
         broker._read_blocking = original_read_blocking
         broker._ensure_connection = original_ensure_connection
+
+
+@pytest.mark.redis
+class TestRedisReconnectAfterClose:
+    """Reviving a closed Redis connection against a live server (#1055).
+
+    Engine shutdown closes the broker (``redis_instance`` becomes ``None``).
+    Reusing the broker afterwards — a straggler poll read, a publish, or a
+    test-teardown ``_data_reset`` — must reconnect transparently instead of
+    raising ``AttributeError: 'NoneType' object has no attribute ...``.
+    """
+
+    def test_publish_and_read_revive_after_close(self, test_domain):
+        broker = RedisBroker("test_redis", test_domain, {"URI": f"{REDIS_URI}/0"})
+        stream = "revive-stream"
+
+        broker.publish(stream, {"first": "message"})
+
+        # Simulate engine shutdown tearing down the connection.
+        broker.close()
+        assert broker.redis_instance is None
+
+        # Reusing the broker must reconnect, not crash.
+        broker.publish(stream, {"second": "message"})
+        assert broker.redis_instance is not None
+
+        messages = broker.read(stream, "revive-group", no_of_messages=10)
+        assert len(messages) >= 1
+
+    def test_data_reset_revives_after_close(self, test_domain):
+        broker = RedisBroker("test_redis", test_domain, {"URI": f"{REDIS_URI}/0"})
+        broker.publish("some-stream", {"payload": "x"})
+
+        broker.close()
+        assert broker.redis_instance is None
+
+        # Teardown reset after the connection was closed must not raise.
+        broker._data_reset()
+        assert broker.redis_instance is not None
+
+    def test_poll_loop_survives_midrun_close(self, test_domain):
+        """Repeated reads keep working after the connection is closed mid-run.
+
+        Mirrors the engine's poll loop: it reads in a loop; if the connection is
+        torn down (as engine shutdown does) a subsequent read must reconnect and
+        keep draining messages rather than dying with AttributeError.
+        """
+        broker = RedisBroker("test_redis", test_domain, {"URI": f"{REDIS_URI}/0"})
+        stream, group = "survive-stream", "survive-group"
+        broker._ensure_group(group, stream)
+
+        for i in range(3):
+            broker.publish(stream, {"n": i})
+
+        broker.close()
+        assert broker.redis_instance is None
+
+        # Poll loop continues after the mid-run close: read and ACK each message.
+        collected = []
+        for _ in range(5):
+            batch = broker.read(stream, group, no_of_messages=10)
+            for identifier, payload in batch:
+                collected.append(payload)
+                broker.ack(stream, identifier, group)
+
+        assert broker.redis_instance is not None
+        assert sorted(m["n"] for m in collected) == [0, 1, 2]

--- a/tests/server/test_graceful_shutdown.py
+++ b/tests/server/test_graceful_shutdown.py
@@ -171,10 +171,7 @@ class TestEngineShutdownOrder:
                 with caplog.at_level(logging.ERROR):
                     engine.loop.run_until_complete(engine.shutdown())
 
-            assert any(
-                "engine.cleanup_failed" in r.message
-                for r in caplog.records
-            )
+            assert any("engine.cleanup_failed" in r.message for r in caplog.records)
 
 
 @pytest.mark.no_test_domain
@@ -500,6 +497,141 @@ class TestRedisBrokerCloseEdgeCases:
             broker.close()  # Should not raise
 
         assert any("Error closing Redis broker" in r.message for r in caplog.records)
+
+
+@pytest.mark.no_test_domain
+class TestRedisBrokerReconnectAfterClose:
+    """Reviving a closed Redis connection (#1055).
+
+    Engine shutdown calls ``close()``, which sets ``redis_instance`` to ``None``.
+    Under CI timing a straggler poll read or a test-teardown ``_data_reset`` can
+    still run afterwards; these must reconnect transparently instead of raising
+    ``AttributeError: 'NoneType' object has no attribute ...`` and killing the
+    subscription poll loop. These tests use mocks and need no live Redis.
+    """
+
+    def _make_broker(self):
+        from protean.adapters.broker.redis import RedisBroker
+
+        broker = object.__new__(RedisBroker)
+        broker.name = "test"
+        broker.conn_info = {"URI": "redis://localhost:6379/0"}
+        broker._pool_kwargs = {}
+        broker.redis_instance = None
+        broker._consumer_name = "consumer-test"
+        broker._created_groups_set = set()
+        broker._group_creation_times = {}
+        return broker
+
+    def test_client_revives_when_instance_is_none(self):
+        """The _client accessor reconnects when redis_instance is None."""
+        broker = self._make_broker()
+        mock_client = MagicMock()
+
+        with patch("redis.Redis.from_url", return_value=mock_client) as from_url:
+            result = broker._client
+
+        assert result is mock_client
+        assert broker.redis_instance is mock_client
+        from_url.assert_called_once()
+
+    def test_client_reuses_live_instance_without_reconnecting(self):
+        """The _client accessor does not reconnect when already connected."""
+        broker = self._make_broker()
+        broker.redis_instance = MagicMock()
+
+        with patch("redis.Redis.from_url") as from_url:
+            result = broker._client
+
+        assert result is broker.redis_instance
+        from_url.assert_not_called()
+
+    def test_read_revives_closed_connection(self):
+        """_read reconnects after close() instead of raising AttributeError."""
+        broker = self._make_broker()
+        # Pre-populate the group cache so _ensure_group does not hit Redis.
+        broker._created_groups_set = {"stream:group"}
+        mock_client = MagicMock()
+        mock_client.xreadgroup.return_value = []
+
+        with patch("redis.Redis.from_url", return_value=mock_client):
+            result = broker._read("stream", "group", 1)
+
+        assert result == []
+        assert broker.redis_instance is mock_client
+        assert mock_client.xreadgroup.called
+
+    def test_data_reset_revives_closed_connection(self):
+        """_data_reset reconnects after close() and flushes without raising."""
+        broker = self._make_broker()
+        broker._created_groups_set = {"stream:group"}
+        broker._group_creation_times = {"group": 1.0}
+        mock_client = MagicMock()
+
+        with patch("redis.Redis.from_url", return_value=mock_client):
+            broker._data_reset()
+
+        mock_client.flushall.assert_called_once()
+        assert broker.redis_instance is mock_client
+        assert broker._created_groups_set == set()
+        assert broker._group_creation_times == {}
+
+    def test_publish_revives_closed_connection(self):
+        """_publish reconnects after close() instead of raising AttributeError."""
+        broker = self._make_broker()
+        mock_client = MagicMock()
+        mock_client.xadd.return_value = b"1-0"
+
+        with patch("redis.Redis.from_url", return_value=mock_client):
+            identifier = broker._publish("stream", {"k": "v"})
+
+        assert identifier == "1-0"
+        assert broker.redis_instance is mock_client
+        mock_client.xadd.assert_called_once()
+
+    def test_read_blocking_reconnects_on_connection_error(self):
+        """_read_blocking re-establishes the connection on a dropped socket.
+
+        A "Connection closed by server" error on the blocking XREADGROUP is
+        swallowed inside _read_blocking (returns []), so the base read_blocking
+        wrapper's recovery never fires. _read_blocking must trigger the
+        reconnect itself so the next poll tick reads from a healthy socket.
+        """
+        import redis
+
+        broker = self._make_broker()
+        broker._created_groups_set = {"stream:group"}
+        mock_client = MagicMock()
+        mock_client.xreadgroup.side_effect = redis.ConnectionError(
+            "Connection closed by server."
+        )
+        broker.redis_instance = mock_client
+
+        with patch.object(
+            broker, "_ensure_connection", return_value=True
+        ) as ensure_connection:
+            result = broker._read_blocking(
+                "stream", "group", "consumer", timeout_ms=100, count=1
+            )
+
+        assert result == []
+        ensure_connection.assert_called_once()
+
+    def test_read_blocking_does_not_reconnect_on_non_connection_error(self):
+        """_read_blocking does not reconnect for unrelated errors (scope guard)."""
+        broker = self._make_broker()
+        broker._created_groups_set = {"stream:group"}
+        mock_client = MagicMock()
+        mock_client.xreadgroup.side_effect = ValueError("bad payload")
+        broker.redis_instance = mock_client
+
+        with patch.object(broker, "_ensure_connection") as ensure_connection:
+            result = broker._read_blocking(
+                "stream", "group", "consumer", timeout_ms=100, count=1
+            )
+
+        assert result == []
+        ensure_connection.assert_not_called()
 
 
 @pytest.mark.no_test_domain


### PR DESCRIPTION
## What

Backports the Redis broker revive-after-close fix to `release/0.16.x`, **staging for a future 0.16.3** (not being released yet — batching more fixes first, per maintainer decision).

Two cherry-picks, in order:

- **#1086 (#1055)** — *Revive the Redis broker connection after close instead of crashing.* The Redis Streams broker now transparently reconnects if its connection was closed (e.g. `redis_instance` set to `None` by engine shutdown) before a later operation, instead of raising `AttributeError: 'NoneType' object has no attribute ...` and killing a subscription's poll loop. Every Redis call now routes through a `_client` accessor that revives via `_connect()`. Makes `Engine(test_mode=True).run()` against a Redis broker reliable in CI.
- **#1090** — *Add Redis broker DLQ management tests* (`dlq_list/inspect/replay/replay_all/purge/trim/depth`) against real Redis, backfilling coverage for the `_client` accessor refactor. This is the follow-up that unblocked backporting #1086 (its only reason for 0.16.2 deferral).

## Conflict resolution

#1086 conflicted in 2 hunks of `redis.py` (the release branch diverged there); both resolved to the incoming #1086 version:
- `_read_blocking` except handler — added the connection-error revive (`if self._is_connection_error(e): self._ensure_connection()`). `_is_connection_error` is inherited from `BaseBroker` (`port/broker.py`); `_ensure_connection` exists on the release branch.
- reconnect loop — swapped the inline `redis.Redis.from_url(...)` for `self._connect()`.

Verified: no stray `self.redis_instance.<method>` calls remain (only `close()` uses the raw instance, intentionally), `Optional` imported, module imports cleanly, ruff clean.

## Testing

- Local: ruff clean; broker module imports (`_client`/`_connect` present).
- The Redis edge-case, DLQ-management, and graceful-shutdown tests need a live Redis and run in **CI's FULL matrix** on this `release/**` branch (via the GHCR mirror unblocked in 0.16.2).

## Release status

**Not a release.** No version bump / tag. Its `changes/1055.fixed.md` + `changes/1090.changed.md` fragments will assemble into the 0.16.3 CHANGELOG whenever that patch is cut.