### PR TITLE
Type-safety (#997) Phase 2: Domain composition root + public-signature corrections

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -302,7 +302,6 @@ module = [
   "protean.domain.validation",
   "protean.exceptions",
   "protean.ext.mypy_plugin",
-  "protean.fields.association",
   "protean.fields.base",
   "protean.fields.containers",
   "protean.fields.simple",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -297,7 +297,6 @@ module = [
   "protean.domain.handler_setup",
   "protean.domain.infrastructure",
   "protean.domain.query_processor",
-  "protean.domain.registry",
   "protean.domain.resolver",
   "protean.domain.type_manager",
   "protean.domain.validation",

--- a/src/protean/adapters/cache/__init__.py
+++ b/src/protean/adapters/cache/__init__.py
@@ -11,6 +11,7 @@ from protean.port.cache import BaseCache
 from protean.utils.inflection import underscore
 
 if TYPE_CHECKING:
+    from protean.core.projection import BaseProjection
     from protean.domain import Domain
 
 logger = logging.getLogger(__name__)
@@ -97,7 +98,7 @@ class Caches(collections.abc.MutableMapping[str, BaseCache]):
         except KeyError:
             raise AssertionError(f"No Provider registered with name {provider_name}")
 
-    def cache_for(self, projection_cls):
+    def cache_for(self, projection_cls: "type[BaseProjection]") -> BaseCache:
         """Retrieve cache associated with the Projection"""
         if self._caches is None:
             self._initialize()
@@ -107,7 +108,7 @@ class Caches(collections.abc.MutableMapping[str, BaseCache]):
         # with projections that call cache_for() without formal registration.
         cache_name = projection_cls.meta_.cache or projection_cls.meta_.provider
 
-        cache = self.get(cache_name)
+        cache = self[cache_name]
 
         projection_name = underscore(projection_cls.__name__)
         if projection_name not in cache._projections:

--- a/src/protean/adapters/event_store/__init__.py
+++ b/src/protean/adapters/event_store/__init__.py
@@ -14,6 +14,7 @@ from protean.exceptions import ConfigurationError
 from protean.utils import fqn
 
 if TYPE_CHECKING:
+    from protean.core.projection import BaseProjection
     from protean.domain import Domain
     from protean.port.event_store import BaseEventStore
 
@@ -169,11 +170,11 @@ class EventStore:
 
         return set.union(configured_stream_handlers, all_stream_handlers)
 
-    def projectors_for(self, projection_cls) -> set:
+    def projectors_for(self, projection_cls: "type[BaseProjection]") -> set[Any]:
         """Return Projectors listening to a specific projection
 
         Args:
-            projection_cls (BaseProjection): Projection to be consumed
+            projection_cls (type[BaseProjection]): Projection to be consumed
 
         Returns:
             List[BaseProjector]: Projectors that have registered to consume the projection

--- a/src/protean/domain/__init__.py
+++ b/src/protean/domain/__init__.py
@@ -66,16 +66,22 @@ from typing import (
     Dict,
     List,
     Optional,
+    Protocol,
     Tuple,
     Type,
     TypeVar,
     Union,
+    cast,
     dataclass_transform,
     overload,
 )
 
 if TYPE_CHECKING:
+    from types import FrameType
+
+    from protean.port.cache import BaseCache
     from protean.utils.projection_rebuilder import RebuildResult
+    from protean.utils.upcasting import UpcasterChain
 
 from inflection import parameterize, titleize, transliterate, underscore
 
@@ -102,7 +108,7 @@ from protean.core.subscriber import subscriber_factory
 from protean.core.upcaster import upcaster_factory
 from protean.core.value_object import value_object_factory
 from protean.core.view import ReadView
-from protean.domain.registry import _DomainRegistry
+from protean.domain.registry import DomainRecord, _DomainRegistry
 from protean.exceptions import (
     ConfigurationError,
     IncorrectUsageError,
@@ -172,31 +178,23 @@ from .validation import DomainValidator
 
 logger = logging.getLogger(__name__)
 
-# Field specifiers for @dataclass_transform() — tells mypy which callables
-# represent field declarations in class bodies using annotation syntax.
-_FIELD_SPECIFIERS = (
-    Auto,
-    Boolean,
-    Date,
-    DateTime,
-    DictField,
-    Float,
-    HasMany,
-    HasOne,
-    Identifier,
-    Integer,
-    ListField,
-    Reference,
-    Status,
-    String,
-    Text,
-    ValueObject,
-)
+# Field specifiers for ``@dataclass_transform()`` tell type-checkers which
+# callables represent field declarations in class bodies using annotation
+# syntax. mypy requires the ``field_specifiers`` argument to be a tuple
+# literal at each decorator call site (it cannot be a shared module-level
+# name), so the tuple is inlined on every element decorator below rather
+# than referenced through a constant.
 
 _T = TypeVar("_T")
 
 # a singleton sentinel value for parameter defaults
 _sentinel = object()
+
+
+class _Closeable(Protocol):
+    """Structural type for infrastructure adapters that can be closed."""
+
+    def close(self) -> None: ...
 
 
 class Domain:
@@ -264,7 +262,7 @@ class Domain:
     #: :data:`secret_key` configuration key. Defaults to ``None``.
     secret_key = ConfigAttribute("secret_key")
 
-    def _is_interactive_context(self, filename):
+    def _is_interactive_context(self, filename: str | None) -> bool:
         """Check if the given filename indicates an interactive context like shell or notebook.
 
         Args:
@@ -302,7 +300,7 @@ class Domain:
             # Handle frozen applications (PyInstaller, etc.)
             if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
                 # PyInstaller creates a temp folder and stores path in _MEIPASS
-                return getattr(sys, "_MEIPASS")
+                return str(getattr(sys, "_MEIPASS"))
 
             # Regular Python script
             try:
@@ -316,11 +314,12 @@ class Domain:
 
     def __init__(
         self,
-        root_path: str = None,
+        root_path: str | None = None,
         name: str = "",
-        config: Optional[Dict] = None,
-        identity_function: Optional[Callable] = None,
-    ):
+        config: Optional[dict[str, Any]] = None,
+        identity_function: Optional[Callable[..., Any]] = None,
+    ) -> None:
+        self.root_path: str
         # Determine root_path based on resolution priority
         if root_path is None:
             # Try to get from environment variable
@@ -374,8 +373,8 @@ class Domain:
         # Event enrichers receive (event, aggregate) and return dict[str, Any].
         # Command enrichers receive (command,) and return dict[str, Any].
         # Results are merged into metadata.extensions.
-        self._event_enrichers: List[Callable] = []
-        self._command_enrichers: List[Callable] = []
+        self._event_enrichers: List[Callable[..., Any]] = []
+        self._command_enrichers: List[Callable[..., Any]] = []
 
         # Composed helpers — see handler_setup.py, validation.py, etc.
         self._command_processor = CommandProcessor(self)
@@ -389,20 +388,20 @@ class Domain:
         #: A list of functions that are called when the domain context
         #: is destroyed.  This is the place to store code that cleans up and
         #: disconnects from databases, for example.
-        self.teardown_domain_context_functions: List[Callable] = []
+        self.teardown_domain_context_functions: List[Callable[..., Any]] = []
 
         # Placeholder array for resolving classes referenced by domain elements
         self._pending_class_resolutions: dict[str, Any] = defaultdict(list)
 
         # Lazy-initialized idempotency store
-        self._idempotency_store = None
+        self._idempotency_store: IdempotencyStore | None = None
 
         # Lazy-initialized trace emitter for command processing observability
-        self._trace_emitter = None
+        self._trace_emitter: TraceEmitter | None = None
 
         # Lazy-initialized OpenTelemetry providers (set by init_telemetry)
-        self._otel_tracer_provider = None
-        self._otel_meter_provider = None
+        self._otel_tracer_provider: Any = None
+        self._otel_meter_provider: Any = None
         self._otel_init_attempted = False
 
     # ------------------------------------------------------------------
@@ -420,11 +419,11 @@ class Domain:
         return self._type_manager.upcasters
 
     @property
-    def _upcaster_chain(self):
+    def _upcaster_chain(self) -> "UpcasterChain":
         return self._type_manager.upcaster_chain
 
     @property
-    def _outbox_repos(self) -> dict:
+    def _outbox_repos(self) -> dict[str, BaseRepository]:
         return self._infrastructure.outbox_repos
 
     @property
@@ -454,7 +453,7 @@ class Domain:
         )
 
     @property
-    def idempotency_store(self):
+    def idempotency_store(self) -> IdempotencyStore:
         """Lazily initialize and return the idempotency store.
 
         The store is created on first access using the ``idempotency``
@@ -471,7 +470,7 @@ class Domain:
         return self._idempotency_store
 
     @property
-    def trace_emitter(self):
+    def trace_emitter(self) -> TraceEmitter:
         """Lazily initialize and return a TraceEmitter for command tracing.
 
         Used by CommandProcessor to emit handler.started/completed/failed
@@ -492,7 +491,7 @@ class Domain:
         return self._trace_emitter
 
     @property
-    def tracer(self):
+    def tracer(self) -> Any:
         """Return an OpenTelemetry ``Tracer`` for this domain.
 
         Lazy-initializes the telemetry providers on first access when
@@ -504,7 +503,7 @@ class Domain:
         return get_tracer(self)
 
     @property
-    def meter(self):
+    def meter(self) -> Any:
         """Return an OpenTelemetry ``Meter`` for this domain.
 
         Lazy-initializes the telemetry providers on first access when
@@ -607,7 +606,7 @@ class Domain:
         if validate:
             self._validate_domain()
 
-    def init(self, traverse=True):  # noqa: C901
+    def init(self, traverse: bool = True) -> None:  # noqa: C901
         """Parse the domain folder, and attach elements dynamically to the domain.
 
         Protean parses all files in the domain file's folder, as well as under it,
@@ -746,7 +745,7 @@ class Domain:
             },
         }
 
-    def _traverse(self):
+    def _traverse(self) -> None:
         # Ensure root_path is a directory path
         root_path = Path(self.root_path)
         if root_path.is_file():
@@ -814,6 +813,7 @@ class Domain:
                     spec = importlib.util.spec_from_file_location(
                         file_module_name, os.path.join(directory, filename)
                     )
+                    assert spec is not None and spec.loader is not None
                     module = importlib.util.module_from_spec(spec)
 
                     # Register in sys.modules before execution to prevent
@@ -821,12 +821,11 @@ class Domain:
                     # during execution (e.g., circular or relative imports).
                     if module.__name__ not in sys.modules:
                         sys.modules[module.__name__] = module
-                        assert spec is not None and spec.loader is not None
                         spec.loader.exec_module(module)
 
                     logger.debug(f"Loaded {filename}")
 
-    def _is_domain_file(self, file_path):
+    def _is_domain_file(self, file_path: str) -> bool:
         """Check if this is the domain file itself, to avoid self-import.
 
         This replaces the direct path comparison that was used before.
@@ -835,7 +834,7 @@ class Domain:
             return False
 
         # Get the frame where the Domain was instantiated
-        frame = sys._getframe(0)
+        frame: FrameType | None = sys._getframe(0)
         while frame:
             if frame.f_code.co_filename == file_path:
                 return True
@@ -843,7 +842,7 @@ class Domain:
 
         return False
 
-    def _initialize(self):
+    def _initialize(self) -> None:
         """Initialize domain dependencies and adapters."""
         self.providers._initialize()
         self.caches._initialize()
@@ -861,12 +860,13 @@ class Domain:
         """
         logger.info("Closing domain infrastructure...")
 
-        for name, closeable in [
+        closeables: list[tuple[str, _Closeable]] = [
             ("event store", self.event_store),
             ("brokers", self.brokers),
             ("caches", self.caches),
             ("providers", self.providers),
-        ]:
+        ]
+        for name, closeable in closeables:
             try:
                 closeable.close()
             except Exception:
@@ -874,8 +874,9 @@ class Domain:
 
         logger.info("Domain infrastructure closed")
 
-    def load_config(self, config: Optional[Dict] = None) -> Config2:
+    def load_config(self, config: Optional[dict[str, Any]] = None) -> Config2:
         """Load configuration from a dict or a .toml file."""
+        config_obj: Config2
         if config is not None:
             config_obj = Config2.load_from_dict(config)
         else:
@@ -888,7 +889,7 @@ class Domain:
 
         return config_obj
 
-    def domain_context(self, **kwargs):
+    def domain_context(self, **kwargs: Any) -> DomainContext:
         """Create a ``DomainContext``. Use as a ``with``
         block to push the context, which will make ``current_domain``
         point at this domain.
@@ -900,7 +901,7 @@ class Domain:
         """
         return DomainContext(self, **kwargs)
 
-    def teardown_domain_context(self, f):
+    def teardown_domain_context(self, f: Callable[..., Any]) -> Callable[..., Any]:
         """Registers a function to be called when the domain context
         ends.
 
@@ -926,7 +927,7 @@ class Domain:
         self.teardown_domain_context_functions.append(f)
         return f
 
-    def do_teardown_domain_context(self, exc=_sentinel):
+    def do_teardown_domain_context(self, exc: Any = _sentinel) -> None:
         """Called right before the domain context is popped.
 
         This calls all functions decorated with
@@ -945,11 +946,11 @@ class Domain:
 
     @property
     @lru_cache()
-    def registry(self):
+    def registry(self) -> _DomainRegistry:
         return self._domain_registry
 
-    def factory_for(self, domain_object_type):
-        factories = {
+    def factory_for(self, domain_object_type: DomainObjects) -> Callable[..., Any]:
+        factories: dict[str, Callable[..., Any]] = {
             DomainObjects.AGGREGATE.value: aggregate_factory,
             DomainObjects.APPLICATION_SERVICE.value: application_service_factory,
             DomainObjects.COMMAND.value: command_factory,
@@ -999,7 +1000,12 @@ class Domain:
         #  ```
 
         factory = self.factory_for(element_type)
-        new_cls = factory(element_cls, self, **opts)
+        # The factory returns the enriched, registered element class. It is
+        # genuinely untyped (Any) — the concrete class carries framework
+        # attributes (``meta_``, ``element_type``) injected at registration
+        # that are not visible on the bare ``type[_T]`` type parameter, so we
+        # treat it as Any internally and re-narrow to ``type[_T]`` at return.
+        new_cls: Any = factory(element_cls, self, **opts)
 
         if element_type == DomainObjects.DATABASE_MODEL:
             # Remember model association with aggregate/entity class, for easy fetching
@@ -1090,7 +1096,7 @@ class Domain:
                     ("QueryHandlerProjectionCls", (new_cls))
                 )
 
-        return new_cls
+        return cast("type[_T]", new_cls)
 
     def _resolve_references(self) -> None:
         """Resolve pending class references in association fields."""
@@ -1102,13 +1108,13 @@ class Domain:
     def _domain_element(
         self,
         element_type: DomainObjects,
-        _cls: type | None = None,
+        _cls: type[_T] | None = None,
         internal: bool = False,
         **kwargs: Any,
-    ) -> Any:
+    ) -> type[_T] | Callable[[type[_T]], type[_T]]:
         """Returns the registered class after decorating it and recording its presence in the domain"""
 
-        def wrap(cls: type) -> type:
+        def wrap(cls: type[_T]) -> type[_T]:
             return self._register_element(element_type, cls, internal, **kwargs)
 
         # See if we're being called as @Entity or @Entity().
@@ -1120,8 +1126,8 @@ class Domain:
         return wrap(_cls)
 
     def register_database_model(
-        self, database_model_cls, internal: bool = False, **kwargs
-    ):
+        self, database_model_cls: type[_T], internal: bool = False, **kwargs: Any
+    ) -> type[_T]:
         """Register a model class"""
         return self._register_element(
             DomainObjects.DATABASE_MODEL, database_model_cls, internal, **kwargs
@@ -1132,7 +1138,7 @@ class Domain:
         element_cls: Any,
         internal: bool = False,
         auto_generated: bool = False,
-        **kwargs: dict,
+        **kwargs: Any,
     ) -> Any:
         """Register an element with the domain.
 
@@ -1158,18 +1164,22 @@ class Domain:
         """Util Method to fetch an Element's class from its name"""
         try:
             # Try fetching by class name
-            return self._get_element_by_name(element_types, element).cls
+            element_cls: Element = self._get_element_by_name(element_types, element).cls
+            return element_cls
         except ConfigurationError:
             try:
                 # Try fetching by fully qualified class name
-                return self._get_element_by_fully_qualified_name(
+                fq_element_cls: Element = self._get_element_by_fully_qualified_name(
                     element_types, element
                 ).cls
+                return fq_element_cls
             except ConfigurationError:
                 # Element has not been registered
                 raise
 
-    def _get_element_by_name(self, element_types, element_name):
+    def _get_element_by_name(
+        self, element_types: Tuple[DomainObjects, ...], element_name: str
+    ) -> DomainRecord:
         """Fetch Domain record with the provided Element name"""
         try:
             elements = self._domain_registry._elements_by_name[element_name]
@@ -1204,7 +1214,9 @@ class Domain:
                 }
             )
 
-    def _get_element_by_fully_qualified_name(self, element_types, element_fq_name):
+    def _get_element_by_fully_qualified_name(
+        self, element_types: Tuple[DomainObjects, ...], element_fq_name: str
+    ) -> DomainRecord:
         """Fetch Domain record with the Fully Qualified Element name"""
         for element_type in element_types:
             if element_fq_name in self._domain_registry._elements[element_type.value]:
@@ -1218,14 +1230,16 @@ class Domain:
                 }
             )
 
-    def _get_element_by_class(self, element_types, element_cls):
+    def _get_element_by_class(
+        self, element_types: Tuple[DomainObjects, ...], element_cls: type
+    ) -> DomainRecord:
         """Fetch Domain record with Element class details"""
         element_qualname = fqn(element_cls)
         return self._get_element_by_fully_qualified_name(
             element_types, element_qualname
         )
 
-    def _replace_element_by_class(self, new_element_cls):
+    def _replace_element_by_class(self, new_element_cls: type) -> None:
         aggregate_record = self._get_element_by_class(
             (DomainObjects.AGGREGATE, DomainObjects.ENTITY), new_element_cls
         )
@@ -1311,7 +1325,26 @@ class Domain:
     def aggregate(
         self, _cls: None = ..., **kwargs: Any
     ) -> Callable[[type[_T]], type[_T]]: ...
-    @dataclass_transform(field_specifiers=_FIELD_SPECIFIERS)
+    @dataclass_transform(
+        field_specifiers=(
+            Auto,
+            Boolean,
+            Date,
+            DateTime,
+            DictField,
+            Float,
+            HasMany,
+            HasOne,
+            Identifier,
+            Integer,
+            ListField,
+            Reference,
+            Status,
+            String,
+            Text,
+            ValueObject,
+        )
+    )
     def aggregate(
         self, _cls: type[_T] | None = None, **kwargs: Any
     ) -> type[_T] | Callable[[type[_T]], type[_T]]:
@@ -1327,7 +1360,26 @@ class Domain:
     def application_service(
         self, _cls: None = ..., **kwargs: Any
     ) -> Callable[[type[_T]], type[_T]]: ...
-    @dataclass_transform(field_specifiers=_FIELD_SPECIFIERS)
+    @dataclass_transform(
+        field_specifiers=(
+            Auto,
+            Boolean,
+            Date,
+            DateTime,
+            DictField,
+            Float,
+            HasMany,
+            HasOne,
+            Identifier,
+            Integer,
+            ListField,
+            Reference,
+            Status,
+            String,
+            Text,
+            ValueObject,
+        )
+    )
     def application_service(
         self, _cls: type[_T] | None = None, **kwargs: Any
     ) -> type[_T] | Callable[[type[_T]], type[_T]]:
@@ -1343,7 +1395,26 @@ class Domain:
     def command(
         self, _cls: None = ..., **kwargs: Any
     ) -> Callable[[type[_T]], type[_T]]: ...
-    @dataclass_transform(field_specifiers=_FIELD_SPECIFIERS)
+    @dataclass_transform(
+        field_specifiers=(
+            Auto,
+            Boolean,
+            Date,
+            DateTime,
+            DictField,
+            Float,
+            HasMany,
+            HasOne,
+            Identifier,
+            Integer,
+            ListField,
+            Reference,
+            Status,
+            String,
+            Text,
+            ValueObject,
+        )
+    )
     def command(
         self, _cls: type[_T] | None = None, **kwargs: Any
     ) -> type[_T] | Callable[[type[_T]], type[_T]]:
@@ -1359,7 +1430,26 @@ class Domain:
     def command_handler(
         self, _cls: None = ..., **kwargs: Any
     ) -> Callable[[type[_T]], type[_T]]: ...
-    @dataclass_transform(field_specifiers=_FIELD_SPECIFIERS)
+    @dataclass_transform(
+        field_specifiers=(
+            Auto,
+            Boolean,
+            Date,
+            DateTime,
+            DictField,
+            Float,
+            HasMany,
+            HasOne,
+            Identifier,
+            Integer,
+            ListField,
+            Reference,
+            Status,
+            String,
+            Text,
+            ValueObject,
+        )
+    )
     def command_handler(
         self, _cls: type[_T] | None = None, **kwargs: Any
     ) -> type[_T] | Callable[[type[_T]], type[_T]]:
@@ -1371,7 +1461,26 @@ class Domain:
     def event(
         self, _cls: None = ..., **kwargs: Any
     ) -> Callable[[type[_T]], type[_T]]: ...
-    @dataclass_transform(field_specifiers=_FIELD_SPECIFIERS)
+    @dataclass_transform(
+        field_specifiers=(
+            Auto,
+            Boolean,
+            Date,
+            DateTime,
+            DictField,
+            Float,
+            HasMany,
+            HasOne,
+            Identifier,
+            Integer,
+            ListField,
+            Reference,
+            Status,
+            String,
+            Text,
+            ValueObject,
+        )
+    )
     def event(
         self, _cls: type[_T] | None = None, **kwargs: Any
     ) -> type[_T] | Callable[[type[_T]], type[_T]]:
@@ -1387,7 +1496,26 @@ class Domain:
     def event_handler(
         self, _cls: None = ..., **kwargs: Any
     ) -> Callable[[type[_T]], type[_T]]: ...
-    @dataclass_transform(field_specifiers=_FIELD_SPECIFIERS)
+    @dataclass_transform(
+        field_specifiers=(
+            Auto,
+            Boolean,
+            Date,
+            DateTime,
+            DictField,
+            Float,
+            HasMany,
+            HasOne,
+            Identifier,
+            Integer,
+            ListField,
+            Reference,
+            Status,
+            String,
+            Text,
+            ValueObject,
+        )
+    )
     def event_handler(
         self, _cls: type[_T] | None = None, **kwargs: Any
     ) -> type[_T] | Callable[[type[_T]], type[_T]]:
@@ -1403,7 +1531,26 @@ class Domain:
     def domain_service(
         self, _cls: None = ..., **kwargs: Any
     ) -> Callable[[type[_T]], type[_T]]: ...
-    @dataclass_transform(field_specifiers=_FIELD_SPECIFIERS)
+    @dataclass_transform(
+        field_specifiers=(
+            Auto,
+            Boolean,
+            Date,
+            DateTime,
+            DictField,
+            Float,
+            HasMany,
+            HasOne,
+            Identifier,
+            Integer,
+            ListField,
+            Reference,
+            Status,
+            String,
+            Text,
+            ValueObject,
+        )
+    )
     def domain_service(
         self, _cls: type[_T] | None = None, **kwargs: Any
     ) -> type[_T] | Callable[[type[_T]], type[_T]]:
@@ -1419,7 +1566,26 @@ class Domain:
     def entity(
         self, _cls: None = ..., **kwargs: Any
     ) -> Callable[[type[_T]], type[_T]]: ...
-    @dataclass_transform(field_specifiers=_FIELD_SPECIFIERS)
+    @dataclass_transform(
+        field_specifiers=(
+            Auto,
+            Boolean,
+            Date,
+            DateTime,
+            DictField,
+            Float,
+            HasMany,
+            HasOne,
+            Identifier,
+            Integer,
+            ListField,
+            Reference,
+            Status,
+            String,
+            Text,
+            ValueObject,
+        )
+    )
     def entity(
         self, _cls: type[_T] | None = None, **kwargs: Any
     ) -> type[_T] | Callable[[type[_T]], type[_T]]:
@@ -1431,7 +1597,26 @@ class Domain:
     def email(
         self, _cls: None = ..., **kwargs: Any
     ) -> Callable[[type[_T]], type[_T]]: ...
-    @dataclass_transform(field_specifiers=_FIELD_SPECIFIERS)
+    @dataclass_transform(
+        field_specifiers=(
+            Auto,
+            Boolean,
+            Date,
+            DateTime,
+            DictField,
+            Float,
+            HasMany,
+            HasOne,
+            Identifier,
+            Integer,
+            ListField,
+            Reference,
+            Status,
+            String,
+            Text,
+            ValueObject,
+        )
+    )
     def email(
         self, _cls: type[_T] | None = None, **kwargs: Any
     ) -> type[_T] | Callable[[type[_T]], type[_T]]:
@@ -1443,7 +1628,26 @@ class Domain:
     def database_model(
         self, _cls: None = ..., **kwargs: Any
     ) -> Callable[[type[_T]], type[_T]]: ...
-    @dataclass_transform(field_specifiers=_FIELD_SPECIFIERS)
+    @dataclass_transform(
+        field_specifiers=(
+            Auto,
+            Boolean,
+            Date,
+            DateTime,
+            DictField,
+            Float,
+            HasMany,
+            HasOne,
+            Identifier,
+            Integer,
+            ListField,
+            Reference,
+            Status,
+            String,
+            Text,
+            ValueObject,
+        )
+    )
     def database_model(
         self, _cls: type[_T] | None = None, **kwargs: Any
     ) -> type[_T] | Callable[[type[_T]], type[_T]]:
@@ -1455,7 +1659,26 @@ class Domain:
     def repository(
         self, _cls: None = ..., **kwargs: Any
     ) -> Callable[[type[_T]], type[_T]]: ...
-    @dataclass_transform(field_specifiers=_FIELD_SPECIFIERS)
+    @dataclass_transform(
+        field_specifiers=(
+            Auto,
+            Boolean,
+            Date,
+            DateTime,
+            DictField,
+            Float,
+            HasMany,
+            HasOne,
+            Identifier,
+            Integer,
+            ListField,
+            Reference,
+            Status,
+            String,
+            Text,
+            ValueObject,
+        )
+    )
     def repository(
         self, _cls: type[_T] | None = None, **kwargs: Any
     ) -> type[_T] | Callable[[type[_T]], type[_T]]:
@@ -1467,7 +1690,26 @@ class Domain:
     def subscriber(
         self, _cls: None = ..., **kwargs: Any
     ) -> Callable[[type[_T]], type[_T]]: ...
-    @dataclass_transform(field_specifiers=_FIELD_SPECIFIERS)
+    @dataclass_transform(
+        field_specifiers=(
+            Auto,
+            Boolean,
+            Date,
+            DateTime,
+            DictField,
+            Float,
+            HasMany,
+            HasOne,
+            Identifier,
+            Integer,
+            ListField,
+            Reference,
+            Status,
+            String,
+            Text,
+            ValueObject,
+        )
+    )
     def subscriber(
         self, _cls: type[_T] | None = None, **kwargs: Any
     ) -> type[_T] | Callable[[type[_T]], type[_T]]:
@@ -1483,7 +1725,26 @@ class Domain:
     def value_object(
         self, _cls: None = ..., **kwargs: Any
     ) -> Callable[[type[_T]], type[_T]]: ...
-    @dataclass_transform(field_specifiers=_FIELD_SPECIFIERS)
+    @dataclass_transform(
+        field_specifiers=(
+            Auto,
+            Boolean,
+            Date,
+            DateTime,
+            DictField,
+            Float,
+            HasMany,
+            HasOne,
+            Identifier,
+            Integer,
+            ListField,
+            Reference,
+            Status,
+            String,
+            Text,
+            ValueObject,
+        )
+    )
     def value_object(
         self, _cls: type[_T] | None = None, **kwargs: Any
     ) -> type[_T] | Callable[[type[_T]], type[_T]]:
@@ -1499,7 +1760,26 @@ class Domain:
     def projection(
         self, _cls: None = ..., **kwargs: Any
     ) -> Callable[[type[_T]], type[_T]]: ...
-    @dataclass_transform(field_specifiers=_FIELD_SPECIFIERS)
+    @dataclass_transform(
+        field_specifiers=(
+            Auto,
+            Boolean,
+            Date,
+            DateTime,
+            DictField,
+            Float,
+            HasMany,
+            HasOne,
+            Identifier,
+            Integer,
+            ListField,
+            Reference,
+            Status,
+            String,
+            Text,
+            ValueObject,
+        )
+    )
     def projection(
         self, _cls: type[_T] | None = None, **kwargs: Any
     ) -> type[_T] | Callable[[type[_T]], type[_T]]:
@@ -1515,7 +1795,26 @@ class Domain:
     def projector(
         self, _cls: None = ..., **kwargs: Any
     ) -> Callable[[type[_T]], type[_T]]: ...
-    @dataclass_transform(field_specifiers=_FIELD_SPECIFIERS)
+    @dataclass_transform(
+        field_specifiers=(
+            Auto,
+            Boolean,
+            Date,
+            DateTime,
+            DictField,
+            Float,
+            HasMany,
+            HasOne,
+            Identifier,
+            Integer,
+            ListField,
+            Reference,
+            Status,
+            String,
+            Text,
+            ValueObject,
+        )
+    )
     def projector(
         self, _cls: type[_T] | None = None, **kwargs: Any
     ) -> type[_T] | Callable[[type[_T]], type[_T]]:
@@ -1531,7 +1830,26 @@ class Domain:
     def query(
         self, _cls: None = ..., **kwargs: Any
     ) -> Callable[[type[_T]], type[_T]]: ...
-    @dataclass_transform(field_specifiers=_FIELD_SPECIFIERS)
+    @dataclass_transform(
+        field_specifiers=(
+            Auto,
+            Boolean,
+            Date,
+            DateTime,
+            DictField,
+            Float,
+            HasMany,
+            HasOne,
+            Identifier,
+            Integer,
+            ListField,
+            Reference,
+            Status,
+            String,
+            Text,
+            ValueObject,
+        )
+    )
     def query(
         self, _cls: type[_T] | None = None, **kwargs: Any
     ) -> type[_T] | Callable[[type[_T]], type[_T]]:
@@ -1547,7 +1865,26 @@ class Domain:
     def query_handler(
         self, _cls: None = ..., **kwargs: Any
     ) -> Callable[[type[_T]], type[_T]]: ...
-    @dataclass_transform(field_specifiers=_FIELD_SPECIFIERS)
+    @dataclass_transform(
+        field_specifiers=(
+            Auto,
+            Boolean,
+            Date,
+            DateTime,
+            DictField,
+            Float,
+            HasMany,
+            HasOne,
+            Identifier,
+            Integer,
+            ListField,
+            Reference,
+            Status,
+            String,
+            Text,
+            ValueObject,
+        )
+    )
     def query_handler(
         self, _cls: type[_T] | None = None, **kwargs: Any
     ) -> type[_T] | Callable[[type[_T]], type[_T]]:
@@ -1563,7 +1900,26 @@ class Domain:
     def process_manager(
         self, _cls: None = ..., **kwargs: Any
     ) -> Callable[[type[_T]], type[_T]]: ...
-    @dataclass_transform(field_specifiers=_FIELD_SPECIFIERS)
+    @dataclass_transform(
+        field_specifiers=(
+            Auto,
+            Boolean,
+            Date,
+            DateTime,
+            DictField,
+            Float,
+            HasMany,
+            HasOne,
+            Identifier,
+            Integer,
+            ListField,
+            Reference,
+            Status,
+            String,
+            Text,
+            ValueObject,
+        )
+    )
     def process_manager(
         self, _cls: type[_T] | None = None, **kwargs: Any
     ) -> type[_T] | Callable[[type[_T]], type[_T]]:
@@ -1602,7 +1958,7 @@ class Domain:
         """
 
         def wrap(cls: type) -> type:
-            new_cls = upcaster_factory(cls, self, **kwargs)
+            new_cls: type = upcaster_factory(cls, self, **kwargs)
             self._upcasters.append(new_cls)
             return new_cls
 
@@ -1613,7 +1969,7 @@ class Domain:
     ########################
     # Message Enrichment  #
     ########################
-    def register_event_enricher(self, fn: Callable) -> None:
+    def register_event_enricher(self, fn: Callable[..., Any]) -> None:
         """Register a callable that enriches every event's metadata.
 
         The enricher is called during :meth:`~protean.core.aggregate.raise_`
@@ -1639,7 +1995,7 @@ class Domain:
         self._event_enrichers.append(fn)
 
     @property
-    def event_enricher(self) -> Callable:
+    def event_enricher(self) -> Callable[..., Any]:
         """Decorator form of :meth:`register_event_enricher`.
 
         Example::
@@ -1649,13 +2005,13 @@ class Domain:
                 return {"tenant_id": get_current_tenant_id()}
         """
 
-        def decorator(fn: Callable) -> Callable:
+        def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
             self.register_event_enricher(fn)
             return fn
 
         return decorator
 
-    def register_command_enricher(self, fn: Callable) -> None:
+    def register_command_enricher(self, fn: Callable[..., Any]) -> None:
         """Register a callable that enriches every command's metadata.
 
         The enricher is called during :meth:`process` with ``(command,)``
@@ -1681,7 +2037,7 @@ class Domain:
         self._command_enrichers.append(fn)
 
     @property
-    def command_enricher(self) -> Callable:
+    def command_enricher(self) -> Callable[..., Any]:
         """Decorator form of :meth:`register_command_enricher`.
 
         Example::
@@ -1691,7 +2047,7 @@ class Domain:
                 return {"request_id": get_request_id()}
         """
 
-        def decorator(fn: Callable) -> Callable:
+        def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
             self.register_command_enricher(fn)
             return fn
 
@@ -1771,7 +2127,7 @@ class Domain:
     ###################
     # Handling Events #
     ###################
-    def handlers_for(self, event: Any) -> set:
+    def handlers_for(self, event: Any) -> set[Any]:
         """Return Event Handlers listening to a specific event
 
         Args:
@@ -1785,11 +2141,11 @@ class Domain:
     ############################
     # Projector Functionality  #
     ############################
-    def projectors_for(self, projection_cls: BaseProjection) -> set:
+    def projectors_for(self, projection_cls: type[BaseProjection]) -> set[Any]:
         """Return Projectors listening to a specific projection
 
         Args:
-            projection_cls (BaseProjection): Projection to be consumed
+            projection_cls (type[BaseProjection]): Projection to be consumed
 
         Returns:
             List[BaseProjector]: Projectors that have registered to consume the projection
@@ -1800,21 +2156,23 @@ class Domain:
     # Repository Functionality #
     ############################
 
-    def repository_for(self, element_cls) -> BaseRepository:
+    def repository_for(self, element_cls: Any) -> BaseRepository:
         if isinstance(element_cls, str):
             raise IncorrectUsageError(
                 f"Element {element_cls} is not registered in domain {self.name}"
             )
 
+        repository: BaseRepository
         if (
             element_cls.element_type == DomainObjects.AGGREGATE
             and element_cls.meta_.is_event_sourced
         ):
             # Return an Event Sourced repository
-            return self.event_store.repository_for(element_cls)
+            repository = self.event_store.repository_for(element_cls)
         else:
             # This is a regular aggregate or a projection
-            return self.providers.repository_for(element_cls)
+            repository = self.providers.repository_for(element_cls)
+        return repository
 
     ###########################
     # ReadView Functionality #
@@ -1849,11 +2207,14 @@ class Domain:
                 f"Element {projection_cls} is not registered in domain {self.name}"
             )
 
-        if projection_cls.element_type != DomainObjects.PROJECTION:
+        # ``element_type`` is a class var injected onto element classes at
+        # registration; it is not visible on the bare ``type`` annotation.
+        projection: Any = projection_cls
+        if projection.element_type != DomainObjects.PROJECTION:
             raise IncorrectUsageError(
                 f"`view_for` is only available for projections. "
-                f"Received {projection_cls.__name__} "
-                f"({projection_cls.element_type})."
+                f"Received {projection.__name__} "
+                f"({projection.element_type})."
             )
 
         return ReadView(self, projection_cls)
@@ -1869,7 +2230,7 @@ class Domain:
     # Cache Functionality #
     #######################
 
-    def cache_for(self, projection_cls):
+    def cache_for(self, projection_cls: type[BaseProjection]) -> "BaseCache":
         return self.caches.cache_for(projection_cls)
 
     ################################
@@ -1909,17 +2270,20 @@ class Domain:
                 f"Element {projection_cls} is not registered in domain {self.name}"
             )
 
-        if projection_cls.element_type != DomainObjects.PROJECTION:
+        # ``element_type`` / ``meta_`` are injected onto element classes at
+        # registration; they are not visible on the bare ``type`` annotation.
+        projection: Any = projection_cls
+        if projection.element_type != DomainObjects.PROJECTION:
             raise IncorrectUsageError(
                 f"`connection_for` is only available for projections. "
-                f"Received {projection_cls.__name__} "
-                f"({projection_cls.element_type})."
+                f"Received {projection.__name__} "
+                f"({projection.element_type})."
             )
 
-        if projection_cls.meta_.cache:
-            return self.caches.get_connection(projection_cls.meta_.cache)
+        if projection.meta_.cache:
+            return self.caches.get_connection(projection.meta_.cache)
         else:
-            return self.providers.get_connection(projection_cls.meta_.provider)
+            return self.providers.get_connection(projection.meta_.provider)
 
     ##########################
     # Snapshot Functionality #
@@ -1949,7 +2313,10 @@ class Domain:
                 f"`{aggregate_cls.__name__}` is not registered in domain {self.name}"
             )
 
-        return self.event_store.store.create_snapshot(aggregate_cls, identifier)
+        created: bool = self.event_store.store.create_snapshot(
+            aggregate_cls, identifier
+        )
+        return created
 
     def create_snapshots(self, aggregate_cls: type) -> int:
         """Create snapshots for all instances of an event-sourced aggregate.
@@ -1973,7 +2340,8 @@ class Domain:
                 f"`{aggregate_cls.__name__}` is not registered in domain {self.name}"
             )
 
-        return self.event_store.store.create_snapshots(aggregate_cls)
+        count: int = self.event_store.store.create_snapshots(aggregate_cls)
+        return count
 
     def create_all_snapshots(self) -> dict[str, int]:
         """Create snapshots for all event-sourced aggregates in the domain.
@@ -2079,15 +2447,15 @@ class Domain:
     # Email Functionality #
     #######################
 
-    def get_email_provider(self, provider_name):
+    def get_email_provider(self, provider_name: str) -> Any:
         return self.email_providers.get_email_provider(provider_name)
 
-    def send_email(self, email):
+    def send_email(self, email: Any) -> Any:
         return self.email_providers.send_email(email)
 
-    def make_shell_context(self):
+    def make_shell_context(self) -> dict[str, Any]:
         """Return a dictionary of context variables for a shell session."""
-        values = {"domain": self}
+        values: dict[str, Any] = {"domain": self}
 
         # For each domain element type in Domain Objects,
         #   Cycle through all values in self.registry._elements[element_type]
@@ -2107,13 +2475,13 @@ class Domain:
     def _initialize_outbox(self) -> None:
         self._infrastructure.initialize_outbox()
 
-    def _get_outbox_repo(self, provider_name: str):
+    def _get_outbox_repo(self, provider_name: str) -> BaseRepository:
         return self._infrastructure.get_outbox_repo(provider_name)
 
     def _initialize_processed_messages(self) -> None:
         self._infrastructure.initialize_processed_messages()
 
-    def _get_processed_message_repo(self, provider_name: str):
+    def _get_processed_message_repo(self, provider_name: str) -> BaseRepository:
         return self._infrastructure.get_processed_message_repo(provider_name)
 
     # ------------------------------------------------------------------
@@ -2215,7 +2583,7 @@ class Domain:
         # Skip OTel injection when telemetry is disabled so the structlog
         # chain does not pay the cost of a no-op processor on every log call.
         extra_processors = config_kwargs.pop("extra_processors", None)
-        extra: list = [protean_correlation_processor]
+        extra: list[Any] = [protean_correlation_processor]
         if telemetry_enabled:
             extra.append(protean_otel_processor)
         extra.extend(list(extra_processors or []))

--- a/src/protean/domain/__init__.py
+++ b/src/protean/domain/__init__.py
@@ -80,6 +80,7 @@ if TYPE_CHECKING:
     from types import FrameType
 
     from protean.port.cache import BaseCache
+    from protean.utils.outbox import OutboxRepository
     from protean.utils.projection_rebuilder import RebuildResult
     from protean.utils.upcasting import UpcasterChain
 
@@ -2475,8 +2476,12 @@ class Domain:
     def _initialize_outbox(self) -> None:
         self._infrastructure.initialize_outbox()
 
-    def _get_outbox_repo(self, provider_name: str) -> BaseRepository:
-        return self._infrastructure.get_outbox_repo(provider_name)
+    def _get_outbox_repo(self, provider_name: str) -> "OutboxRepository":
+        # The infrastructure builds an OutboxRepository (typed BaseRepository at
+        # its boundary); narrow so callers see count_by_status et al.
+        return cast(
+            "OutboxRepository", self._infrastructure.get_outbox_repo(provider_name)
+        )
 
     def _initialize_processed_messages(self) -> None:
         self._infrastructure.initialize_processed_messages()

--- a/src/protean/domain/registry.py
+++ b/src/protean/domain/registry.py
@@ -1,7 +1,7 @@
 import logging
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict, List
 
 import inflection
 
@@ -75,6 +75,32 @@ class _DomainRegistry:
     """
 
     __slots__ = ("_elements", "_elements_by_name")
+
+    if TYPE_CHECKING:
+        # Element-type accessors installed dynamically at import time via
+        # ``_create_element_property`` + ``setattr`` (see bottom of module).
+        # Declared here so static checkers (mypy, pyright) see them as real
+        # attributes. Each returns the ``{qualname: DomainRecord}`` mapping of
+        # non-internal elements for that element type.
+        aggregates: Dict[str, DomainRecord]
+        application_services: Dict[str, DomainRecord]
+        commands: Dict[str, DomainRecord]
+        command_handlers: Dict[str, DomainRecord]
+        database_models: Dict[str, DomainRecord]
+        domain_services: Dict[str, DomainRecord]
+        emails: Dict[str, DomainRecord]
+        entities: Dict[str, DomainRecord]
+        events: Dict[str, DomainRecord]
+        event_handlers: Dict[str, DomainRecord]
+        event_sourced_repositories: Dict[str, DomainRecord]
+        process_managers: Dict[str, DomainRecord]
+        projections: Dict[str, DomainRecord]
+        projectors: Dict[str, DomainRecord]
+        queries: Dict[str, DomainRecord]
+        query_handlers: Dict[str, DomainRecord]
+        repositories: Dict[str, DomainRecord]
+        subscribers: Dict[str, DomainRecord]
+        value_objects: Dict[str, DomainRecord]
 
     def __init__(self) -> None:
         self._elements: Dict[str, Dict[str, DomainRecord]] = {}

--- a/src/protean/domain/registry.py
+++ b/src/protean/domain/registry.py
@@ -1,7 +1,7 @@
 import logging
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Protocol, cast
 
 import inflection
 
@@ -10,6 +10,21 @@ from protean.utils import DomainObjects, fully_qualified_name
 from protean.utils.container import Element
 
 logger = logging.getLogger(__name__)
+
+
+class _ElementClass(Protocol):
+    """Structural type for a registered element class.
+
+    Every concrete Protean element subclass carries an ``element_type``
+    class attribute (a :class:`DomainObjects` member) declared on the
+    subclass rather than on the shared ``Element`` base. This Protocol
+    exposes that attribute to static checkers after
+    :meth:`_DomainRegistry._is_invalid_element_cls` has verified it is
+    present at runtime.
+    """
+
+    element_type: ClassVar[DomainObjects]
+    __name__: str
 
 
 # Define property names for each element type
@@ -124,10 +139,11 @@ class _DomainRegistry:
         * `element_type` is an Enum value
         * The value of `element_type` enum is among recognized `DomainObjects` values
         """
+        element_type = getattr(element_cls, "element_type", None)
         return (
-            not hasattr(element_cls, "element_type")
-            or not isinstance(element_cls.element_type, Enum)
-            or element_cls.element_type.name not in DomainObjects.__members__
+            element_type is None
+            or not isinstance(element_type, Enum)
+            or element_type.name not in DomainObjects.__members__
         )
 
     def register_element(
@@ -151,10 +167,15 @@ class _DomainRegistry:
                 f"Element `{element_cls.__name__}` is not a valid element class"
             )
 
+        # ``_is_invalid_element_cls`` has verified that ``element_type`` is
+        # present and valid; narrow to the structural type so checkers can
+        # see the attribute (declared on subclasses, not the ``Element`` base).
+        element = cast(_ElementClass, element_cls)
+
         # Element name is always the fully qualified name of the class
         element_name = fully_qualified_name(element_cls)
 
-        element_dict = self._elements[element_cls.element_type.value]
+        element_dict = self._elements[element.element_type.value]
         if element_name in element_dict:
             if element_dict[element_name].cls is not element_cls:
                 logger.warning(
@@ -168,7 +189,7 @@ class _DomainRegistry:
             element_record = DomainRecord(
                 name=element_cls.__name__,
                 qualname=element_name,
-                class_type=element_cls.element_type.value,
+                class_type=element.element_type.value,
                 cls=element_cls,
                 internal=internal,
                 auto_generated=auto_generated,
@@ -183,7 +204,7 @@ class _DomainRegistry:
                 self._elements_by_name[element_cls.__name__] = [element_record]
 
             logger.debug(
-                f"Registered Element {element_name} with Domain as a {element_cls.element_type.value}"
+                f"Registered Element {element_name} with Domain as a {element.element_type.value}"
             )
 
     @property

--- a/src/protean/fields/association.py
+++ b/src/protean/fields/association.py
@@ -1,8 +1,10 @@
 from abc import abstractmethod
+from typing import TYPE_CHECKING, Any
 
-from protean import exceptions, utils
+from protean import exceptions
 from protean.exceptions import ValidationError
 from protean.utils.globals import current_domain
+from protean.utils.inflection import underscore
 from protean.utils.reflection import (
     association_fields,
     has_association_fields,
@@ -12,6 +14,10 @@ from protean.utils.reflection import (
 from .base import Field, FieldBase
 from .mixins import FieldCacheMixin, FieldDescriptorMixin
 from .tempdata import HasManyChanges, HasOneChanges
+
+if TYPE_CHECKING:
+    from protean.core.entity import BaseEntity
+    from protean.domain import Domain
 
 
 class _ReferenceField(Field):
@@ -23,12 +29,12 @@ class _ReferenceField(Field):
         **kwargs: Additional keyword arguments to be passed to the base `Field` class.
     """
 
-    def __init__(self, reference, **kwargs):
+    def __init__(self, reference: "Reference", **kwargs: Any) -> None:
         """Accept reference field as an attribute, otherwise is a straightforward field"""
         self.reference = reference
         super().__init__(**kwargs)
 
-    def __set__(self, instance, value):
+    def __set__(self, instance: Any, value: Any) -> None:
         """Override `__set__` to update relation field and keep it in sync with the shadow
         attribute's value
 
@@ -44,7 +50,7 @@ class _ReferenceField(Field):
             # Important to handle None assignment, and interpret it to mean resetting values
             self._reset_values(instance)
 
-    def __delete__(self, instance):
+    def __delete__(self, instance: Any) -> None:
         """Nullify values and linkages
 
         Args:
@@ -52,7 +58,7 @@ class _ReferenceField(Field):
         """
         self._reset_values(instance)
 
-    def _cast_to_type(self, value):
+    def _cast_to_type(self, value: Any) -> Any:
         """Pass through without validation.
 
         The shadow field's value is set by Reference.__set__ which
@@ -60,7 +66,7 @@ class _ReferenceField(Field):
         """
         return value
 
-    def as_dict(self, value):
+    def as_dict(self, value: Any) -> Any:
         """Return JSON-compatible value of self
 
         Args:
@@ -72,7 +78,7 @@ class _ReferenceField(Field):
         """
         raise NotImplementedError
 
-    def _reset_values(self, instance):
+    def _reset_values(self, instance: Any) -> None:
         """Reset all associated values and clean up dictionary items
 
         Args:
@@ -94,32 +100,36 @@ class Reference(FieldCacheMixin, Field):
         **kwargs (Any): Additional keyword arguments to be passed to the base `Field` class.
     """
 
-    def __init__(self, to_cls, **kwargs):
+    #: Shadow slot cleared by the paired ``_ReferenceField`` on reset. Written
+    #: to but not read; declared so the reset path type-checks.
+    value: Any
+
+    def __init__(self, to_cls: "str | type", **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self._to_cls = to_cls
 
         self.relation = _ReferenceField(self)
 
     @property
-    def to_cls(self):
+    def to_cls(self) -> "str | type":
         return self._to_cls
 
-    def get_attribute_name(self):
+    def get_attribute_name(self) -> str:
         """Return formatted attribute name for the shadow field"""
         return self.referenced_as or "{}_{}".format(
             self.field_name, self.linked_attribute
         )
 
-    def get_shadow_field(self):
+    def get_shadow_field(self) -> "tuple[str | None, _ReferenceField]":
         """Return shadow field
         Primarily used during Entity initialization to register shadow field"""
         return (self.attribute_name, self.relation)
 
-    def get_cache_name(self):
+    def get_cache_name(self) -> "str | None":
         return self.field_name
 
     @property
-    def linked_attribute(self):
+    def linked_attribute(self) -> str:
         """Return linkage attribute to the target class
 
         This method is initially called from `__set_name__()` -> `get_attribute_name()`
@@ -134,9 +144,10 @@ class Reference(FieldCacheMixin, Field):
         else:
             id_fld = id_field(self.to_cls)
             assert id_fld is not None
+            assert id_fld.attribute_name is not None
             return id_fld.attribute_name
 
-    def _resolve_to_cls(self, domain, to_cls, owner_cls):
+    def _resolve_to_cls(self, domain: "Domain", to_cls: type, owner_cls: type) -> None:
         assert isinstance(self.to_cls, str)
 
         self._to_cls = to_cls
@@ -162,7 +173,7 @@ class Reference(FieldCacheMixin, Field):
         # Update domain records because we enriched the class structure
         domain._replace_element_by_class(owner_cls)
 
-    def __get__(self, instance, owner):
+    def __get__(self, instance: Any, owner: Any) -> Any:
         """Retrieve associated objects"""
         reference_obj = None
         if hasattr(instance, "state_"):
@@ -186,17 +197,18 @@ class Reference(FieldCacheMixin, Field):
 
         return reference_obj
 
-    def _fetch_objects(self, key, value):
+    def _fetch_objects(self, key: str, value: Any) -> Any:
         """Fetch referenced aggregate through its repository's public API"""
         return current_domain.repository_for(self.to_cls).find_by(**{key: value})
 
-    def __set__(self, instance, value):
+    def __set__(self, instance: Any, value: Any) -> None:
         """Override `__set__` to coordinate between relation field and its shadow attribute"""
         value = self._load(value)
 
         if value:
             id_fld = id_field(value)
             assert id_fld is not None
+            assert id_fld.field_name is not None
             if getattr(value, id_fld.field_name) is None:
                 raise ValueError(
                     "Target Object must be saved before being referenced",
@@ -210,7 +222,7 @@ class Reference(FieldCacheMixin, Field):
         else:
             self._reset_values(instance)
 
-    def _set_own_value(self, instance, value):
+    def _set_own_value(self, instance: Any, value: Any) -> None:
         if value is None:
             instance.__dict__.pop(self.field_name, None)
             self.delete_cached_value(instance)
@@ -222,21 +234,21 @@ class Reference(FieldCacheMixin, Field):
         if hasattr(instance, "state_"):
             instance.state_.mark_changed()
 
-    def _set_relation_value(self, instance, value):
+    def _set_relation_value(self, instance: Any, value: Any) -> None:
         if value is None:
             instance.__dict__.pop(self.attribute_name, None)
         else:
             instance.__dict__[self.attribute_name] = value
 
-    def __delete__(self, instance):
+    def __delete__(self, instance: Any) -> None:
         self._reset_values(instance)
 
-    def _reset_values(self, instance):
+    def _reset_values(self, instance: Any) -> None:
         """Reset all associated values and clean up dictionary items"""
         self._set_own_value(instance, None)
         self._set_relation_value(instance, None)
 
-    def _cast_to_type(self, value):
+    def _cast_to_type(self, value: Any) -> Any:
         """Pass through without validation.
 
         Type checking happens in __set__ after the reference is fully
@@ -244,7 +256,7 @@ class Reference(FieldCacheMixin, Field):
         """
         return value
 
-    def as_dict(self, value):
+    def as_dict(self, value: Any) -> Any:
         """Return JSON-compatible value of self"""
         raise NotImplementedError
 
@@ -260,21 +272,40 @@ class Association(FieldBase, FieldDescriptorMixin, FieldCacheMixin):
         to_cls (class): The class of the target entity that this association references.
     """
 
-    def __init__(self, to_cls, **kwargs):
+    #: Pending change state for a HasOne association, mirroring the tracked
+    #: ``HasOneChanges.change`` value ("ADDED"/"UPDATED"/"DELETED"/None). Read
+    #: by ``has_changed``; set explicitly by callers before it is inspected.
+    change: str | None
+
+    def __init__(self, to_cls: "str | type", **kwargs: Any) -> None:
         super().__init__(**kwargs)
 
         self._to_cls = to_cls
-        self.via = kwargs.pop("via", None)
+        self.via: str | None = kwargs.pop("via", None)
+        self.change = None
 
         # Associations are not data fields — they cannot be `required` or `unique`
         self.required = False
         self.unique = False
 
     @property
-    def to_cls(self):
+    def to_cls(self) -> "str | type":
         return self._to_cls
 
-    def _resolve_to_cls(self, domain, to_cls, owner_cls):
+    @property
+    def _target_cls(self) -> "type[BaseEntity]":
+        """Return the resolved target entity class.
+
+        ``to_cls`` starts life as a string during registration and is replaced
+        with the actual class by ``_resolve_to_cls``. Every runtime mutation
+        path (``__set__``/``add``/``remove``/``_fetch_objects``) only executes
+        once the association is bound to an initialized entity, by which point
+        the class has been resolved.
+        """
+        assert not isinstance(self._to_cls, str)
+        return self._to_cls
+
+    def _resolve_to_cls(self, domain: "Domain", to_cls: type, owner_cls: type) -> None:
         """Resolves class references to actual class object.
 
         Called by the domain when a new element is registered,
@@ -282,7 +313,7 @@ class Association(FieldBase, FieldDescriptorMixin, FieldCacheMixin):
         """
         self._to_cls = to_cls
 
-    def _cast_to_type(self, value):
+    def _cast_to_type(self, value: Any) -> Any:
         """Pass through without validation.
 
         Type checking happens in HasOne.__set__ and HasMany.add()
@@ -290,19 +321,20 @@ class Association(FieldBase, FieldDescriptorMixin, FieldCacheMixin):
         """
         return value
 
-    def _linked_attribute(self, owner):
+    def _linked_attribute(self, owner: type) -> str:
         """Return linkage attribute to own entity's `id_field`."""
         if self.via:
             return self.via
 
         id_fld = id_field(owner)
         assert id_fld is not None
-        return utils.inflection.underscore(owner.__name__) + "_" + id_fld.attribute_name
+        assert id_fld.attribute_name is not None
+        return underscore(owner.__name__) + "_" + id_fld.attribute_name
 
-    def _linked_reference(self, owner):
-        return utils.inflection.underscore(owner.__name__)
+    def _linked_reference(self, owner: type) -> str:
+        return underscore(owner.__name__)
 
-    def __get__(self, instance, owner):
+    def __get__(self, instance: Any, owner: Any) -> Any:
         """Retrieve associated objects"""
 
         try:
@@ -328,6 +360,7 @@ class Association(FieldBase, FieldDescriptorMixin, FieldCacheMixin):
                     # Fetch target object by own Identifier
                     id_fld = id_field(instance)
                     assert id_fld is not None
+                    assert id_fld.field_name is not None
                     id_value = getattr(instance, id_fld.field_name)
                     reference_obj = self._fetch_objects(
                         instance, self._linked_attribute(owner), id_value
@@ -337,7 +370,7 @@ class Association(FieldBase, FieldDescriptorMixin, FieldCacheMixin):
 
         return reference_obj
 
-    def _set_own_value(self, instance, value):
+    def _set_own_value(self, instance: Any, value: Any) -> None:
         instance.__dict__[self.field_name] = value
         self.set_cached_value(instance, value)
 
@@ -346,14 +379,14 @@ class Association(FieldBase, FieldDescriptorMixin, FieldCacheMixin):
             instance.state_.mark_changed()
 
     @abstractmethod
-    def _fetch_objects(self, instance, key, value):
+    def _fetch_objects(self, instance: Any, key: str, value: Any) -> Any:
         """Placeholder method for customized Association query methods"""
 
     @abstractmethod
-    def as_dict(self, value):
+    def as_dict(self, value: Any) -> Any:
         """Return JSON-compatible value of field"""
 
-    def __set__(self, instance, value):
+    def __set__(self, instance: Any, value: Any) -> None:
         """Set the value of the association field"""
         # Preserve heirarchy of entities.
         #
@@ -364,18 +397,18 @@ class Association(FieldBase, FieldDescriptorMixin, FieldCacheMixin):
             for item in items:
                 item._set_root_and_owner(instance._root, instance)
 
-    def __delete__(self, instance):
+    def __delete__(self, instance: Any) -> None:
         """Cannot pop values for an association"""
         raise exceptions.NotSupportedError(
             "Object does not support the operation being performed",
             self.field_name,
         )
 
-    def get_cache_name(self):
+    def get_cache_name(self) -> "str | None":
         return self.field_name
 
     @property
-    def has_changed(self):
+    def has_changed(self) -> bool:
         return self.change is not None
 
     def _clone(self) -> "Association":
@@ -395,7 +428,7 @@ class HasOne(Association):
     with at most one instance of a child entity.
     """
 
-    def __set__(self, instance, value):
+    def __set__(self, instance: Any, value: Any) -> None:
         """Setup relationship to be persisted/updated
 
         We track the change in the instance's `_temp_cache` to determine if the relationship
@@ -416,15 +449,15 @@ class HasOne(Association):
         """
         # Accept dictionary values and convert them to Entity objects
         if isinstance(value, dict):
-            value = self.to_cls(**value)
+            value = self._target_cls(**value)
 
         super().__set__(instance, value)
 
-        if value is not None and not isinstance(value, self.to_cls):
+        if value is not None and not isinstance(value, self._target_cls):
             raise ValidationError(
                 {
                     "_entity": [
-                        f"Value assigned to '{self.field_name}' is not of type '{self.to_cls.__name__}'"
+                        f"Value assigned to '{self.field_name}' is not of type '{self._target_cls.__name__}'"
                     ]
                 }
             )
@@ -435,6 +468,7 @@ class HasOne(Association):
             #   so that the foreign key relationship is preserved
             instance_id_fld = id_field(instance)
             assert instance_id_fld is not None
+            assert instance_id_fld.field_name is not None
             id_value = getattr(instance, instance_id_fld.field_name)
             linked_attribute = self._linked_attribute(instance.__class__)
             if hasattr(value, linked_attribute):
@@ -447,16 +481,19 @@ class HasOne(Association):
             setattr(value, self._linked_reference(type(instance)), instance)
 
         # 2. Determine and store the change in the relationship
+        assert self.field_name is not None
         current_value = getattr(instance, self.field_name)
         if current_value:
             current_value_id_fld = id_field(current_value)
             assert current_value_id_fld is not None
+            assert current_value_id_fld.field_name is not None
             current_value_id = getattr(current_value, current_value_id_fld.field_name)
         else:
             current_value_id = None
         if value:
             value_id_fld = id_field(value)
             assert value_id_fld is not None
+            assert value_id_fld.field_name is not None
             value_id = getattr(value, value_id_fld.field_name)
         else:
             value_id = None
@@ -493,22 +530,22 @@ class HasOne(Association):
         if instance._initialized and instance._root is not None:
             instance._root._postcheck()  # Trigger validations from the top
 
-    def _fetch_objects(self, instance, key, identifier):
+    def _fetch_objects(self, instance: Any, key: str, value: Any) -> Any:
         """Fetch single linked object"""
         try:
             repo = current_domain.repository_for(self.to_cls)
-            value = repo._dao.find_by(**{key: identifier})
+            obj = repo._dao.find_by(**{key: value})
 
             # Set up linkage with owner element
             setattr(
-                value, key, identifier
+                obj, key, value
             )  # This overwrites any existing linkage, which is correct
 
-            return value
+            return obj
         except exceptions.ObjectNotFoundError:
             return None
 
-    def as_dict(self, value):
+    def as_dict(self, value: Any) -> Any:
         """Return JSON-compatible value of self"""
         if value is not None:
             return value.to_dict()
@@ -524,7 +561,7 @@ class HasMany(Association):
         **kwargs (Any): Additional keyword arguments to be passed to the base field class.
     """
 
-    def __set__(self, instance, value):
+    def __set__(self, instance: Any, value: Any) -> None:
         """This supports direct assignment of values to HasMany fields, like:
         `order.items = [item1, item2, item3]`
         """
@@ -534,7 +571,7 @@ class HasMany(Association):
         values = []
         for item in value:
             if isinstance(item, dict):
-                values.append(self.to_cls(**item))
+                values.append(self._target_cls(**item))
             else:
                 values.append(item)
 
@@ -550,7 +587,7 @@ class HasMany(Association):
                 self.set_cached_value(instance, [])
             self.add(instance, values)
 
-    def add(self, instance, items) -> None:
+    def add(self, instance: Any, items: Any) -> None:
         """
         Available as `add_<HasMany Field Name>` method on the entity instance.
 
@@ -585,6 +622,7 @@ class HasMany(Association):
         if instance._initialized and instance._root is not None:
             instance._root._precheck()
 
+        assert self.field_name is not None
         data = getattr(instance, self.field_name)
 
         # Convert a single item into a list of items, if necessary
@@ -592,19 +630,21 @@ class HasMany(Association):
 
         # Validate that all items are of the same type, and the correct type
         for item in items:
-            if not isinstance(item, self.to_cls):
+            if not isinstance(item, self._target_cls):
                 raise ValidationError(
                     {
                         "_entity": [
-                            f"Value assigned to '{self.field_name}' is not of type '{self.to_cls.__name__}'"
+                            f"Value assigned to '{self.field_name}' is not of type '{self._target_cls.__name__}'"
                         ]
                     }
                 )
 
-        entity_id_fld = id_field(self.to_cls)
+        entity_id_fld = id_field(self._target_cls)
         assert entity_id_fld is not None
+        assert entity_id_fld.field_name is not None
         instance_id_fld = id_field(instance)
         assert instance_id_fld is not None
+        assert instance_id_fld.field_name is not None
 
         current_value_ids = [getattr(value, entity_id_fld.field_name) for value in data]
 
@@ -670,7 +710,7 @@ class HasMany(Association):
         if instance._initialized and instance._root is not None:
             instance._root._postcheck()  # Trigger validations from the top
 
-    def remove(self, instance, items) -> None:
+    def remove(self, instance: Any, items: Any) -> None:
         """
         Available as `remove_<HasMany Field Name>` method on the entity instance.
 
@@ -686,6 +726,7 @@ class HasMany(Association):
         if instance._initialized and instance._root is not None:
             instance._root._precheck()
 
+        assert self.field_name is not None
         data = getattr(instance, self.field_name)
 
         # Convert a single item into a list of items, if necessary
@@ -693,22 +734,23 @@ class HasMany(Association):
 
         # Validate that all items are of the same type, and the correct type
         for item in items:
-            if not isinstance(item, self.to_cls):
+            if not isinstance(item, self._target_cls):
                 raise ValidationError(
                     {
                         "_entity": [
-                            f"Value assigned to '{self.field_name}' is not of type '{self.to_cls.__name__}'"
+                            f"Value assigned to '{self.field_name}' is not of type '{self._target_cls.__name__}'"
                         ]
                     }
                 )
 
-        entity_id_fld = id_field(self.to_cls)
+        entity_id_fld = id_field(self._target_cls)
         assert entity_id_fld is not None
+        assert entity_id_fld.field_name is not None
 
         current_value_ids = [getattr(value, entity_id_fld.field_name) for value in data]
 
         cache = instance._temp_cache.setdefault(self.field_name, HasManyChanges())
-        removed_ids = set()
+        removed_ids: set[Any] = set()
         for item in items:
             identity = getattr(item, entity_id_fld.field_name)
             if identity in current_value_ids:
@@ -736,7 +778,7 @@ class HasMany(Association):
         if instance._initialized and instance._root is not None:
             instance._root._postcheck()  # Trigger validations from the top
 
-    def _fetch_objects(self, instance, key, value) -> list:
+    def _fetch_objects(self, instance: Any, key: str, value: Any) -> list[Any]:
         """
         Fetch linked entities.
 
@@ -748,10 +790,11 @@ class HasMany(Association):
         Returns:
             list: A list of linked entity instances.
         """
-        entity_id_fld = id_field(self.to_cls)
+        entity_id_fld = id_field(self._target_cls)
         assert entity_id_fld is not None
+        assert entity_id_fld.field_name is not None
 
-        children_repo = current_domain.repository_for(self.to_cls)
+        children_repo = current_domain.repository_for(self._target_cls)
         data = children_repo._dao.query.filter(**{key: value}).all().items
 
         # Set up linkage with owner element.
@@ -792,7 +835,7 @@ class HasMany(Association):
 
         return data
 
-    def as_dict(self, value) -> list:
+    def as_dict(self, value: Any) -> list[Any]:
         """
         Return JSON-compatible value of self.
 
@@ -804,7 +847,7 @@ class HasMany(Association):
         """
         return [item.to_dict() for item in value]
 
-    def get(self, instance, **kwargs):
+    def get(self, instance: Any, **kwargs: Any) -> Any:
         """Fetch a single linked entity based on the provided criteria.
 
         Available as `get_one_from_<HasMany Field Name>` method on the entity instance.
@@ -826,7 +869,7 @@ class HasMany(Association):
 
         return data[0]
 
-    def filter(self, instance, **kwargs):
+    def filter(self, instance: Any, **kwargs: Any) -> list[Any]:
         """Filter the linked entities based on the provided criteria.
 
         Available as `filter_<HasMany Field Name>` method on the entity instance.
@@ -834,6 +877,7 @@ class HasMany(Association):
         Args:
             **kwargs (Any): The filtering criteria.
         """
+        assert self.field_name is not None
         data = getattr(instance, self.field_name)
         return [
             item

--- a/src/protean/fields/basic.py
+++ b/src/protean/fields/basic.py
@@ -2,6 +2,8 @@
 
 import datetime
 
+from typing import Any, Callable, cast
+
 from protean.exceptions import ValidationError
 from protean.fields import Field
 from protean.fields.embedded import ValueObject
@@ -49,7 +51,12 @@ class ValueObjectList(Field):
         "invalid_content": "Invalid value {value}",
     }
 
-    def __init__(self, content_type=str, pickled=False, **kwargs):
+    def __init__(
+        self,
+        content_type: type | ValueObject = str,
+        pickled: bool = False,
+        **kwargs: Any,
+    ) -> None:
         if content_type not in _SUPPORTED_CONTENT_TYPES and not isinstance(
             content_type, ValueObject
         ):
@@ -59,7 +66,7 @@ class ValueObjectList(Field):
 
         super().__init__(**kwargs)
 
-    def _cast_to_type(self, value):
+    def _cast_to_type(self, value: Any) -> Any:
         """Raise errors if the value is not a list, or
         the items in the list are not of the right data type.
         """
@@ -75,16 +82,19 @@ class ValueObjectList(Field):
                 self.fail("invalid_content", value=value)
             return new_value
 
-        # For Python primitive types, cast each item
+        # For Python primitive types, cast each item. In this branch
+        # ``content_type`` is a constructor invoked with a single value; a
+        # bad arity (e.g. ``date``) surfaces as the caught TypeError below.
+        cast_fn = cast(Callable[[Any], Any], self.content_type)
         new_value = []
         try:
             for item in value:
-                new_value.append(self.content_type(item))
+                new_value.append(cast_fn(item))
         except (ValueError, TypeError):
             self.fail("invalid_content", value=value)
         return new_value
 
-    def as_dict(self, value):
+    def as_dict(self, value: Any) -> Any:
         """Return JSON-compatible value of self"""
         if isinstance(self.content_type, ValueObject):
             return [self.content_type.as_dict(item) for item in value]
@@ -99,15 +109,15 @@ class ValueObjectList(Field):
 class Method(Field):
     """Helper field for custom methods associated with serializer fields"""
 
-    def __init__(self, method_name, **kwargs):
+    def __init__(self, method_name: str, **kwargs: Any) -> None:
         self.method_name = method_name
         super().__init__(**kwargs)
 
-    def _cast_to_type(self, value):
+    def _cast_to_type(self, value: Any) -> Any:
         """Perform no validation for Method fields. Return the value as is"""
         return value
 
-    def as_dict(self, value):
+    def as_dict(self, value: Any) -> Any:
         """Return JSON-compatible value of self"""
         return value
 
@@ -115,20 +125,20 @@ class Method(Field):
 class Nested(Field):
     """Helper field for nested objects associated with serializer fields"""
 
-    def __init__(self, schema_name, many=False, **kwargs):
+    def __init__(self, schema_name: str, many: bool = False, **kwargs: Any) -> None:
         self.schema_name = schema_name
         self.many = many
         super().__init__(**kwargs)
 
-    def _cast_to_type(self, value):
+    def _cast_to_type(self, value: Any) -> Any:
         """Perform no validation for Nested fields. Return the value as is"""
         return value
 
-    def as_dict(self, value):
+    def as_dict(self, value: Any) -> Any:
         """Return JSON-compatible value of self"""
         return value
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         values = []
         if self.schema_name:
             values.append(f"'{self.schema_name}'")

--- a/src/protean/integrations/fastapi/health.py
+++ b/src/protean/integrations/fastapi/health.py
@@ -15,6 +15,7 @@ Usage::
 
 from __future__ import annotations
 
+from enum import Enum
 from typing import TYPE_CHECKING, Any
 
 from fastapi import APIRouter
@@ -37,7 +38,7 @@ def create_health_router(
     domain: Domain,
     *,
     prefix: str = "",
-    tags: list[str] | None = None,
+    tags: list[str | Enum] | None = None,
 ) -> APIRouter:
     """Create a FastAPI router with health check endpoints.
 

--- a/src/protean/server/subscription/config_resolver.py
+++ b/src/protean/server/subscription/config_resolver.py
@@ -35,6 +35,7 @@ from protean.server.subscription.profiles import (
 
 if TYPE_CHECKING:
     from protean.domain import Domain
+    from protean.server.subscription.factory import CommandDispatcherProtocol
     from protean.utils.mixins import HandlerMixin
 
 logger = logging.getLogger(__name__)
@@ -73,7 +74,7 @@ class ConfigResolver:
 
     def resolve(
         self,
-        handler_cls: Type["HandlerMixin"],
+        handler_cls: 'Type["HandlerMixin"] | "CommandDispatcherProtocol"',
         *,
         stream_category: Optional[str] = None,
     ) -> SubscriptionConfig:
@@ -257,7 +258,7 @@ class ConfigResolver:
         return dict(subscriptions.get(handler_name, {}))
 
     def _get_handler_meta_config(
-        self, handler_cls: Type["HandlerMixin"]
+        self, handler_cls: 'Type["HandlerMixin"] | "CommandDispatcherProtocol"'
     ) -> dict[str, Any]:
         """Extract subscription configuration from handler's Meta options.
 

--- a/src/protean/server/subscription/factory.py
+++ b/src/protean/server/subscription/factory.py
@@ -14,7 +14,7 @@ Example:
 """
 
 import logging
-from typing import TYPE_CHECKING, Type, Union
+from typing import TYPE_CHECKING, Protocol, Union, cast
 
 from protean.server.subscription.config_resolver import ConfigResolver
 from protean.server.subscription.event_store_subscription import EventStoreSubscription
@@ -22,13 +22,53 @@ from protean.server.subscription.profiles import SubscriptionConfig, Subscriptio
 from protean.server.subscription.stream_subscription import StreamSubscription
 
 if TYPE_CHECKING:
+    from protean.core.command import BaseCommand
     from protean.core.command_handler import BaseCommandHandler
+    from protean.core.event import BaseEvent
     from protean.core.event_handler import BaseEventHandler
     from protean.server import Engine
+    from protean.utils.container import Options
+    from protean.utils.eventing import Message
 
     from . import BaseSubscription
 
+
+class CommandDispatcherProtocol(Protocol):
+    """Structural type for the engine's ``CommandDispatcher``.
+
+    The engine may pass a ``CommandDispatcher`` *instance* (rather than a
+    handler class) to :meth:`SubscriptionFactory.create_subscription` when
+    several command handlers share a stream category. The factory and the
+    subscriptions treat the handler purely duck-typed, so this Protocol
+    captures the surface actually consumed: an identity (``__name__``), the
+    resolved subscription options (``meta_``), and the message-routing methods.
+    """
+
+    __name__: str
+    meta_: "Options"
+
+    def resolve_handler(
+        self, message: "Message | BaseCommand | BaseEvent"
+    ) -> "type[BaseCommandHandler] | None": ...
+
+    def _handle(
+        self, message: "Message | BaseCommand | BaseEvent"
+    ) -> object | None: ...
+
+    def handle_error(self, exc: Exception, message: "Message") -> None: ...
+
+
 logger = logging.getLogger(__name__)
+
+# The kinds of handler the factory can build a subscription for: a handler
+# *class* (event or command handler — also covers projectors and process
+# managers, which are ``HandlerMixin`` subclasses), or a duck-typed
+# ``CommandDispatcher`` instance routing several command handlers on one stream.
+HandlerArg = Union[
+    "type[BaseEventHandler]",
+    "type[BaseCommandHandler]",
+    "CommandDispatcherProtocol",
+]
 
 
 class SubscriptionFactory:
@@ -73,7 +113,7 @@ class SubscriptionFactory:
 
     def create_subscription(
         self,
-        handler: Type[Union["BaseEventHandler", "BaseCommandHandler"]],
+        handler: "HandlerArg",
         stream_category: str,
     ) -> "BaseSubscription":
         """Create a subscription for the given handler.
@@ -130,7 +170,7 @@ class SubscriptionFactory:
 
     def _create_subscription_from_config(
         self,
-        handler: Type[Union["BaseEventHandler", "BaseCommandHandler"]],
+        handler: "HandlerArg",
         stream_category: str,
         config: SubscriptionConfig,
     ) -> "BaseSubscription":
@@ -144,18 +184,25 @@ class SubscriptionFactory:
         Returns:
             A configured subscription instance.
         """
+        # ``from_config`` still declares the narrower handler-class type; the
+        # engine's ``CommandDispatcher`` instance is accepted duck-typed at
+        # runtime (only ``__name__``/``__module__``/``__qualname__`` and the
+        # routing methods are read). Cast to the declared type at this boundary
+        # until the subscription classes' signatures are widened in turn.
+        handler_arg = cast("type[BaseEventHandler] | type[BaseCommandHandler]", handler)
+
         if config.subscription_type == SubscriptionType.STREAM:
             return StreamSubscription.from_config(
                 engine=self._engine,
                 stream_category=stream_category,
-                handler=handler,
+                handler=handler_arg,
                 config=config,
             )
         else:  # EVENT_STORE
             return EventStoreSubscription.from_config(
                 engine=self._engine,
                 stream_category=stream_category,
-                handler=handler,
+                handler=handler_arg,
                 config=config,
             )
 

--- a/src/protean/utils/inflection.py
+++ b/src/protean/utils/inflection.py
@@ -3,7 +3,7 @@
 import re
 
 
-def camelize(string, uppercase_first_letter=True):
+def camelize(string: str, uppercase_first_letter: bool = True) -> str:
     """
     Convert strings to CamelCase.
 
@@ -30,7 +30,7 @@ def camelize(string, uppercase_first_letter=True):
         return string[0].lower() + camelize(string)[1:]
 
 
-def dasherize(word):
+def dasherize(word: str) -> str:
     """Replace underscores with dashes in the string.
 
     Example::
@@ -42,7 +42,7 @@ def dasherize(word):
     return word.replace("_", "-")
 
 
-def humanize(word):
+def humanize(word: str) -> str:
     """
     Capitalize the first word and turn underscores into spaces and strip a
     trailing ``"_id"``, if any. Like :func:`titleize`, this is meant for
@@ -63,7 +63,7 @@ def humanize(word):
     return word
 
 
-def titleize(word):
+def titleize(word: str) -> str:
     """
     Capitalize all the words and replace some characters in the string to
     create a nicer looking title. :func:`titleize` is meant for creating pretty
@@ -88,7 +88,7 @@ def titleize(word):
     )
 
 
-def underscore(word):
+def underscore(word: str) -> str:
     """
     Make an underscored, lowercase form from the expression in the string.
 

--- a/src/protean/utils/processing.py
+++ b/src/protean/utils/processing.py
@@ -76,7 +76,7 @@ _processing_priority: ContextVar[int] = ContextVar(
 
 
 @contextmanager
-def processing_priority(priority: "Priority") -> Generator[None, None, None]:
+def processing_priority(priority: "Priority | int") -> Generator[None, None, None]:
     """Context manager to set processing priority for all operations in scope.
 
     All commands processed within this context will have their events tagged


### PR DESCRIPTION
## Summary

Second phase of the type-safety epic (#997), building on #1122. Types the **`Domain` composition root** (the central 2258-line `domain/__init__.py`) and applies the approved non-breaking public-signature corrections.

### What's typed
- **`domain/__init__.py` fully typed** (134 own mypy errors → 0; remaining are cross-file `no-untyped-call` into still-quarantined modules) — the linchpin that drove cross-file remainders across the codebase.
- `utils/inflection`, `utils/processing`, `fields/basic`, `integrations/fastapi/health`, `server/subscription/factory` typed.
- **Graduated out of the quarantine:** `domain/registry` and `fields/association` (narrowed `field_name`, which is always bound/`str` at the getattr sites).

### Non-breaking signature corrections (approved)
- `Domain.register(**kwargs: dict)` → `**kwargs: Any` (the `dict` annotation wrongly typed every kwarg *value* as a dict; strictly wider).
- `Domain.projectors_for` / `cache_for`: `BaseProjection` → `type[BaseProjection]` (every caller passes a class).
- `create_health_router(tags=...)` widened to `list[str | Enum] | None` (FastAPI `APIRouter` compat).
- `processing_priority` widened to `Priority | int` (docstring already documented int).
- `SubscriptionFactory.create_subscription` widened to accept the duck-typed `CommandDispatcher`.

### Bug fixes surfaced by the typing
- **Observatory `count_by_status`**: typing `_get_outbox_repo` as `BaseRepository` broke `outbox_repo.count_by_status()` in `observatory/{api,metrics,routes}`. The infra builds an `OutboxRepository`; narrowed the return so callers see the method.
- **`Caches.cache_for`** used `MutableMapping.get(...)` then dereferenced unconditionally — a latent `AttributeError` for a missing cache. Switched to subscript access (raises a clear `KeyError`).

## Scope
Incremental — **does not close #997**. 86 modules remain listed in the mypy quarantine (typed but not yet graduated to strict); the road to global `strict = true` continues in follow-ups. Two genuine public-ABC design calls stay queued: `BaseBroker.publish` None-stream, `BaseProvider.get_connection` Liskov.

## Test plan
- [x] Full core suite green (`protean test`) — 9915 passed
- [x] CI `mypy src/protean` gate green
- [x] Full adapter suite (`-c FULL`) — CI