### PR TITLE
Assert descending order in the in-memory sorting test (found via mutation testing)

### DIFF
--- a/changes/1100.changed.md
+++ b/changes/1100.changed.md
@@ -1,0 +1,1 @@
+Strengthen the in-memory sorting test that verified descending `order_by` — it previously compared results with a bare `==` expression and no `assert`, so a broken descending (`-`) prefix would have gone unnoticed; it now asserts the full ordered sequence. (Surfaced by a mutation-testing pass over the memory repository DAO.)

--- a/scripts/mutation.sh
+++ b/scripts/mutation.sh
@@ -54,9 +54,13 @@ case "$TARGET" in
     MODULE="src/protean/core/event_sourced_repository.py"
     TESTS="tests/event_sourced_repository tests/event_sourced_aggregates"
     ;;
+  repositories-dao)
+    MODULE="src/protean/adapters/repository/memory.py"
+    TESTS="tests/adapters/repository/memory tests/dao tests/repository"
+    ;;
   *)
     echo "Unknown mutation target: '$TARGET'" >&2
-    echo "Known targets: outbox, entity, status-field, event-sourcing" >&2
+    echo "Known targets: outbox, entity, status-field, event-sourcing, repositories-dao" >&2
     exit 2
     ;;
 esac

--- a/tests/adapters/repository/memory/test_memory_sorting_on_none_values.py
+++ b/tests/adapters/repository/memory/test_memory_sorting_on_none_values.py
@@ -20,8 +20,13 @@ def test_for_sorting_without_nulls(test_domain):
     user_repo.add(User(name="Baby1", seq=3))
     user_repo.add(User(name="Baby2", seq=4))
 
-    user_repo.query.order_by("seq").all().first.name == "John"
-    user_repo.query.order_by("-seq").all().first.name == "Baby2"
+    # Assert the full ordered sequence, ascending and descending, so a broken
+    # ``-`` (descending) prefix cannot slip through by matching only ``.first``.
+    ascending = [u.name for u in user_repo.query.order_by("seq").all().items]
+    assert ascending == ["John", "Jane", "Baby1", "Baby2"]
+
+    descending = [u.name for u in user_repo.query.order_by("-seq").all().items]
+    assert descending == ["Baby2", "Baby1", "Jane", "John"]
 
 
 def test_for_sorting_with_dates(test_domain):


### PR DESCRIPTION
## Summary

The #1100 mutation-testing pass over the memory repository DAO (`adapters/repository/memory.py`) scored **83.6%** (453/542 killed) — well covered. Its one genuinely valuable finding was a **test that asserted nothing**.

## The finding

`tests/adapters/repository/memory/test_memory_sorting_on_none_values.py::test_for_sorting_without_nulls` had:

```python
user_repo.query.order_by("seq").all().first.name == "John"
user_repo.query.order_by("-seq").all().first.name == "Baby2"
```

Both lines are bare `==` expressions with **no `assert`** — their results were discarded, so the test verified nothing. That's why the descending-order mutants in `_filter` (`is_desc = o_key.startswith("-")` → `None`; `o_key[1:]` → `o_key[2:]`) survived: nothing checked that `-seq` actually sorts descending.

## The fix

Rewrite the test to assert the **full ordered sequence**, ascending and descending — verified to kill those mutants (a `.first`-only assertion would coincidentally pass under them):

```python
ascending = [u.name for u in user_repo.query.order_by("seq").all().items]
assert ascending == ["John", "Jane", "Baby1", "Baby2"]
descending = [u.name for u in user_repo.query.order_by("-seq").all().items]
assert descending == ["Baby2", "Baby1", "Jane", "John"]
```

## Tooling

Wires a `repositories-dao` target into `scripts/mutation.sh` (runs cleanly on mutmut 3.x now that #1124 landed).

The remaining ~87 survivors are low-value: adapter boilerplate (`__init__`, `commit`, provider registration), equivalent default-arg / `.get(k, {})` / `.pop(k, None)` mutations, and message-string wording. Documented rather than pinned.

Closes #1100. Part of epic #1096.