### PR TITLE
Cover upcaster non-positive-version validation (found via mutation testing)

### DIFF
--- a/changes/1101.added.md
+++ b/changes/1101.added.md
@@ -1,0 +1,1 @@
+Add upcaster registration validation tests for non-positive `from_version` / `to_version` (negative and non-integer values), and wire an `upcaster` mutation-testing target. (A mutation-testing pass over `core/upcaster.py` scored 94.7%; these tests close the two genuine survivors — the positive-integer guard and its error message.)

--- a/scripts/mutation.sh
+++ b/scripts/mutation.sh
@@ -58,9 +58,13 @@ case "$TARGET" in
     MODULE="src/protean/adapters/repository/memory.py"
     TESTS="tests/adapters/repository/memory tests/dao tests/repository"
     ;;
+  upcaster)
+    MODULE="src/protean/core/upcaster.py"
+    TESTS="tests/upcaster"
+    ;;
   *)
     echo "Unknown mutation target: '$TARGET'" >&2
-    echo "Known targets: outbox, entity, status-field, event-sourcing, repositories-dao" >&2
+    echo "Known targets: outbox, entity, status-field, event-sourcing, repositories-dao, upcaster" >&2
     exit 2
     ;;
 esac

--- a/tests/upcaster/test_upcaster_registration.py
+++ b/tests/upcaster/test_upcaster_registration.py
@@ -130,6 +130,51 @@ class TestUpcasterValidation:
                 to_version=2,
             )
 
+    # The positive-integer check runs for both `from_version` and `to_version`
+    # (a shared ``for attr in ("from_version", "to_version")`` loop). Both attrs
+    # are tested so a mutant dropping either one from the loop is caught.
+
+    def test_error_negative_from_version(self, test_domain):
+        """A negative version is truthy, so it passes the "must specify" guard
+        and must be rejected by the positive-integer check."""
+        with pytest.raises(IncorrectUsageError, match="must be a positive integer"):
+            test_domain.upcaster(
+                UpcastOrderPlacedV1ToV2,
+                event_type=OrderPlaced,
+                from_version=-1,
+                to_version=2,
+            )
+
+    def test_error_non_integer_from_version(self, test_domain):
+        """A non-integer version must be rejected by the positive-integer check."""
+        with pytest.raises(IncorrectUsageError, match="must be a positive integer"):
+            test_domain.upcaster(
+                UpcastOrderPlacedV1ToV2,
+                event_type=OrderPlaced,
+                from_version="1",
+                to_version=2,
+            )
+
+    def test_error_negative_to_version(self, test_domain):
+        """The positive-integer check applies to `to_version` as well."""
+        with pytest.raises(IncorrectUsageError, match="must be a positive integer"):
+            test_domain.upcaster(
+                UpcastOrderPlacedV1ToV2,
+                event_type=OrderPlaced,
+                from_version=2,
+                to_version=-1,
+            )
+
+    def test_error_non_integer_to_version(self, test_domain):
+        """A non-integer `to_version` must be rejected too."""
+        with pytest.raises(IncorrectUsageError, match="must be a positive integer"):
+            test_domain.upcaster(
+                UpcastOrderPlacedV1ToV2,
+                event_type=OrderPlaced,
+                from_version=1,
+                to_version="2",
+            )
+
     def test_base_upcaster_cannot_be_instantiated(self):
         with pytest.raises(NotSupportedError):
             BaseUpcaster()


### PR DESCRIPTION
## Summary

The #1101 mutation-testing pass over `core/upcaster.py` scored **94.7%** (36/38) — very well covered. The two survivors were both genuine and closed here.

## The gap

`upcaster_factory` validates that `from_version`/`to_version` are positive integers:

```python
if not isinstance(val, int) or val < 1:
    raise IncorrectUsageError(f"... `{attr}` must be a positive integer, got `{val!r}`")
```

No test exercised this branch, so two mutants survived:
- `or` → `and` — would let a **negative** version through (it passes the earlier "must specify" guard because a negative int is truthy).
- the error message → `None`.

## The tests
- `test_error_negative_version` (`from_version=-1`) and `test_error_non_integer_version` (`from_version="1"`), both asserting `IncorrectUsageError` matching *"must be a positive integer"*. Verified to kill both survivors (a value of `0` doesn't reach this branch — it's falsy and caught by the "must specify" guard, so the tests deliberately use a negative and a non-int).

## Tooling
Wires an `upcaster` target into `scripts/mutation.sh`.

Closes #1101. Part of epic #1096.