### PR TITLE
Add superseded_by event option and raise-time deprecation warning

### DIFF
--- a/changes/1133.added.md
+++ b/changes/1133.added.md
@@ -1,0 +1,1 @@
+Events accept a `superseded_by` option naming their replacement (an Event class or a name string). Raising a deprecated event now emits a `ProteanDeprecationWarning` once per event type that names the successor, and the `DEPRECATED_ELEMENT` diagnostic reports it in the IR.

--- a/docs/patterns/event-versioning-and-evolution.md
+++ b/docs/patterns/event-versioning-and-evolution.md
@@ -214,6 +214,39 @@ class FulfillmentEventHandler(BaseEventHandler):
 **When to use:** Significant structural changes, renamed fields, changed
 semantics, new required fields without meaningful defaults.
 
+#### Marking the old event deprecated
+
+Once the aggregate raises the new event, mark the old one deprecated and point
+`superseded_by` at its replacement:
+
+```python
+@domain.event(
+    part_of=Order,
+    deprecated={"since": "0.16", "removal": "0.19"},
+    superseded_by=OrderPlacedV2,          # an Event class or its name as a string
+)
+class OrderPlaced(BaseEvent):
+    order_id = Identifier(required=True)
+    customer_id = Identifier(required=True)
+    items = List(required=True)
+    total = Float(required=True)
+```
+
+The old class stays registered so historical events keep deserializing, but
+two things now flag its continued use:
+
+- **Raising it warns.** If code still calls `raise_(OrderPlaced(...))`, Protean
+  emits a `ProteanDeprecationWarning` naming the successor. The warning fires
+  **once per event type**, not once per instance, so a hot path is nudged
+  without flooding the logs.
+- **`protean check` reports it.** The `DEPRECATED_ELEMENT` diagnostic names the
+  successor (`superseded by \`OrderPlacedV2\``), and `protean ir diff` treats
+  removing it before its `removal` version as a premature (breaking) removal.
+
+`superseded_by` is documentation-only: it accepts an Event class or a name
+string and is never resolved to a link, so pointing at an event in another
+bounded context is fine.
+
 ### Strategy 2: Upcasting on Read
 
 Transform old events to the new schema when they're read from the event store,

--- a/docs/reference/compatibility/index.md
+++ b/docs/reference/compatibility/index.md
@@ -103,6 +103,23 @@ When deprecating a domain element or field:
 The `protean ir diff` command distinguishes expected removals (deprecated
 elements past their removal version) from unexpected removals.
 
+Events additionally accept a `superseded_by` option naming the replacement (an
+Event class or a name string):
+
+```python
+@domain.event(
+    part_of=Order,
+    deprecated={"since": "0.16", "removal": "0.19"},
+    superseded_by=OrderPlacedV2,
+)
+class OrderPlaced(BaseEvent): ...
+```
+
+The successor is surfaced two ways: raising a deprecated event emits a
+`ProteanDeprecationWarning` (once per event type) that names it, and the
+`DEPRECATED_ELEMENT` diagnostic appends `superseded by \`<name>\``. It is
+documentation-only and never resolved to a link.
+
 ---
 
 ## `.protean/config.toml` reference

--- a/src/protean/_deprecation.py
+++ b/src/protean/_deprecation.py
@@ -75,7 +75,7 @@ def _warning_for_removal(removal: str) -> type[ProteanDeprecationWarning]:
 def warn_deprecated(
     subject: str,
     *,
-    removal: str,
+    removal: str | None = None,
     alternative: str | None = None,
     stacklevel: int = 2,
 ) -> None:
@@ -84,8 +84,11 @@ def warn_deprecated(
     Args:
         subject: What is deprecated, phrased as it should read at the start of
             the sentence (e.g. ``"--debug"`` or ``"assert_valid()"``).
-        removal: Canonical ``X.Y.Z`` version the API is removed in. Selects the
-            per-version warning class via :func:`_warning_for_removal`.
+        removal: Canonical ``X.Y.Z`` version the API is removed in, or ``None``
+            when no removal is scheduled yet. A recognized version selects its
+            per-version warning class; ``None`` (or an unrecognized version)
+            uses the base :class:`ProteanDeprecationWarning` and omits the
+            "Will be removed" clause.
         alternative: An optional complete sentence telling the caller what to do
             instead (e.g. ``"Use --log-level DEBUG instead."``).
         stacklevel: Which frame the warning is attributed to, counted from the
@@ -105,11 +108,17 @@ def warn_deprecated(
     parts = [f"{subject} is deprecated."]
     if alternative:
         parts.append(alternative)
-    parts.append(f"Will be removed in v{removal}.")
+    if removal:
+        parts.append(f"Will be removed in v{removal}.")
 
+    category: type[ProteanDeprecationWarning] = (
+        _REMOVAL_WARNINGS.get(removal, ProteanDeprecationWarning)
+        if removal
+        else ProteanDeprecationWarning
+    )
     warnings.warn(
         " ".join(parts),
-        _REMOVAL_WARNINGS.get(removal, ProteanDeprecationWarning),
+        category,
         # +1 accounts for this helper's own frame so the caller's ``stacklevel``
         # has the same meaning it would when calling ``warnings.warn`` directly.
         stacklevel=stacklevel + 1,

--- a/src/protean/_deprecation.py
+++ b/src/protean/_deprecation.py
@@ -86,9 +86,11 @@ def warn_deprecated(
             the sentence (e.g. ``"--debug"`` or ``"assert_valid()"``).
         removal: Canonical ``X.Y.Z`` version the API is removed in, or ``None``
             when no removal is scheduled yet. A recognized version selects its
-            per-version warning class; ``None`` (or an unrecognized version)
-            uses the base :class:`ProteanDeprecationWarning` and omits the
-            "Will be removed" clause.
+            per-version warning class; ``None`` or an unrecognized version
+            falls back to the base :class:`ProteanDeprecationWarning`. The
+            "Will be removed in v<removal>." clause is included whenever
+            ``removal`` is given (recognized or not); it is omitted only when
+            ``removal`` is ``None``.
         alternative: An optional complete sentence telling the caller what to do
             instead (e.g. ``"Use --log-level DEBUG instead."``).
         stacklevel: Which frame the warning is attributed to, counted from the

--- a/src/protean/core/aggregate.py
+++ b/src/protean/core/aggregate.py
@@ -13,6 +13,7 @@ from pydantic import Field as PydanticField
 from pydantic import PrivateAttr
 from pydantic_core import PydanticUndefined
 
+from protean._deprecation import warn_deprecated
 from protean.core.entity import BaseEntity, _EntityState
 from protean.core.value_object import value_object_from_entity
 from protean.fields.tempdata import AssociationCache
@@ -184,6 +185,9 @@ class BaseAggregate(BaseEntity):
                 f" aggregate `{self.__class__.__name__}`"
             )
 
+        # Warn once per type when a deprecated event is raised.
+        self._warn_if_deprecated(event.__class__)
+
         id_field_name = getattr(self.__class__, _ID_FIELD_NAME, None)
         identifier = getattr(self, id_field_name) if id_field_name else None
 
@@ -279,6 +283,41 @@ class BaseAggregate(BaseEntity):
             if not event.__class__.meta_.is_fact_event:
                 with atomic_change(self):
                     self._apply_handler(event_with_metadata)
+
+    @staticmethod
+    def _warn_if_deprecated(event_cls: type[BaseEvent]) -> None:
+        """Emit a raise-time deprecation warning for a deprecated event.
+
+        Routes through :func:`protean._deprecation.warn_deprecated`. Fires at
+        most once per event type per domain (tracked on the domain, which is
+        fresh per run) to avoid log spam when the event is raised many times.
+        Names the ``superseded_by`` replacement when one is declared.
+        """
+        deprecated = event_cls.meta_.deprecated
+        if not deprecated:
+            return
+
+        warned = current_domain._deprecated_events_warned
+        if event_cls in warned:
+            return
+        warned.add(event_cls)
+
+        superseded_by = event_cls.meta_.superseded_by
+        alternative = None
+        if superseded_by is not None:
+            successor = (
+                superseded_by.__name__
+                if isinstance(superseded_by, type)
+                else superseded_by
+            )
+            alternative = f"Use `{successor}` instead."
+
+        warn_deprecated(
+            f"Event `{event_cls.__name__}`",
+            removal=deprecated.get("removal"),
+            alternative=alternative,
+            stacklevel=3,
+        )
 
     def _apply_handler(self, event: Any) -> None:
         """Invoke @apply handler(s) for an event without version management.

--- a/src/protean/core/upcaster.py
+++ b/src/protean/core/upcaster.py
@@ -97,8 +97,8 @@ def upcaster_factory(element_cls: type[_T], domain: Any, **opts: Any) -> type[_T
         isinstance(event_type, type) and issubclass(event_type, BaseEvent)
     ):
         raise IncorrectUsageError(
-            f"Upcaster `{element_cls.__name__}` event_type must be an Event class, "
-            f"got `{event_type}`"
+            f"Upcaster `{element_cls.__name__}` event_type must be an Event class "
+            f"or a string reference to one, got `{event_type}`"
         )
 
     # from_version and to_version must be positive integers

--- a/src/protean/domain/__init__.py
+++ b/src/protean/domain/__init__.py
@@ -395,6 +395,10 @@ class Domain:
         # Placeholder array for resolving classes referenced by domain elements
         self._pending_class_resolutions: dict[str, Any] = defaultdict(list)
 
+        # Event classes that have already emitted a raise-time deprecation
+        # warning, so a deprecated event warns once per type, not per instance.
+        self._deprecated_events_warned: set[type] = set()
+
         # Lazy-initialized idempotency store
         self._idempotency_store: IdempotencyStore | None = None
 

--- a/src/protean/ir/builder.py
+++ b/src/protean/ir/builder.py
@@ -591,6 +591,12 @@ class IRBuilder:
         if deprecated is not None:
             entry["deprecated"] = deprecated
 
+        superseded_by = getattr(cls.meta_, "superseded_by", None)
+        if superseded_by is not None:
+            entry["superseded_by"] = (
+                fqn(superseded_by) if isinstance(superseded_by, type) else superseded_by
+            )
+
         doc = (cls.__doc__ or "").strip()
         if doc:
             entry["description"] = doc
@@ -1792,6 +1798,10 @@ class IRBuilder:
                 )
             else:
                 msg = f"`{name}` is deprecated since v{since}"
+
+            superseded_by = element.get("superseded_by")
+            if superseded_by:
+                msg += f"; superseded by `{superseded_by}`"
 
             self._diagnostics.append(
                 {

--- a/src/protean/utils/__init__.py
+++ b/src/protean/utils/__init__.py
@@ -499,6 +499,17 @@ def derive_element_class(
     # so it doesn't interfere with element-specific default logic).
     element_with_meta.meta_.deprecated = normalized_deprecated
 
+    # Guard the event-only `superseded_by` reference (an Event class or a name
+    # string). This is the one funnel both the decorator and `register` paths
+    # pass through, so validating here rejects a bad value (e.g. an event
+    # instance or a dict) before it can reach IR serialization or warning text.
+    superseded_by = getattr(element_with_meta.meta_, "superseded_by", None)
+    if superseded_by is not None and not isinstance(superseded_by, (str, type)):
+        raise ConfigurationError(
+            f"`superseded_by` must be an Event class or a name string, "
+            f"got {superseded_by!r}"
+        )
+
     # Re-trigger identity field tracking when a previously-abstract class
     # is registered as concrete (e.g. via domain.register()).  During normal
     # class creation __pydantic_init_subclass__ skips __track_id_field()

--- a/src/protean/utils/eventing.py
+++ b/src/protean/utils/eventing.py
@@ -287,6 +287,9 @@ class BaseMessageType(Element, BaseModel, OptionsMixin):
         ("is_fact_event", False),
         ("published", False),
         ("version", None),
+        # The replacement for a deprecated event (an Event class or a name
+        # string). `deprecated` itself is the universal element option.
+        ("superseded_by", None),
     ]
 
     def __init_subclass__(cls, **kwargs: Any) -> None:

--- a/tests/event/test_event_deprecation.py
+++ b/tests/event/test_event_deprecation.py
@@ -8,10 +8,12 @@ and stay silent for non-deprecated events.
 
 import warnings
 
+import pytest
+
 from protean import apply
 from protean.core.aggregate import BaseAggregate
 from protean.core.event import BaseEvent
-from protean.exceptions import ProteanDeprecationWarning
+from protean.exceptions import ConfigurationError, ProteanDeprecationWarning
 from protean.fields import Identifier, String
 
 
@@ -257,3 +259,23 @@ class TestSupersededByOption:
         test_domain.init(traverse=False)
 
         assert OrderPlaced.meta_.superseded_by is OrderConfirmed
+
+    def test_superseded_by_rejects_non_class_non_string(self, test_domain):
+        """A `superseded_by` that is neither an Event class nor a name string
+        is rejected at registration, so a non-serializable value cannot reach
+        IR serialization or warning text (#1148)."""
+
+        class Order(BaseAggregate):
+            name = String()
+
+        class OrderPlaced(BaseEvent):
+            order_id = Identifier(identifier=True)
+
+        test_domain.register(Order)
+        with pytest.raises(
+            ConfigurationError,
+            match="`superseded_by` must be an Event class or a name string",
+        ):
+            test_domain.register(
+                OrderPlaced, part_of=Order, superseded_by={"not": "valid"}
+            )

--- a/tests/event/test_event_deprecation.py
+++ b/tests/event/test_event_deprecation.py
@@ -1,0 +1,259 @@
+"""Tests for #1133: event deprecation completion.
+
+Covers the `superseded_by` event option and the raise-time
+`DeprecationWarning` emitted through `raise_()` — which must fire **exactly
+once per event type** (not per instance), name the successor when one is set,
+and stay silent for non-deprecated events.
+"""
+
+import warnings
+
+from protean import apply
+from protean.core.aggregate import BaseAggregate
+from protean.core.event import BaseEvent
+from protean.exceptions import ProteanDeprecationWarning
+from protean.fields import Identifier, String
+
+
+def _capture(order, *events):
+    """Raise the given events and return the Protean deprecation warnings.
+
+    Uses ``simplefilter("always")`` so Python's own per-location dedup can NOT
+    mask a double emission — any dedup we observe is the framework's own
+    once-per-type tracking, which is what these tests assert.
+    """
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        for event in events:
+            order.raise_(event)
+    return [w for w in record if issubclass(w.category, ProteanDeprecationWarning)]
+
+
+class TestDeprecatedEventRaiseWarning:
+    def test_raising_a_deprecated_event_warns(self, test_domain):
+        class Order(BaseAggregate):
+            name = String()
+
+        class OrderPlaced(BaseEvent):
+            order_id = Identifier(identifier=True)
+
+        test_domain.register(Order)
+        test_domain.register(
+            OrderPlaced,
+            part_of=Order,
+            deprecated={"since": "0.15", "removal": "0.18.0"},
+        )
+        test_domain.init(traverse=False)
+
+        order = Order(name="foo")
+        warns = _capture(order, OrderPlaced(order_id="1"))
+
+        assert len(warns) == 1
+        message = str(warns[0].message)
+        assert "OrderPlaced" in message
+        assert "0.18.0" in message
+
+    def test_deprecated_event_warns_once_per_type_not_per_instance(self, test_domain):
+        """Three raises of the same deprecated event emit a single warning,
+        even under ``simplefilter("always")`` — the dedup is the framework's,
+        not Python's warning filter."""
+
+        class Order(BaseAggregate):
+            name = String()
+
+        class OrderPlaced(BaseEvent):
+            order_id = Identifier(identifier=True)
+
+        test_domain.register(Order)
+        test_domain.register(OrderPlaced, part_of=Order, deprecated={"since": "0.15"})
+        test_domain.init(traverse=False)
+
+        order = Order(name="foo")
+        warns = _capture(
+            order,
+            OrderPlaced(order_id="1"),
+            OrderPlaced(order_id="2"),
+            OrderPlaced(order_id="3"),
+        )
+
+        assert len(warns) == 1
+
+    def test_non_deprecated_event_does_not_warn(self, test_domain):
+        """Negative path: a non-deprecated event raises no deprecation
+        warning, however many times it is raised."""
+
+        class Order(BaseAggregate):
+            name = String()
+
+        class OrderPlaced(BaseEvent):
+            order_id = Identifier(identifier=True)
+
+        test_domain.register(Order)
+        test_domain.register(OrderPlaced, part_of=Order)
+        test_domain.init(traverse=False)
+
+        order = Order(name="foo")
+        warns = _capture(order, OrderPlaced(order_id="1"), OrderPlaced(order_id="2"))
+
+        assert warns == []
+
+    def test_warning_names_successor_when_superseded_by_is_a_class(self, test_domain):
+        class Order(BaseAggregate):
+            name = String()
+
+        class OrderConfirmed(BaseEvent):
+            order_id = Identifier(identifier=True)
+
+        class OrderPlaced(BaseEvent):
+            order_id = Identifier(identifier=True)
+
+        test_domain.register(Order)
+        test_domain.register(OrderConfirmed, part_of=Order)
+        test_domain.register(
+            OrderPlaced,
+            part_of=Order,
+            deprecated={"since": "0.15", "removal": "0.18.0"},
+            superseded_by=OrderConfirmed,
+        )
+        test_domain.init(traverse=False)
+
+        order = Order(name="foo")
+        warns = _capture(order, OrderPlaced(order_id="1"))
+
+        assert len(warns) == 1
+        assert "Use `OrderConfirmed` instead." in str(warns[0].message)
+
+    def test_warning_names_successor_when_superseded_by_is_a_string(self, test_domain):
+        class Order(BaseAggregate):
+            name = String()
+
+        class OrderPlaced(BaseEvent):
+            order_id = Identifier(identifier=True)
+
+        test_domain.register(Order)
+        test_domain.register(
+            OrderPlaced,
+            part_of=Order,
+            deprecated={"since": "0.15"},
+            superseded_by="OrderConfirmed",
+        )
+        test_domain.init(traverse=False)
+
+        order = Order(name="foo")
+        warns = _capture(order, OrderPlaced(order_id="1"))
+
+        assert len(warns) == 1
+        assert "Use `OrderConfirmed` instead." in str(warns[0].message)
+
+    def test_warning_without_removal_omits_removal_clause(self, test_domain):
+        class Order(BaseAggregate):
+            name = String()
+
+        class OrderPlaced(BaseEvent):
+            order_id = Identifier(identifier=True)
+
+        test_domain.register(Order)
+        test_domain.register(OrderPlaced, part_of=Order, deprecated={"since": "0.15"})
+        test_domain.init(traverse=False)
+
+        order = Order(name="foo")
+        warns = _capture(order, OrderPlaced(order_id="1"))
+
+        assert len(warns) == 1
+        assert "Will be removed" not in str(warns[0].message)
+
+    def test_event_sourced_replay_does_not_warn(self, test_domain):
+        """Negative scope: reconstructing an aggregate from stored events via
+        `from_events` (the replay path, which runs `_apply`, not `raise_`) must
+        NOT warn — otherwise loading history would emit a deprecation warning
+        for every stored deprecated event."""
+
+        class MoneyDeposited(BaseEvent):
+            account_id = Identifier(identifier=True)
+            amount = String()
+
+        class Account(BaseAggregate):
+            account_id = Identifier(identifier=True)
+            balance = String()
+
+            @apply
+            def on_deposit(self, event: MoneyDeposited):
+                self.balance = event.amount
+
+        test_domain.register(Account, is_event_sourced=True)
+        test_domain.register(
+            MoneyDeposited,
+            part_of=Account,
+            deprecated={"since": "0.15", "removal": "0.18.0"},
+        )
+        test_domain.init(traverse=False)
+
+        account = Account(account_id="a1", balance="0")
+        with warnings.catch_warnings():  # the setup raise legitimately warns
+            warnings.simplefilter("ignore")
+            account.raise_(MoneyDeposited(account_id="a1", amount="100"))
+        stored = list(account._events)
+        assert len(stored) == 1
+
+        with warnings.catch_warnings(record=True) as record:
+            warnings.simplefilter("always")
+            replayed = Account.from_events(stored)
+        deps = [w for w in record if issubclass(w.category, ProteanDeprecationWarning)]
+
+        assert deps == []
+        assert replayed.balance == "100"
+
+    def test_string_shorthand_deprecated_is_normalized_not_crashed(self, test_domain):
+        """The `deprecated="0.15"` shorthand is normalized to a dict at
+        registration, so the raise-time warning reads it safely instead of
+        calling `.get()` on a bare string."""
+
+        class Order(BaseAggregate):
+            name = String()
+
+        class OrderPlaced(BaseEvent):
+            order_id = Identifier(identifier=True)
+
+        test_domain.register(Order)
+        test_domain.register(OrderPlaced, part_of=Order, deprecated="0.15")
+        test_domain.init(traverse=False)
+
+        assert OrderPlaced.meta_.deprecated == {"since": "0.15"}
+
+        order = Order(name="foo")
+        warns = _capture(order, OrderPlaced(order_id="1"))
+
+        assert len(warns) == 1
+        assert "OrderPlaced" in str(warns[0].message)
+
+
+class TestSupersededByOption:
+    def test_superseded_by_defaults_to_none(self, test_domain):
+        class Order(BaseAggregate):
+            name = String()
+
+        class OrderPlaced(BaseEvent):
+            order_id = Identifier(identifier=True)
+
+        test_domain.register(Order)
+        test_domain.register(OrderPlaced, part_of=Order)
+        test_domain.init(traverse=False)
+
+        assert OrderPlaced.meta_.superseded_by is None
+
+    def test_superseded_by_is_stored_on_meta(self, test_domain):
+        class Order(BaseAggregate):
+            name = String()
+
+        class OrderConfirmed(BaseEvent):
+            order_id = Identifier(identifier=True)
+
+        class OrderPlaced(BaseEvent):
+            order_id = Identifier(identifier=True)
+
+        test_domain.register(Order)
+        test_domain.register(OrderConfirmed, part_of=Order)
+        test_domain.register(OrderPlaced, part_of=Order, superseded_by=OrderConfirmed)
+        test_domain.init(traverse=False)
+
+        assert OrderPlaced.meta_.superseded_by is OrderConfirmed

--- a/tests/ir/test_deprecation.py
+++ b/tests/ir/test_deprecation.py
@@ -335,6 +335,136 @@ class TestIRBuilderDeprecated:
 
 
 # =====================================================================
+# IR Builder — event superseded_by (#1133)
+# =====================================================================
+
+
+@pytest.mark.no_test_domain
+class TestIRBuilderSupersededBy:
+    """`superseded_by` is emitted into the IR event entry and named in the
+    DEPRECATED_ELEMENT diagnostic."""
+
+    @pytest.fixture(autouse=True)
+    def setup_domain(self) -> None:
+        self.domain = Domain(name="TestSuperseded")
+
+    @staticmethod
+    def _find_cluster(ir: dict, cls: type) -> dict:
+        from protean.utils import fqn as get_fqn
+
+        return ir["clusters"][get_fqn(cls)]
+
+    def test_superseded_by_class_emitted_as_fqn(self) -> None:
+        from protean.utils import fqn as get_fqn
+
+        @self.domain.aggregate
+        class Order:
+            pass
+
+        @self.domain.event(part_of=Order)
+        class OrderConfirmed:
+            pass
+
+        @self.domain.event(
+            part_of=Order,
+            deprecated={"since": "0.15", "removal": "0.18"},
+            superseded_by=OrderConfirmed,
+        )
+        class OrderPlaced:
+            pass
+
+        self.domain.init(traverse=False)
+        ir = IRBuilder(self.domain).build()
+
+        cluster = self._find_cluster(ir, Order)
+        placed = next(
+            e for e in cluster["events"].values() if "OrderPlaced" in e["fqn"]
+        )
+        assert placed["superseded_by"] == get_fqn(OrderConfirmed)
+
+    def test_superseded_by_string_emitted_verbatim(self) -> None:
+        @self.domain.aggregate
+        class Order:
+            pass
+
+        @self.domain.event(
+            part_of=Order,
+            deprecated="0.15",
+            superseded_by="OrderConfirmed",
+        )
+        class OrderPlaced:
+            pass
+
+        self.domain.init(traverse=False)
+        ir = IRBuilder(self.domain).build()
+
+        cluster = self._find_cluster(ir, Order)
+        placed = list(cluster["events"].values())[0]
+        assert placed["superseded_by"] == "OrderConfirmed"
+
+    def test_no_superseded_by_key_when_unset(self) -> None:
+        @self.domain.aggregate
+        class Order:
+            pass
+
+        @self.domain.event(part_of=Order, deprecated="0.15")
+        class OrderPlaced:
+            pass
+
+        self.domain.init(traverse=False)
+        ir = IRBuilder(self.domain).build()
+
+        cluster = self._find_cluster(ir, Order)
+        placed = list(cluster["events"].values())[0]
+        assert "superseded_by" not in placed
+
+    def test_diagnostic_names_the_successor(self) -> None:
+        @self.domain.aggregate
+        class Order:
+            pass
+
+        @self.domain.event(part_of=Order)
+        class OrderConfirmed:
+            pass
+
+        @self.domain.event(
+            part_of=Order,
+            deprecated={"since": "0.15", "removal": "0.18"},
+            superseded_by=OrderConfirmed,
+        )
+        class OrderPlaced:
+            pass
+
+        self.domain.init(traverse=False)
+        ir = IRBuilder(self.domain).build()
+
+        dep_diags = [
+            d
+            for d in ir["diagnostics"]
+            if d["code"] == "DEPRECATED_ELEMENT" and "OrderPlaced" in d["message"]
+        ]
+        assert len(dep_diags) == 1
+        assert "superseded by" in dep_diags[0]["message"]
+        assert "OrderConfirmed" in dep_diags[0]["message"]
+
+    def test_diagnostic_omits_successor_when_unset(self) -> None:
+        @self.domain.aggregate
+        class Order:
+            pass
+
+        @self.domain.event(part_of=Order, deprecated="0.15")
+        class OrderPlaced:
+            pass
+
+        self.domain.init(traverse=False)
+        ir = IRBuilder(self.domain).build()
+
+        dep_diags = [d for d in ir["diagnostics"] if d["code"] == "DEPRECATED_ELEMENT"]
+        assert len(dep_diags) == 1
+        assert "superseded by" not in dep_diags[0]["message"]
+
+
+# =====================================================================
 # IR Diagnostics — DEPRECATED_ELEMENT and DEPRECATED_FIELD
 # =====================================================================
 

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -136,6 +136,17 @@ class TestWarnDeprecated:
         assert record[0].category is ProteanDeprecationWarning
         assert f"Will be removed in v{removal}." in str(record[0].message)
 
+    def test_no_removal_omits_the_removal_clause(self):
+        """A deprecation with no scheduled removal (e.g. a deprecated event)
+        uses the base class and drops the "Will be removed" sentence."""
+        with pytest.warns(ProteanDeprecationWarning) as record:
+            warn_deprecated("Event `OrderPlaced`", alternative="Use `NewOne`.")
+        assert record[0].category is ProteanDeprecationWarning
+        assert str(record[0].message) == (
+            "Event `OrderPlaced` is deprecated. Use `NewOne`."
+        )
+        assert "Will be removed" not in str(record[0].message)
+
 
 class TestDeprecatedDecorator:
     def test_call_emits_the_warning(self):

--- a/tests/upcaster/test_upcaster_registration.py
+++ b/tests/upcaster/test_upcaster_registration.py
@@ -122,7 +122,12 @@ class TestUpcasterValidation:
             )
 
     def test_error_event_type_not_an_event(self, test_domain):
-        with pytest.raises(IncorrectUsageError, match="must be an Event class"):
+        # The message names both accepted forms (Event class or string
+        # reference) so a user passing a string is not misled (#1147).
+        with pytest.raises(
+            IncorrectUsageError,
+            match="must be an Event class or a string reference to one",
+        ):
             test_domain.upcaster(
                 UpcastOrderPlacedV1ToV2,
                 event_type=Order,  # Not an event!


### PR DESCRIPTION
## Summary
- Adds a `superseded_by` option to events (an Event class or a name string) naming a deprecated event's replacement.
- Raising a deprecated event now emits a `ProteanDeprecationWarning` **once per event type** (tracked on the domain, fresh per run), routed through the shared `protean._deprecation.warn_deprecated` helper; the message names the successor. Event-sourced replay (`from_events`/`_apply`) does **not** warn.
- The IR emits `superseded_by`, and the `DEPRECATED_ELEMENT` diagnostic names the successor.
- Makes `warn_deprecated`'s `removal` optional, since a deprecated event need not have a scheduled removal version.
- Folds in the Copilot review comment from #1147: the upcaster `event_type` validation message now names both accepted forms (Event class **or** a string reference).

Part of epic #1130 (Event Evolution), milestone 0.17.0.

## Test plan
- [x] New tests: `tests/event/test_event_deprecation.py` (raise warns once/type; replay silent; non-deprecated silent; class/string/None successor; string+dict shorthand); additions to `tests/ir/test_deprecation.py` (IR emission + diagnostic) and `tests/test_deprecation.py` (`removal=None`); upcaster message test strengthened.
- [x] Core suite passes (`protean test`: 9996 passed).
- [x] 100% patch coverage (diff-cover).
- [x] `ruff` + `mypy --strict` clean; `mkdocs build --strict` clean.
- [x] Red-team revert check: behavioral tests go red with the fix reverted.
- [x] Full adapter suite (`make test-full`) not run locally — change is core Python with no adapter surface.

Docs: `docs/patterns/event-versioning-and-evolution.md` (Strategy 1) and `docs/reference/compatibility/index.md`.

Closes #1133