### PR TITLE
Fix Dependabot grouping so weekly bumps land in one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,17 +14,16 @@ updates:
     labels:
       - "dependencies"
     groups:
-      # Collapse every non-security version update — major, minor, and patch —
-      # into a single grouped PR per run. Without "major" here, each major bump
-      # (e.g. elasticsearch, diff-cover, types-mock) opens its own PR and fires
-      # its own CI run; grouping them keeps the weekly bump to one PR.
+      # Collapse every non-security version update into a single grouped PR per
+      # run. A group with no "update-types" filter already covers major, minor,
+      # and patch — so we deliberately omit it. Listing update-types here breaks
+      # grouping for "requirement" updates (raising a >= floor in
+      # [dependency-groups]); Dependabot can't classify those into a semver
+      # bucket, drops them from the group, and opens one PR per package instead
+      # (see #1163–#1167). Leaving patterns: "*" alone groups everything.
       all-dependencies:
         patterns:
           - "*"
-        update-types:
-          - "major"
-          - "minor"
-          - "patch"
       security-updates:
         patterns:
           - "*"


### PR DESCRIPTION
## Problem

The `all-dependencies` group in `.github/dependabot.yml` never actually grouped anything. This week's run split into five individual PRs (#1163–#1167) — one per package — despite the group being on `main` since #1149.

The branch names give it away: `dependabot/pip/pytest-asyncio-gte-1.4.0` etc. are per-package branches, not the `dependabot/pip/all-dependencies-<hash>` a grouped run produces.

## Root cause

The group carried an `update-types: [major, minor, patch]` filter, added on the assumption it was needed to fold major bumps in. Two things wrong with that:

1. **Redundant** — a group with *no* `update-types` filter already covers major, minor, and patch.
2. **Actively harmful** — the filter matches on the semver level of a *version* update. All five deps live in PEP 735 `[dependency-groups]` with `>=` floors, so under `versioning-strategy: auto` they get *requirement-widening* updates (`>=A` → `>=B`). Dependabot can't slot those into a semver bucket, so the filter drops every one of them out of the group → one PR per package.

## Fix

Remove the `update-types` block. A bare `patterns: ["*"]` group captures every update — majors, minors, patches, and requirement widenings alike. This can only broaden grouping, never narrow it.

Once merged, the five open Dependabot PRs will be closed and a `@dependabot recreate` triggered to produce a single grouped PR — verifying the fix now rather than waiting for next week's run.