### PR TITLE
Hold mypy and elasticsearch majors out of the Dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,13 @@ updates:
         patterns:
           - "*"
         applies-to: security-updates
+    ignore:
+      # Major bumps of these two need deliberate handling, not the weekly group.
+      # mypy majors change reveal_type() output and tighten checks (breaking the
+      # plugin tests and adding new errors); adopt them in a dedicated PR.
+      - dependency-name: "mypy"
+        update-types: ["version-update:semver-major"]
+      # The elasticsearch 9.x client migration is tracked separately (#1150); the
+      # adapter is pinned to the 8.x line and CI runs against ES 8.7.
+      - dependency-name: "elasticsearch"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Problem

The weekly `all-dependencies` group (fixed to actually group in #1171) now bundles **major** version bumps of tools that can't ride the group cleanly, producing a red PR (#1173):

- `mypy 1.11 → 2.2` — 2.x changed `reveal_type()` output format (breaking 16 plugin tests) and tightened analysis (5 new type-check errors).
- `elasticsearch 8.x → 9.x` — a deliberately deferred major; the adapter is pinned to the 8.x line and CI runs against ES 8.7. The 9.x migration is tracked in #1150.

## Fix

Add top-level `ignore` rules for the semver-major update type of both dependencies. `ignore` is applied before grouping, so the group simply drops these two and stays green. Minor/patch bumps still flow through the group as normal.

- **mypy** — majors are adopted deliberately in their own PR (see the companion mypy-2.x adoption PR).
- **elasticsearch** — majors stay out until the #1150 migration.

This is orthogonal to the grouping fix in #1171 — `ignore` rules and groups don't interact.

## Follow-up

Once this and the mypy-2.x adoption PR merge, `@dependabot recreate` on #1173 will produce a clean, green grouped PR carrying the ~40 remaining bumps.