### PR TITLE
Align generated-project template to mypy>=2.2.0

### DIFF
--- a/src/protean/template/domain_template/pyproject.toml.jinja
+++ b/src/protean/template/domain_template/pyproject.toml.jinja
@@ -85,7 +85,7 @@ test = [
     "faker>=22.0.0",
 ]
 types = [
-    "mypy>=1.8.0",
+    "mypy>=2.2.0",
     "types-python-dateutil>=2.8.19",
     "types-requests>=2.31.0",
 ]


### PR DESCRIPTION
Follow-up to #1175 (Adopt mypy 2.x), catching a Copilot review point that missed the merge window.

The framework now baselines mypy 2.x and its mypy plugin is validated only against that major. The generated-project template (`src/protean/template/domain_template/pyproject.toml.jinja`) still pinned `mypy>=1.8.0`, so newly scaffolded projects would default to an older major than the plugin they depend on is tested against.

Bump the template's `mypy` pin to `>=2.2.0` to keep generated projects aligned with the framework.

One-line change; no code or tests affected.