### PR TITLE
Use version-range Dependabot ignores so the elasticsearch major is actually held

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,11 +30,19 @@ updates:
         applies-to: security-updates
     ignore:
       # Major bumps of these two need deliberate handling, not the weekly group.
-      # mypy majors change reveal_type() output and tighten checks (breaking the
-      # plugin tests and adding new errors); adopt them in a dedicated PR.
+      # NB: pin explicit version *ranges* rather than
+      # `update-types: ["version-update:semver-major"]`. Dependabot can't reliably
+      # classify ">=" requirement updates (deps in [dependency-groups] /
+      # [project.optional-dependencies]) into a semver bucket — the same limitation
+      # that broke the group's update-types filter (#1171) — so a semver-major
+      # ignore silently fails to hold them (elasticsearch 8->9 slipped into #1178).
+      # A `versions` range is matched directly and is not subject to that.
+      #
+      # mypy: hold on 2.x — 3.x majors change reveal_type() output and tighten
+      # checks; adopt them in a dedicated PR (2.x adopted in #1175).
       - dependency-name: "mypy"
-        update-types: ["version-update:semver-major"]
-      # The elasticsearch 9.x client migration is tracked separately (#1150); the
-      # adapter is pinned to the 8.x line and CI runs against ES 8.7.
+        versions: [">=3.0.0"]
+      # elasticsearch: hold on 8.x — the 9.x client migration is tracked in #1150,
+      # the adapter is pinned to the 8.x line, and CI runs against ES 8.7.
       - dependency-name: "elasticsearch"
-        update-types: ["version-update:semver-major"]
+        versions: [">=9.0.0"]


### PR DESCRIPTION
## Problem

#1174 added `ignore` rules meant to keep `mypy` and `elasticsearch` majors out of the weekly group, using `update-types: ["version-update:semver-major"]`. They don't work: after `@dependabot recreate`, the regrouped PR (#1178) **still bumps `elasticsearch 8.18 → 9.4.1`** (a major we've deliberately deferred to #1150).

## Root cause

Same limitation that broke the group's `update-types` filter in #1171: Dependabot can't reliably classify a `>=` **requirement** update (deps declared in `[dependency-groups]` / `[project.optional-dependencies]`) into a semver bucket. With no semver classification, `update-types: version-update:semver-major` never matches, and the ignore silently no-ops.

(`mypy` *looked* held only because `main` is already at `>=2.2.0`, so there was no bump to slip through — it doesn't prove that ignore works either.)

## Fix

Switch both ignores to explicit `versions` ranges, which Dependabot matches directly and are immune to the classification gap:

```yaml
- dependency-name: "mypy"
  versions: [">=3.0.0"]
- dependency-name: "elasticsearch"
  versions: [">=9.0.0"]
```

## Follow-up

Once merged, `@dependabot recreate` on #1178 should finally drop the elasticsearch bump and produce a clean group. **Do not merge #1178 as-is** — it still carries the ES 9.x major.