### PR TITLE
Add event_sourced option alias; internalize is_fact_event

### DIFF
--- a/changes/1107.added.md
+++ b/changes/1107.added.md
@@ -1,0 +1,1 @@
+Added the `event_sourced` aggregate option as the canonical spelling for enabling event-sourcing mode (`@domain.aggregate(event_sourced=True)`). This follows the convention that boolean element options are bare predicates rather than `is_`-prefixed.

--- a/changes/1107.deprecated.md
+++ b/changes/1107.deprecated.md
@@ -1,0 +1,1 @@
+Deprecated the `is_event_sourced` aggregate option in favor of `event_sourced`. The alias continues to work but emits a `RemovedInProtean10Warning` and surfaces a `DEPRECATED_OPTION` diagnostic from `protean check`; it will be removed in v1.0.0. If both are supplied, `event_sourced` wins.

--- a/changes/1107.removed.md
+++ b/changes/1107.removed.md
@@ -1,0 +1,1 @@
+Removed `is_fact_event` from the user-facing event/command option surface. It was never an option user code should set — the framework assigns it during fact-event generation — and `meta_.is_fact_event` remains available (defaulting to `False`) for reads. Passing `is_fact_event=` to an event or command via the decorator or `domain.register` now raises `ConfigurationError`.

--- a/docs/concepts/async-processing/stream-categories.md
+++ b/docs/concepts/async-processing/stream-categories.md
@@ -216,10 +216,10 @@ Learn more in [Subscriptions](./subscriptions.md#stream-categories).
 
 ## Stream Categories and Event Sourcing
 
-For event-sourced aggregates (marked with `is_event_sourced=True`), stream categories become even more critical:
+For event-sourced aggregates (marked with `event_sourced=True`), stream categories become even more critical:
 
 ```python
-@domain.aggregate(is_event_sourced=True)
+@domain.aggregate(event_sourced=True)
 class Account:
     account_number: String(required=True)
     balance: Float(default=0.0)

--- a/docs/concepts/building-blocks/repositories.md
+++ b/docs/concepts/building-blocks/repositories.md
@@ -76,7 +76,7 @@ scenarios like projection rebuilds, test teardown, and compliance requirements.
 
 ### Event-sourced aggregates get a different repository. { data-toc-label="Event Sourced" }
 
-When an aggregate is configured with `is_event_sourced=True`,
+When an aggregate is configured with `event_sourced=True`,
 `domain.repository_for()` transparently returns an event-sourced repository
 that reconstructs state by replaying events from the aggregate's stream,
 rather than reading from a database table. The calling code does not change.

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -397,6 +397,7 @@ Design reasoning and internal architecture for contributors and advanced users.
 ## Migration
 
 - [Compatibility Reference](./reference/compatibility/index.md) -- Breaking change rules, three-tier taxonomy, deprecation lifecycle, and config.toml reference.
+- [Migrating to 0.17](./reference/migration/v0-17.md) -- Upgrade guide for the 0.17 API-consolidation release. Covers the `event_sourced` option rename and the internalized `is_fact_event` option.
 - [Migrating to 0.16](./reference/migration/v0-16.md) -- Upgrade guide for the 0.16 stability release. Covers the outbox column-bounds structural change and its per-backend `ALTER TABLE` recipes.
 - [Migrating to 0.15](./reference/migration/v0-15.md) -- Upgrade guide for the Pydantic v2 foundation release. Covers breaking changes, field style migration, and new features.
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -130,7 +130,7 @@ A pattern where domain events carry the complete state of an aggregate, allowing
 
 ### Event Sourcing
 
-A persistence pattern in which an aggregate's state is stored as a sequence of immutable domain events rather than as a current-state snapshot. The aggregate's state at any point in time can be reconstructed by replaying its events from the beginning. In Protean, aggregates opt in with `is_event_sourced=True`.
+A persistence pattern in which an aggregate's state is stored as a sequence of immutable domain events rather than as a current-state snapshot. The aggregate's state at any point in time can be reconstructed by replaying its events from the beginning. In Protean, aggregates opt in with `event_sourced=True`.
 
 [Learn more →](concepts/architecture/event-sourcing.md) | **See also**: [Event Store](#event-store), [Event Stream](#event-stream), [Replay](#replay), [Snapshot](#snapshot)
 
@@ -176,9 +176,9 @@ A decorator used on methods within event-sourced aggregates to mutate aggregate 
 
 [Learn more →](guides/domain-behavior/aggregate-mutation.md) | **See also**: [Event Sourcing](#event-sourcing), [Aggregate](#aggregate), [Domain Event](#domain-event)
 
-### `is_event_sourced` Option
+### `event_sourced` Option
 
-An aggregate decorator option (`@domain.aggregate(is_event_sourced=True)`) that switches the aggregate's persistence model from current-state storage to event sourcing. When enabled, the aggregate's state is derived entirely from replaying its event stream rather than loading a snapshot from a database table.
+An aggregate decorator option (`@domain.aggregate(event_sourced=True)`) that switches the aggregate's persistence model from current-state storage to event sourcing. When enabled, the aggregate's state is derived entirely from replaying its event stream rather than loading a snapshot from a database table. (The old `is_event_sourced` spelling is a deprecated alias, removed in v1.0.0.)
 
 [Learn more →](guides/pathways/event-sourcing.md) | **See also**: [Event Sourcing](#event-sourcing), [`@apply` Decorator](#apply-decorator)
 

--- a/docs/guides/change-state/event-store-setup.md
+++ b/docs/guides/change-state/event-store-setup.md
@@ -60,11 +60,11 @@ database_uri = "${MESSAGEDB_URL}"
 
 ## Marking aggregates as event-sourced
 
-Only aggregates marked with `is_event_sourced=True` use the event store
+Only aggregates marked with `event_sourced=True` use the event store
 for persistence:
 
 ```python
-@domain.aggregate(is_event_sourced=True)
+@domain.aggregate(event_sourced=True)
 class Account:
     balance = Float(default=0.0)
 

--- a/docs/guides/change-state/repositories.md
+++ b/docs/guides/change-state/repositories.md
@@ -208,7 +208,7 @@ order = repo.get(order_id)
 
 How it works:
 
-- If the aggregate has `is_event_sourced=True`, `repository_for()` returns an
+- If the aggregate has `event_sourced=True`, `repository_for()` returns an
   **event-sourced repository** backed by the event store. The event-sourced
   repository reconstructs aggregate state by replaying events from the
   aggregate's stream — it does not read from a database table.

--- a/docs/guides/consume-state/event-upcasting.md
+++ b/docs/guides/consume-state/event-upcasting.md
@@ -243,7 +243,7 @@ historical schema variant.
 schema:
 
 ```python
-@domain.aggregate(is_event_sourced=True)
+@domain.aggregate(event_sourced=True)
 class Order(BaseAggregate):
     order_id = Identifier(identifier=True)
     total_amount = Float()

--- a/docs/guides/domain-behavior/aggregate-mutation.md
+++ b/docs/guides/domain-behavior/aggregate-mutation.md
@@ -135,7 +135,7 @@ and the framework automatically invokes the corresponding `@apply`
 handler to perform the state change:
 
 ```python
-@domain.aggregate(is_event_sourced=True)
+@domain.aggregate(event_sourced=True)
 class Order:
     status: String(max_length=20, default="PENDING")
 

--- a/docs/guides/domain-behavior/raising-events.md
+++ b/docs/guides/domain-behavior/raising-events.md
@@ -127,7 +127,7 @@ them even after restarts.
 
 ## Event Sourced Aggregates: `raise_()` and `@apply` {#es-raise-apply}
 
-For **event-sourced aggregates** (`is_event_sourced=True`), `raise_()`
+For **event-sourced aggregates** (`event_sourced=True`), `raise_()`
 does more than collect events — it automatically invokes the
 corresponding `@apply` handler to mutate the aggregate's state in-place.
 This makes `@apply` the **single source of truth** for all state
@@ -137,7 +137,7 @@ reconstructed from stored events.
 ```python
 from protean import apply
 
-@domain.aggregate(is_event_sourced=True)
+@domain.aggregate(event_sourced=True)
 class Order:
     customer_name: String(max_length=150, required=True)
     status: String(max_length=20, default="PENDING")

--- a/docs/guides/domain-behavior/status-transitions.md
+++ b/docs/guides/domain-behavior/status-transitions.md
@@ -168,7 +168,7 @@ For event-sourced aggregates, `raise_()` wraps the `@apply` handler in
 `atomic_change`. The same start-to-end validation applies:
 
 ```python
-@domain.aggregate(is_event_sourced=True)
+@domain.aggregate(event_sourced=True)
 class Order:
     status = Status(OrderStatus, default="DRAFT", transitions={
         OrderStatus.DRAFT: [OrderStatus.PLACED],

--- a/docs/guides/domain-definition/aggregates.md
+++ b/docs/guides/domain-definition/aggregates.md
@@ -87,7 +87,7 @@ create a blank aggregate with auto-generated identity, then raise a
 creation event whose `@apply` handler populates the remaining state:
 
 ```python
-@domain.aggregate(is_event_sourced=True)
+@domain.aggregate(event_sourced=True)
 class Order:
     customer_name: String(max_length=150, required=True)
     status: String(max_length=20, default="PENDING")
@@ -263,13 +263,13 @@ Groups an aggregate with other aggregates into a named cluster. This is
 primarily used internally by Protean to organize aggregate-related elements
 and resolve cross-references.
 
-### `is_event_sourced`
+### `event_sourced`
 
 When `True`, the aggregate's state is derived entirely from its event
 stream rather than loaded from a database. Business methods must use
 `raise_()` and `@apply` handlers instead of direct mutation. See the
 [Event Sourcing pathway](../pathways/event-sourcing.md) for a complete
-walkthrough.
+walkthrough. (The old `is_event_sourced` spelling is a deprecated alias.)
 
 For details on `auto_add_id_field`, `schema_name`, `database_model`, and
 other options, see

--- a/docs/guides/domain-definition/relationships.md
+++ b/docs/guides/domain-definition/relationships.md
@@ -283,7 +283,7 @@ and its children.
 
 ## Event Sourcing Considerations
 
-For **event-sourced aggregates** (`is_event_sourced=True`), associations
+For **event-sourced aggregates** (`event_sourced=True`), associations
 behave differently because state is reconstructed from events rather than
 loaded from a database:
 

--- a/docs/guides/getting-started/es-tutorial/01-the-faithful-ledger.md
+++ b/docs/guides/getting-started/es-tutorial/01-the-faithful-ledger.md
@@ -48,7 +48,7 @@ what number it was assigned, and how much was deposited.
 
 ## Defining the Account Aggregate
 
-Now let's define the `Account` aggregate with `is_event_sourced=True`:
+Now let's define the `Account` aggregate with `event_sourced=True`:
 
 ```python
 --8<-- "guides/getting-started/es-tutorial/ch01.py:aggregate"
@@ -56,7 +56,7 @@ Now let's define the `Account` aggregate with `is_event_sourced=True`:
 
 There is a lot happening here. Let's break it down:
 
-- **`is_event_sourced=True`** tells Protean this aggregate derives its
+- **`event_sourced=True`** tells Protean this aggregate derives its
   state from events, not from a database row.
 - **`Account.open()`** is a class-level factory method. It calls
   `_create_new()` to create a blank aggregate with only an

--- a/docs/guides/getting-started/es-tutorial/15-fact-events.md
+++ b/docs/guides/getting-started/es-tutorial/15-fact-events.md
@@ -25,7 +25,7 @@ stand.
 Add `fact_events=True` to the aggregate:
 
 ```python
-@domain.aggregate(is_event_sourced=True, fact_events=True)
+@domain.aggregate(event_sourced=True, fact_events=True)
 class Account:
     account_number: String(max_length=20, required=True)
     holder_name: String(max_length=100, required=True)

--- a/docs/guides/pathways/event-sourcing.md
+++ b/docs/guides/pathways/event-sourcing.md
@@ -20,7 +20,7 @@ history. This gives you a complete, immutable audit trail and the ability
 to answer "what was the state at time T?" for any aggregate.
 
 In Protean, you enable Event Sourcing on a per-aggregate basis by marking
-it with `is_event_sourced=True`. The aggregate uses `@apply` methods to
+it with `event_sourced=True`. The aggregate uses `@apply` methods to
 define how each event type mutates state, and an Event Sourced Repository
 handles persistence to the event store.
 
@@ -69,7 +69,7 @@ sequenceDiagram
 
 | CQRS Element | Event Sourcing Change |
 |--------------|-----------------------|
-| `@domain.aggregate` | Add `is_event_sourced=True` option |
+| `@domain.aggregate` | Add `event_sourced=True` option |
 | Aggregate methods | Use `@apply` decorator for event application |
 | `@domain.repository` | Replace with `@domain.event_sourced_repository` |
 | Persistence Store | Replace with **Event Store** (e.g., Message DB) |
@@ -81,7 +81,7 @@ Everything from the [CQRS pathway](./cqrs.md), **with these changes**:
 
 | Element | Purpose |
 |---------|---------|
-| Event Sourced Aggregates | Aggregates with `is_event_sourced=True` that derive state from events |
+| Event Sourced Aggregates | Aggregates with `event_sourced=True` that derive state from events |
 | `@apply` decorator | Methods that define how each event type mutates aggregate state — called automatically by `raise_()` and during replay |
 | Event Sourced Repository | Persists events and reconstructs aggregates from event streams |
 | Fact Events | Auto-generated snapshot events capturing full aggregate state |
@@ -165,7 +165,7 @@ by `raise_()` during live operations and during event replay —
 making them the **single source of truth** for all state mutations:
 
 ```python
-@domain.aggregate(is_event_sourced=True)
+@domain.aggregate(event_sourced=True)
 class Order:
     status: String(default="draft")
     total: Float(default=0.0)
@@ -207,7 +207,7 @@ others use event sourcing — the decision is explicit and per-aggregate:
 class Product:
     ...
 
-@domain.aggregate(is_event_sourced=True)  # Event Sourced — state from events
+@domain.aggregate(event_sourced=True)  # Event Sourced — state from events
 class Order:
     ...
 ```

--- a/docs/guides/pathways/migrating-between-architectures.md
+++ b/docs/guides/pathways/migrating-between-architectures.md
@@ -168,7 +168,7 @@ class Order(BaseAggregate):
     total = Float()
 
 # After (Event Sourcing)
-@domain.aggregate(is_event_sourced=True)
+@domain.aggregate(event_sourced=True)
 class Order(BaseAggregate):
     customer_id = Identifier(required=True)
     status = String(default="draft")
@@ -181,7 +181,7 @@ Event-sourced aggregates must define `@apply` methods that reconstruct state
 from events. These are the **only** place where state changes happen.
 
 ```python
-@domain.aggregate(is_event_sourced=True)
+@domain.aggregate(event_sourced=True)
 class Order(BaseAggregate):
     customer_id = Identifier(required=True)
     status = String(default="draft")
@@ -242,7 +242,7 @@ persistence strategy.
 
 ```python
 # This aggregate uses event sourcing (full audit trail needed)
-@domain.aggregate(is_event_sourced=True)
+@domain.aggregate(event_sourced=True)
 class Account(BaseAggregate):
     ...
 
@@ -259,7 +259,7 @@ guide for criteria on which aggregates benefit from event sourcing.
 ### Migration checklist
 
 - [ ] Identify aggregates that need audit trails or temporal queries
-- [ ] Add `is_event_sourced=True` to those aggregates
+- [ ] Add `event_sourced=True` to those aggregates
 - [ ] Ensure every state mutation goes through `raise_()` + `@apply`
 - [ ] Configure the event store in `domain.toml`
 - [ ] Verify projections still populate correctly (they consume events, so

--- a/docs/patterns/command-idempotency.md
+++ b/docs/patterns/command-idempotency.md
@@ -421,7 +421,7 @@ matches what was expected. If the command was already processed (meaning the
 aggregate has moved forward), the version check fails.
 
 ```python
-@domain.aggregate(is_event_sourced=True)
+@domain.aggregate(event_sourced=True)
 class BankAccount(BaseAggregate):
     account_id: Identifier(identifier=True)
     balance: Float(default=0.0)

--- a/docs/patterns/encapsulate-state-changes.md
+++ b/docs/patterns/encapsulate-state-changes.md
@@ -383,7 +383,7 @@ For event-sourced aggregates, methods and events are even more tightly coupled.
 The method raises an event, and the `@apply` handler mutates state:
 
 ```python
-@domain.aggregate(is_event_sourced=True)
+@domain.aggregate(event_sourced=True)
 class Account(BaseAggregate):
     account_id: Auto(identifier=True)
     balance: Float(default=0.0)

--- a/docs/patterns/event-versioning-and-evolution.md
+++ b/docs/patterns/event-versioning-and-evolution.md
@@ -481,7 +481,7 @@ it will encounter every historical event version.
 they reach the handler:
 
 ```python
-@domain.aggregate(is_event_sourced=True)
+@domain.aggregate(event_sourced=True)
 class Order(BaseAggregate):
     # ... fields ...
 
@@ -499,7 +499,7 @@ manually, either with separate handlers for each version or tolerant-reader
 patterns:
 
 ```python
-@domain.aggregate(is_event_sourced=True)
+@domain.aggregate(event_sourced=True)
 class Order(BaseAggregate):
     @apply
     def on_order_placed(self, event: OrderPlaced):

--- a/docs/patterns/temporal-queries.md
+++ b/docs/patterns/temporal-queries.md
@@ -156,7 +156,7 @@ class AccountSuspended:
     suspended_at = DateTime()
 
 
-@compliance.aggregate(is_event_sourced=True)
+@compliance.aggregate(event_sourced=True)
 class Account:
     account_id = Auto(identifier=True)
     holder_name = String()

--- a/docs/reference/adapters/eventstore/index.md
+++ b/docs/reference/adapters/eventstore/index.md
@@ -72,7 +72,7 @@ Events are written to streams by the framework as part of aggregate
 persistence. You do not typically call the event store directly:
 
 ```python
-@domain.aggregate(is_event_sourced=True)
+@domain.aggregate(event_sourced=True)
 class Account:
     balance: Float(default=0.0)
 

--- a/docs/reference/cli/data/events.md
+++ b/docs/reference/cli/data/events.md
@@ -98,7 +98,7 @@ Total: 70 event(s) across 23 aggregate instance(s)
 ```
 
 The **ES?** column indicates whether the aggregate is configured as
-event-sourced (`is_event_sourced=True`).
+event-sourced (`event_sourced=True`).
 
 ## `protean events search`
 

--- a/docs/reference/domain-elements/element-decorators.md
+++ b/docs/reference/domain-elements/element-decorators.md
@@ -29,7 +29,7 @@ logic, enforce invariants, and own the transaction lifecycle.
 |--------|---------|-------------|
 | `abstract` | `False` | Cannot be instantiated when `True` |
 | `auto_add_id_field` | `True` | Auto-adds an `id` identity field |
-| `is_event_sourced` | `False` | Enables event sourcing for this aggregate |
+| `event_sourced` | `False` | Enables event sourcing for this aggregate |
 | `fact_events` | `False` | Auto-generates fact events on state changes |
 | `indexes` | `()` | List of [`Index`](indexes.md) declarations for the persistence layer |
 | `provider` | `"default"` | Database provider name |
@@ -37,6 +37,15 @@ logic, enforce invariants, and own the transaction lifecycle.
 | `stream_category` | `snake_case(cls)` | Message stream category |
 | `database_model` | `None` | Custom database model class |
 | `limit` | `100` | Default query result limit |
+
+Boolean element options are bare predicates (`event_sourced`, `fact_events`,
+`abstract`), not `is_`-prefixed.
+
+!!! warning "Deprecated: `is_event_sourced`"
+    `is_event_sourced` is a deprecated alias for `event_sourced`. It still works
+    but emits a `RemovedInProtean10Warning` and is reported as a
+    `DEPRECATED_OPTION` diagnostic by `protean check`; it will be removed in
+    v1.0.0. If both are supplied, `event_sourced` wins.
 
 Guide: [Aggregates](../../guides/domain-definition/aggregates.md) ·
 [Declaring Indexes](../../guides/domain-definition/indexes.md)

--- a/docs/reference/migration/index.md
+++ b/docs/reference/migration/index.md
@@ -2,5 +2,6 @@
 
 Guides for upgrading between Protean versions.
 
+- [**v0.17 Migration**](./v0-17.md) — 1.0 API surface: `event_sourced` option and internalized `is_fact_event`
 - [**v0.16 Migration**](./v0-16.md) — Outbox column bounds and upgrade steps for v0.16
 - [**v0.15 Migration**](./v0-15.md) — Breaking changes and upgrade steps for v0.15

--- a/docs/reference/migration/v0-17.md
+++ b/docs/reference/migration/v0-17.md
@@ -1,0 +1,44 @@
+# Migrating to 0.17
+
+!!! abstract "From 0.16 to 0.17"
+
+Protean 0.17 begins consolidating the 1.0 public API surface. The changes below
+are drop-in: deprecated spellings keep working through the transition window.
+
+**On this page:**
+
+- [`event_sourced` replaces `is_event_sourced`](#event_sourced-replaces-is_event_sourced) — canonical boolean option spelling
+- [`is_fact_event` is now framework-internal](#is_fact_event-is-now-framework-internal) — it can no longer be passed as an option
+
+---
+
+## `event_sourced` replaces `is_event_sourced`
+
+**Tier 1.** Boolean element options are now bare predicates. The aggregate
+option that enables event sourcing is `event_sourced`; the old
+`is_event_sourced` spelling is a deprecated alias.
+
+```python
+@domain.aggregate(event_sourced=True)   # was: is_event_sourced=True
+class Account:
+    ...
+```
+
+The alias still works but emits a `RemovedInProtean10Warning` and is reported as
+a `DEPRECATED_OPTION` diagnostic by `protean check`. It will be removed in
+v1.0.0. If both spellings are supplied, `event_sourced` wins. The internal
+`meta_.is_event_sourced` attribute is unchanged.
+
+---
+
+## `is_fact_event` is now framework-internal
+
+**Tier 1.** `is_fact_event` was never an option user code should set: the
+framework assigns it when it generates fact events for an aggregate marked
+`fact_events=True`. Passing `is_fact_event=` to an event or command (via the
+decorator or `domain.register`) now raises `ConfigurationError`.
+
+Nothing changes for reads: `meta_.is_fact_event` is still present on every
+event and command (defaulting to `False`), and fact events still carry
+`meta_.is_fact_event is True`. If you were setting the option by hand, drop it
+and let `fact_events=True` on the aggregate drive generation.

--- a/docs/reference/migration/v0-17.md
+++ b/docs/reference/migration/v0-17.md
@@ -2,8 +2,10 @@
 
 !!! abstract "From 0.16 to 0.17"
 
-Protean 0.17 begins consolidating the 1.0 public API surface. The changes below
-are drop-in: deprecated spellings keep working through the transition window.
+Protean 0.17 begins consolidating the 1.0 public API surface. Renamed **public**
+options are drop-in: the deprecated spelling keeps working (behind a warning)
+through the transition window. One **framework-internal** option that was never
+part of the public API is removed outright, with no transition window.
 
 **On this page:**
 
@@ -33,10 +35,12 @@ v1.0.0. If both spellings are supplied, `event_sourced` wins. The internal
 
 ## `is_fact_event` is now framework-internal
 
-**Tier 1.** `is_fact_event` was never an option user code should set: the
-framework assigns it when it generates fact events for an aggregate marked
-`fact_events=True`. Passing `is_fact_event=` to an event or command (via the
-decorator or `domain.register`) now raises `ConfigurationError`.
+**Internal option removed (no deprecation window).** `is_fact_event` was never a
+public option user code should set: the framework assigns it when it generates
+fact events for an aggregate marked `fact_events=True`. Because it was never part
+of the public API, it is removed outright rather than deprecated: passing
+`is_fact_event=` to an event or command (via the decorator or `domain.register`)
+now raises `ConfigurationError` immediately.
 
 Nothing changes for reads: `meta_.is_fact_event` is still present on every
 event and command (defaulting to `False`), and fact events still carry

--- a/docs/why-protean.md
+++ b/docs/why-protean.md
@@ -138,7 +138,7 @@ audit trails, temporal queries, or complex state reconstruction, switch to
 event sourcing -- without rewriting the rest of your system.
 
 ```python
-@domain.aggregate(is_event_sourced=True)
+@domain.aggregate(event_sourced=True)
 class Account:
     balance: Float(default=0.0)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -377,6 +377,7 @@ nav:
       - reference/compatibility/index.md
     - Migration:
       - reference/migration/index.md
+      - reference/migration/v0-17.md
       - reference/migration/v0-16.md
       - reference/migration/v0-15.md
     - Architecture Decisions:

--- a/src/protean/core/aggregate.py
+++ b/src/protean/core/aggregate.py
@@ -647,6 +647,10 @@ def aggregate_factory(element_cls: type[_T], domain: Any, **opts: Any) -> type[_
     if "event_sourced" in opts:
         # Canonical wins if both are supplied.
         opts["is_event_sourced"] = opts.pop("event_sourced")
+    if "is_event_sourced" in opts:
+        # Coerce to the documented `bool` contract so a value like `None` does
+        # not leak onto `meta_`/the IR wire node (and suppress the default).
+        opts["is_event_sourced"] = bool(opts["is_event_sourced"])
 
     # Always route to Pydantic base
     base_cls = BaseAggregate
@@ -662,9 +666,11 @@ def aggregate_factory(element_cls: type[_T], domain: Any, **opts: Any) -> type[_
 
     # Record the deprecated alias usage for the `DEPRECATED_OPTION` check
     # diagnostic. Set on the derived class (which `derive_element_class` may
-    # have rebuilt) so the IR builder can read it off the registry.
-    if alias_used:
-        aggregate_cls._deprecated_options_used = ("is_event_sourced",)
+    # have rebuilt) so the IR builder can read it off the registry. Always
+    # assign — the same class object can be re-registered (e.g. shared across
+    # bounded contexts) with the canonical spelling, and a stale marker would
+    # make `check()` falsely flag already-migrated code.
+    aggregate_cls._deprecated_options_used = ("is_event_sourced",) if alias_used else ()
 
     # Iterate through methods marked as `@invariant` and record them for later use
     for klass in aggregate_cls.__mro__:

--- a/src/protean/core/aggregate.py
+++ b/src/protean/core/aggregate.py
@@ -64,7 +64,7 @@ class BaseAggregate(BaseEntity):
 
     | Option | Type | Description |
     |--------|------|-------------|
-    | ``is_event_sourced`` | ``bool`` | Enable event-sourcing mode (default: ``False``). |
+    | ``event_sourced`` | ``bool`` | Enable event-sourcing mode (default: ``False``). |
     | ``fact_events`` | ``bool`` | Auto-generate fact events on persistence (default: ``False``). |
     | ``stream_category`` | ``str`` | Override the event stream category name. |
     | ``provider`` | ``str`` | The persistence provider name (default: ``"default"``). |
@@ -87,6 +87,11 @@ class BaseAggregate(BaseEntity):
     # Event sourcing maps (ClassVar — populated by factory)
     _projections: ClassVar[defaultdict[str, set[Any]]] = defaultdict(set)
     _events_cls_map: ClassVar[dict[str, Any]] = {}
+
+    # Deprecated option names supplied at registration (e.g. the
+    # ``is_event_sourced`` alias). Set by ``aggregate_factory`` and read by the
+    # IR builder to emit ``DEPRECATED_OPTION`` diagnostics. Empty by default.
+    _deprecated_options_used: ClassVar[tuple[str, ...]] = ()
 
     if TYPE_CHECKING:
         # Assigned per-subclass by the fact-event factory via
@@ -626,6 +631,23 @@ def aggregate_factory(element_cls: type[_T], domain: Any, **opts: Any) -> type[_
     if "limit" in opts and opts["limit"] is not None and opts["limit"] < 0:
         opts["limit"] = None
 
+    # Normalize the `event_sourced` boolean option. The internal storage key is
+    # `is_event_sourced`; `event_sourced` is the canonical user-facing spelling
+    # and `is_event_sourced` is a deprecated alias. Both the `@domain.aggregate`
+    # decorator and `domain.register` route through this factory, so both
+    # entry points get the alias handling.
+    alias_used = "is_event_sourced" in opts
+    if alias_used:
+        warn_deprecated(
+            "`is_event_sourced`",
+            removal="1.0.0",
+            alternative="Use `event_sourced` instead.",
+            stacklevel=3,
+        )
+    if "event_sourced" in opts:
+        # Canonical wins if both are supplied.
+        opts["is_event_sourced"] = opts.pop("event_sourced")
+
     # Always route to Pydantic base
     base_cls = BaseAggregate
 
@@ -637,6 +659,12 @@ def aggregate_factory(element_cls: type[_T], domain: Any, **opts: Any) -> type[_
     # (``_invariants``, ``meta_``, ``_projections``, ``_events_cls_map``) are
     # visible to both type checkers.
     aggregate_cls = cast("type[BaseAggregate]", element_cls)
+
+    # Record the deprecated alias usage for the `DEPRECATED_OPTION` check
+    # diagnostic. Set on the derived class (which `derive_element_class` may
+    # have rebuilt) so the IR builder can read it off the registry.
+    if alias_used:
+        aggregate_cls._deprecated_options_used = ("is_event_sourced",)
 
     # Iterate through methods marked as `@invariant` and record them for later use
     for klass in aggregate_cls.__mro__:

--- a/src/protean/domain/type_manager.py
+++ b/src/protean/domain/type_manager.py
@@ -139,9 +139,13 @@ class TypeManager:
         for _, element in registry._elements[DomainObjects.AGGREGATE.value].items():
             if element.cls.meta_.fact_events:
                 event_cls = element_to_fact_event(element.cls)
-                self._domain.register(
+                registered = self._domain.register(
                     event_cls,
                     auto_generated=True,
                     part_of=element.cls,
-                    is_fact_event=True,
                 )
+                # ``is_fact_event`` is framework-internal (rejected as a
+                # register option), so mark the generated class directly. It is
+                # only read at check/runtime, so setting it after registration
+                # is safe.
+                registered.meta_.is_fact_event = True

--- a/src/protean/ir/builder.py
+++ b/src/protean/ir/builder.py
@@ -1434,6 +1434,7 @@ class IRBuilder:
         self._diagnose_handler_too_broad(ir)
         self._diagnose_event_without_data(ir)
         self._diagnose_deprecated_elements(ir)
+        self._diagnose_deprecated_options(ir)
         # Custom lint rules from config
         self._run_custom_lint_rules(ir)
 
@@ -1870,6 +1871,32 @@ class IRBuilder:
                         "field": field_name,
                         "level": "info",
                         "message": f_msg,
+                    }
+                )
+
+    def _diagnose_deprecated_options(self, ir: dict[str, Any]) -> None:
+        """DEPRECATED_OPTION: a deprecated decorator/register option was used.
+
+        Reads the aggregate registry (the deprecated-option marker is not
+        projected into the IR, keeping the IR wire format unchanged) and emits
+        an INFO-level diagnostic per aggregate that used a deprecated option
+        alias, e.g. ``is_event_sourced=`` instead of ``event_sourced=``.
+        """
+        registry = self._domain._domain_registry
+        for record in registry._elements.get("AGGREGATE", {}).values():
+            # Read the class's own attribute (not an inherited one) so a
+            # subclass of an alias-using aggregate is not wrongly flagged.
+            used = record.cls.__dict__.get("_deprecated_options_used", ())
+            for option in used:
+                self._diagnostics.append(
+                    {
+                        "code": "DEPRECATED_OPTION",
+                        "element": fqn(record.cls),
+                        "level": "info",
+                        "message": (
+                            f"Option `{option}` is deprecated; "
+                            f"use `event_sourced` instead."
+                        ),
                     }
                 )
 

--- a/src/protean/utils/__init__.py
+++ b/src/protean/utils/__init__.py
@@ -447,6 +447,16 @@ def derive_element_class(
     if not all(opt in known_options for opt in opts):
         raise ConfigurationError(f"Unknown option(s) {set(opts) - set(known_options)}")
 
+    # Reject framework-internal options. These carry a default (so ``meta_``
+    # always exposes them) but are set by the framework, not by user code.
+    internal_supplied = set(opts) & base_cls._internal_options
+    if internal_supplied:
+        names = ", ".join(f"`{name}`" for name in sorted(internal_supplied))
+        raise ConfigurationError(
+            f"Option(s) {names} are set by the framework and cannot be "
+            f"provided directly."
+        )
+
     if not issubclass(element_cls, base_cls):
         try:
             original_cls = element_cls

--- a/src/protean/utils/container.py
+++ b/src/protean/utils/container.py
@@ -97,6 +97,13 @@ class OptionsMixin:
     # specific runs at class-definition time.
     _default_options: ClassVar[list[tuple[str, Any]]] = []
 
+    # Option names that are framework-internal metadata: they carry a default
+    # (via ``_default_options``) so ``meta_`` always exposes them, but users may
+    # not set them directly. Element Roots override this to declare their own
+    # internal options; :func:`protean.utils.derive_element_class` rejects any
+    # such key passed through the decorator or ``domain.register``.
+    _internal_options: ClassVar[frozenset[str]] = frozenset()
+
     @classmethod
     def _set_defaults(cls) -> None:
         # Assign default options for remaining items from the declarative

--- a/src/protean/utils/eventing.py
+++ b/src/protean/utils/eventing.py
@@ -303,6 +303,12 @@ class BaseMessageType(Element, BaseModel, OptionsMixin):
 
     _metadata: Any = PrivateAttr(default=None)
 
+    # ``is_fact_event`` is framework-set metadata (assigned during fact-event
+    # generation), not a user-facing option. It keeps a default in
+    # ``_default_options`` so ``meta_.is_fact_event`` is always present, but is
+    # declared internal here so ``derive_element_class`` rejects user input.
+    _internal_options: ClassVar[frozenset[str]] = frozenset({"is_fact_event"})
+
     _default_options: ClassVar[list[tuple[str, Any]]] = [
         ("abstract", False),
         ("aggregate_cluster", None),

--- a/tests/aggregate/test_event_sourced_option.py
+++ b/tests/aggregate/test_event_sourced_option.py
@@ -1,0 +1,134 @@
+"""Tests for the ``event_sourced`` aggregate option and its deprecated
+``is_event_sourced`` alias (#1107).
+
+``event_sourced`` is the canonical, user-facing spelling. ``is_event_sourced``
+is retained as a deprecated alias that maps to the same internal
+``meta_.is_event_sourced`` storage key. The alias emits a
+``RemovedInProtean10Warning`` and surfaces a ``DEPRECATED_OPTION`` diagnostic
+from ``domain.check()``.
+"""
+
+import warnings
+
+import pytest
+
+from protean._deprecation import (
+    ProteanDeprecationWarning,
+    RemovedInProtean10Warning,
+)
+from protean.core.aggregate import BaseAggregate
+from protean.fields import Integer, String
+
+
+class TestEventSourcedCanonicalOption:
+    def test_event_sourced_true_sets_internal_flag(self, test_domain):
+        @test_domain.aggregate(event_sourced=True)
+        class Person(BaseAggregate):
+            name: String()
+            age: Integer()
+
+        assert Person.meta_.is_event_sourced is True
+
+    def test_event_sourced_false_sets_internal_flag(self, test_domain):
+        @test_domain.aggregate(event_sourced=False)
+        class Person(BaseAggregate):
+            name: String()
+
+        assert Person.meta_.is_event_sourced is False
+
+    def test_event_sourced_via_register(self, test_domain):
+        class Person(BaseAggregate):
+            name: String()
+
+        test_domain.register(Person, event_sourced=True)
+
+        assert Person.meta_.is_event_sourced is True
+
+    def test_event_sourced_emits_no_deprecation_warning(self, test_domain):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+
+            @test_domain.aggregate(event_sourced=True)
+            class Person(BaseAggregate):
+                name: String()
+
+        assert not any(
+            issubclass(w.category, ProteanDeprecationWarning) for w in caught
+        )
+
+    def test_no_option_emits_no_deprecation_warning(self, test_domain):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+
+            @test_domain.aggregate
+            class Person(BaseAggregate):
+                name: String()
+
+        assert not any(
+            issubclass(w.category, ProteanDeprecationWarning) for w in caught
+        )
+
+
+class TestIsEventSourcedAlias:
+    def test_alias_still_sets_internal_flag(self, test_domain):
+        with pytest.warns(RemovedInProtean10Warning):
+
+            @test_domain.aggregate(is_event_sourced=True)
+            class Person(BaseAggregate):
+                name: String()
+
+        assert Person.meta_.is_event_sourced is True
+
+    def test_alias_via_register_warns(self, test_domain):
+        class Person(BaseAggregate):
+            name: String()
+
+        with pytest.warns(RemovedInProtean10Warning):
+            test_domain.register(Person, is_event_sourced=True)
+
+        assert Person.meta_.is_event_sourced is True
+
+    def test_canonical_wins_when_both_supplied(self, test_domain):
+        # Alias still warns, but the canonical `event_sourced` value takes
+        # precedence over the alias.
+        with pytest.warns(RemovedInProtean10Warning):
+
+            @test_domain.aggregate(event_sourced=True, is_event_sourced=False)
+            class Person(BaseAggregate):
+                name: String()
+
+        assert Person.meta_.is_event_sourced is True
+
+
+class TestDeprecatedOptionDiagnostic:
+    def test_alias_yields_deprecated_option_diagnostic(self, test_domain):
+        with pytest.warns(RemovedInProtean10Warning):
+            test_domain.register(_alias_aggregate(), is_event_sourced=True)
+
+        report = test_domain.check(traverse=False)
+
+        diagnostics = [
+            d for d in report["diagnostics"] if d["code"] == "DEPRECATED_OPTION"
+        ]
+        assert len(diagnostics) == 1
+        assert diagnostics[0]["level"] == "info"
+        assert "is_event_sourced" in diagnostics[0]["message"]
+
+    def test_canonical_yields_no_deprecated_option_diagnostic(self, test_domain):
+        test_domain.register(_alias_aggregate(), event_sourced=True)
+
+        report = test_domain.check(traverse=False)
+
+        diagnostics = [
+            d for d in report["diagnostics"] if d["code"] == "DEPRECATED_OPTION"
+        ]
+        assert diagnostics == []
+
+
+def _alias_aggregate() -> type[BaseAggregate]:
+    """Build a fresh aggregate class so each diagnostic test registers its own."""
+
+    class Widget(BaseAggregate):
+        name: String()
+
+    return Widget

--- a/tests/aggregate/test_event_sourced_option.py
+++ b/tests/aggregate/test_event_sourced_option.py
@@ -17,6 +17,7 @@ from protean._deprecation import (
     RemovedInProtean10Warning,
 )
 from protean.core.aggregate import BaseAggregate
+from protean.domain import Domain
 from protean.fields import Integer, String
 
 
@@ -71,7 +72,10 @@ class TestEventSourcedCanonicalOption:
 
 class TestIsEventSourcedAlias:
     def test_alias_still_sets_internal_flag(self, test_domain):
-        with pytest.warns(RemovedInProtean10Warning):
+        with pytest.warns(
+            RemovedInProtean10Warning,
+            match=r"Use `event_sourced` instead\. Will be removed in v1\.0\.0",
+        ):
 
             @test_domain.aggregate(is_event_sourced=True)
             class Person(BaseAggregate):
@@ -99,6 +103,27 @@ class TestIsEventSourcedAlias:
 
         assert Person.meta_.is_event_sourced is True
 
+    def test_canonical_wins_when_both_supplied_reverse(self, test_domain):
+        # The reverse precedence: canonical `event_sourced=False` must win over
+        # `is_event_sourced=True`, guarding against a "canonical only overrides
+        # when truthy" bug that would let the alias win here.
+        with pytest.warns(RemovedInProtean10Warning):
+
+            @test_domain.aggregate(event_sourced=False, is_event_sourced=True)
+            class Person(BaseAggregate):
+                name: String()
+
+        assert Person.meta_.is_event_sourced is False
+
+    def test_non_bool_value_coerced_to_bool(self, test_domain):
+        # `event_sourced=None` must land on `meta_` as the documented `bool`
+        # (False), not leak `None` onto the IR wire node.
+        @test_domain.aggregate(event_sourced=None)
+        class Person(BaseAggregate):
+            name: String()
+
+        assert Person.meta_.is_event_sourced is False
+
 
 class TestDeprecatedOptionDiagnostic:
     def test_alias_yields_deprecated_option_diagnostic(self, test_domain):
@@ -118,6 +143,28 @@ class TestDeprecatedOptionDiagnostic:
         test_domain.register(_alias_aggregate(), event_sourced=True)
 
         report = test_domain.check(traverse=False)
+
+        diagnostics = [
+            d for d in report["diagnostics"] if d["code"] == "DEPRECATED_OPTION"
+        ]
+        assert diagnostics == []
+
+    @pytest.mark.no_test_domain
+    def test_re_registering_same_class_with_canonical_clears_marker(self):
+        # The same aggregate class object can be shared across bounded contexts.
+        # Registering it with the alias in one domain must not leave a stale
+        # marker that makes a second domain (using the canonical spelling)
+        # falsely report the already-migrated code as deprecated.
+        widget = _alias_aggregate()
+
+        domain_a = Domain(name="AliasDomain", root_path=__file__)
+        with pytest.warns(RemovedInProtean10Warning):
+            domain_a.register(widget, is_event_sourced=True)
+        domain_a.check(traverse=False)
+
+        domain_b = Domain(name="CanonicalDomain", root_path=__file__)
+        domain_b.register(widget, event_sourced=True)
+        report = domain_b.check(traverse=False)
 
         diagnostics = [
             d for d in report["diagnostics"] if d["code"] == "DEPRECATED_OPTION"

--- a/tests/event/test_is_fact_event_internal.py
+++ b/tests/event/test_is_fact_event_internal.py
@@ -40,6 +40,9 @@ class TestIsFactEventRejected:
                 name: String()
 
         assert "is_fact_event" in str(exc.value)
+        # Assert the internal-option branch fired, not the generic
+        # unknown-option branch (whose message also contains "is_fact_event").
+        assert "framework" in str(exc.value)
 
     def test_register_command_with_is_fact_event_raises(self, test_domain):
         class SomeCommand(BaseCommand):
@@ -50,6 +53,9 @@ class TestIsFactEventRejected:
             test_domain.register(SomeCommand, part_of=User, is_fact_event=True)
 
         assert "is_fact_event" in str(exc.value)
+        # Assert the internal-option branch fired, not the generic
+        # unknown-option branch (whose message also contains "is_fact_event").
+        assert "framework" in str(exc.value)
 
 
 class TestIsFactEventDefaultPreserved:

--- a/tests/event/test_is_fact_event_internal.py
+++ b/tests/event/test_is_fact_event_internal.py
@@ -1,0 +1,76 @@
+"""``is_fact_event`` is framework-internal (#1107).
+
+It remains present on ``meta_`` (defaulting to ``False``) so every read site
+keeps working, but user code may not set it directly — the framework assigns it
+only during fact-event generation. Passing it to an event or command through the
+decorator or ``domain.register`` raises ``ConfigurationError``.
+"""
+
+import pytest
+
+from protean.core.aggregate import BaseAggregate
+from protean.core.command import BaseCommand
+from protean.core.event import BaseEvent
+from protean.exceptions import ConfigurationError
+from protean.fields import Identifier, String
+
+
+class User(BaseAggregate):
+    name: String()
+
+
+class TestIsFactEventRejected:
+    def test_register_event_with_is_fact_event_raises(self, test_domain):
+        class SomeEvent(BaseEvent):
+            id: Identifier(identifier=True)
+            name: String()
+
+        with pytest.raises(ConfigurationError) as exc:
+            test_domain.register(SomeEvent, part_of=User, is_fact_event=True)
+
+        assert "is_fact_event" in str(exc.value)
+        assert "framework" in str(exc.value)
+
+    def test_event_decorator_with_is_fact_event_raises(self, test_domain):
+        with pytest.raises(ConfigurationError) as exc:
+
+            @test_domain.event(part_of=User, is_fact_event=True)
+            class SomeEvent(BaseEvent):
+                id: Identifier(identifier=True)
+                name: String()
+
+        assert "is_fact_event" in str(exc.value)
+
+    def test_register_command_with_is_fact_event_raises(self, test_domain):
+        class SomeCommand(BaseCommand):
+            id: Identifier(identifier=True)
+            name: String()
+
+        with pytest.raises(ConfigurationError) as exc:
+            test_domain.register(SomeCommand, part_of=User, is_fact_event=True)
+
+        assert "is_fact_event" in str(exc.value)
+
+
+class TestIsFactEventDefaultPreserved:
+    def test_normal_event_has_is_fact_event_false(self, test_domain):
+        class SomeEvent(BaseEvent):
+            id: Identifier(identifier=True)
+            name: String()
+
+        test_domain.register(SomeEvent, part_of=User)
+        test_domain.init(traverse=False)
+
+        assert SomeEvent.meta_.is_fact_event is False
+
+    def test_generated_fact_event_has_is_fact_event_true(self, test_domain):
+        test_domain.register(User, fact_events=True)
+        test_domain.init(traverse=False)
+
+        event_records = test_domain.registry._elements["EVENT"]
+        fact_events = [
+            r.cls for r in event_records.values() if r.cls.meta_.is_fact_event
+        ]
+        assert len(fact_events) >= 1
+        for fact_event in fact_events:
+            assert fact_event.meta_.is_fact_event is True

--- a/tests/message/test_message_edge_cases.py
+++ b/tests/message/test_message_edge_cases.py
@@ -440,8 +440,11 @@ class TestMessageFromDomainObjectEdgeCases:
             email: String()
             name: String()
 
-        # Register the fact event with is_fact_event meta option
-        test_domain.register(UserFactEvent, part_of=User, is_fact_event=True)
+        # Register the fact event, then mark it as a fact event directly.
+        # ``is_fact_event`` is framework-internal and cannot be passed to
+        # ``register`` (it is set by the framework during fact-event generation).
+        test_domain.register(UserFactEvent, part_of=User)
+        UserFactEvent.meta_.is_fact_event = True
         test_domain.init(traverse=False)
 
         # Simulate a fact event (name ends with FactEvent)


### PR DESCRIPTION
## Summary
- Add `event_sourced` as the canonical bare-predicate spelling for the aggregate option, deprecating `is_event_sourced` (Tier 1: emits `RemovedInProtean10Warning` + a `DEPRECATED_OPTION` diagnostic from `protean check`; canonical wins if both are passed; removal in v1.0.0)
- Remove `is_fact_event` from the user-facing event/command option surface — it's framework-internal, now rejected with `ConfigurationError` if passed via decorator or `domain.register`; `meta_.is_fact_event` still reads back correctly (defaulting to `False`)
- Add a v0.17 migration guide entry and update docs/glossary references from `is_event_sourced` to `event_sourced`

## Test plan
- [x] `tests/aggregate/test_event_sourced_option.py` — alias precedence, deprecation warning, `DEPRECATED_OPTION` diagnostic, bool coercion
- [x] `tests/event/test_is_fact_event_internal.py` — internal option rejection, `meta_.is_fact_event` read-back
- [x] Core tests pass (`protean test`)

Closes #1107