### PR TITLE
Add nightly full-matrix run and share test setup via composite action

### DIFF
--- a/.github/actions/test-suite/action.yml
+++ b/.github/actions/test-suite/action.yml
@@ -61,9 +61,15 @@ runs:
           "ghcr.io/proteanhq/mirror/mssql-server:2022-latest"
         )
 
-        if [ "${{ steps.docker-cache.outputs.cache-hit }}" == "true" ]; then
+        # A cache-hit with no tarballs (e.g. a cache saved by an interrupted
+        # run) would otherwise iterate the literal glob and fail `docker load`;
+        # nullglob makes the array empty and we fall through to pulling.
+        shopt -s nullglob
+        cached_tarballs=(/tmp/docker-images/*.tar)
+
+        if [ "${{ steps.docker-cache.outputs.cache-hit }}" == "true" ] && [ ${#cached_tarballs[@]} -gt 0 ]; then
           echo "Loading cached Docker images..."
-          for f in /tmp/docker-images/*.tar; do
+          for f in "${cached_tarballs[@]}"; do
             docker load -i "$f" &
           done
           wait
@@ -177,7 +183,15 @@ runs:
         sudo apt-get update
         sudo apt-get install -y curl gnupg apt-transport-https
         curl -sSL https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc >/dev/null
-        curl -sSL https://packages.microsoft.com/config/ubuntu/24.04/prod.list | sudo tee /etc/apt/sources.list.d/microsoft-prod.list >/dev/null
+        # Match the runner's Ubuntu release so this keeps working when
+        # `ubuntu-latest` advances; fall back to 24.04 (the last release we know
+        # Microsoft publishes a feed for) if the current release has none yet.
+        ubuntu_ver="$(. /etc/os-release && echo "${VERSION_ID}")"
+        if ! curl -fsSL "https://packages.microsoft.com/config/ubuntu/${ubuntu_ver}/prod.list" -o /tmp/mssql-prod.list; then
+          echo "No Microsoft feed for Ubuntu ${ubuntu_ver}; falling back to 24.04."
+          curl -fsSL "https://packages.microsoft.com/config/ubuntu/24.04/prod.list" -o /tmp/mssql-prod.list
+        fi
+        sudo cp /tmp/mssql-prod.list /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt-get update
         sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18 mssql-tools18 unixodbc-dev
         echo "/opt/mssql-tools18/bin" >> $GITHUB_PATH

--- a/.github/actions/test-suite/action.yml
+++ b/.github/actions/test-suite/action.yml
@@ -1,0 +1,232 @@
+# Shared test-suite runner used by both the per-PR CI (ci.yml) and the nightly
+# full-matrix run (nightly.yml). It is a composite action rather than a reusable
+# `workflow_call` on purpose: a called workflow prefixes its status-check name
+# with the caller job (`caller / job (matrix)`), which would break the exact
+# branch-protection contexts (`Python 3.14 Tests`, `Python 3.14 Full`). A
+# composite action keeps the job in the caller, so the caller owns the name.
+#
+# The caller must `actions/checkout` before invoking this action.
+name: "Protean test suite"
+description: "Install and run the Protean test suite (CORE or FULL) at the chosen resolution."
+
+inputs:
+  python-version:
+    description: "Python version to test against."
+    required: true
+  full:
+    description: "'true' runs the FULL adapter suite (`-c FULL`) against Docker service containers; 'false' runs the fast in-memory CORE suite."
+    required: false
+    default: "false"
+  resolution:
+    description: "'highest' uses the locked latest-compatible versions; 'lowest-direct' re-resolves declared dependencies to their floor."
+    required: false
+    default: "highest"
+  enforce-coverage:
+    description: "'true' fails the run if coverage drops below the project floor. Only meaningful for a FULL leg."
+    required: false
+    default: "false"
+  upload-coverage:
+    description: "'true' uploads coverage to Codecov. Only meaningful for a FULL leg."
+    required: false
+    default: "false"
+  codecov-token:
+    description: "Codecov upload token (required only when upload-coverage is 'true')."
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    # Service setup (this step through "Wait for services") runs only for a FULL
+    # leg; CORE and floors legs need no Docker. Images are pulled from this org's
+    # public GHCR mirror (populated by mirror-images.yml), not Docker Hub, so
+    # there is no login step and fork PRs pull them with zero secrets.
+    - name: Cache Docker images
+      id: docker-cache
+      if: inputs.full == 'true'
+      uses: actions/cache@v6
+      with:
+        path: /tmp/docker-images
+        key: docker-images-${{ runner.os }}-v3
+
+    - name: Load or pull Docker images
+      if: inputs.full == 'true'
+      shell: bash
+      run: |
+        IMAGES=(
+          "ghcr.io/proteanhq/mirror/postgres:16"
+          "ghcr.io/proteanhq/mirror/redis:7"
+          "ghcr.io/proteanhq/mirror/elasticsearch:8.7.0"
+          "ghcr.io/proteanhq/mirror/message-db:1.2.6"
+          "ghcr.io/proteanhq/mirror/mssql-server:2022-latest"
+        )
+
+        if [ "${{ steps.docker-cache.outputs.cache-hit }}" == "true" ]; then
+          echo "Loading cached Docker images..."
+          for f in /tmp/docker-images/*.tar; do
+            docker load -i "$f" &
+          done
+          wait
+        else
+          echo "Pulling Docker images..."
+          for img in "${IMAGES[@]}"; do
+            docker pull "$img" &
+          done
+          wait
+
+          echo "Saving Docker images to cache..."
+          mkdir -p /tmp/docker-images
+          for img in "${IMAGES[@]}"; do
+            name=$(echo "$img" | tr '/:' '_')
+            docker save "$img" -o "/tmp/docker-images/${name}.tar" &
+          done
+          wait
+        fi
+
+    - name: Configure sysctl limits
+      if: inputs.full == 'true'
+      shell: bash
+      run: |
+        sudo swapoff -a
+        sudo sysctl -w vm.swappiness=1
+        sudo sysctl -w fs.file-max=262144
+        sudo sysctl -w vm.max_map_count=262144
+
+    - name: Start service containers
+      if: inputs.full == 'true'
+      shell: bash
+      run: |
+        # Free the host ports below before binding them. Remove ALL containers
+        # left over from a previous run on this (potentially reused) runner:
+        # matching only our own names misses a container leaked under a
+        # different name, or one still shutting down, either of which can keep
+        # a port bound (e.g. the 59300 Elasticsearch transport port) and fail
+        # `docker run` with "address already in use".
+        leaked=$(docker ps -aq)
+        if [ -n "$leaked" ]; then
+          docker rm -f $leaked
+        fi
+
+        docker run -d --name postgres \
+          -p 55432:5432 \
+          -e POSTGRES_PASSWORD=postgres \
+          ghcr.io/proteanhq/mirror/postgres:16
+
+        docker run -d --name redis \
+          -p 56379:6379 \
+          ghcr.io/proteanhq/mirror/redis:7
+
+        docker run -d --name message-db \
+          -p 55433:5432 \
+          ghcr.io/proteanhq/mirror/message-db:1.2.6
+
+        docker run -d --name mssql \
+          -p 51433:1433 \
+          -e ACCEPT_EULA=Y \
+          -e "SA_PASSWORD=Protean123!" \
+          ghcr.io/proteanhq/mirror/mssql-server:2022-latest
+
+        docker run -d --name elasticsearch \
+          -p 59200:9200 \
+          -p 59300:9300 \
+          -e "discovery.type=single-node" \
+          -e "xpack.security.enabled=false" \
+          -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" \
+          ghcr.io/proteanhq/mirror/elasticsearch:8.7.0
+
+    - name: Wait for services
+      if: inputs.full == 'true'
+      shell: bash
+      run: |
+        echo "Waiting for PostgreSQL..."
+        timeout 60 bash -c 'until docker exec postgres pg_isready -U postgres 2>/dev/null; do sleep 2; done'
+        echo "PostgreSQL is ready!"
+
+        echo "Waiting for Redis..."
+        timeout 30 bash -c 'until docker exec redis redis-cli ping 2>/dev/null; do sleep 2; done'
+        echo "Redis is ready!"
+
+        echo "Waiting for Message DB..."
+        timeout 60 bash -c 'until docker exec message-db pg_isready -U postgres 2>/dev/null; do sleep 2; done'
+        echo "Message DB is ready!"
+
+        echo "Waiting for MSSQL..."
+        timeout 60 bash -c 'until docker exec mssql /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "Protean123!" -Q "SELECT 1" -b -C 2>/dev/null; do sleep 2; done'
+        echo "MSSQL is ready!"
+
+        echo "Waiting for Elasticsearch..."
+        timeout 120 bash -c 'until curl -s http://localhost:59200/_cluster/health | grep -q "yellow\|green"; do sleep 2; done'
+        echo "Elasticsearch is ready!"
+
+        echo "All services are ready!"
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+        cache-dependency-glob: "uv.lock"
+
+    - uses: actions/setup-python@v6
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install Microsoft ODBC Driver 18 and tools
+      if: inputs.full == 'true'
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y curl gnupg apt-transport-https
+        curl -sSL https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc >/dev/null
+        curl -sSL https://packages.microsoft.com/config/ubuntu/24.04/prod.list | sudo tee /etc/apt/sources.list.d/microsoft-prod.list >/dev/null
+        sudo apt-get update
+        sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18 mssql-tools18 unixodbc-dev
+        echo "/opt/mssql-tools18/bin" >> $GITHUB_PATH
+
+    - name: Install dependencies
+      # A lowest-direct leg re-resolves declared deps to their floor (installing
+      # all extras so a floor without a wheel for the newest Python fails here);
+      # every other leg uses the locked latest-compatible resolution.
+      shell: bash
+      env:
+        PYO3_USE_ABI3_FORWARD_COMPATIBILITY: ${{ (inputs.python-version == '3.13' || inputs.python-version == '3.14') && '1' || '' }}
+      run: uv sync --all-extras --all-groups ${{ inputs.resolution == 'lowest-direct' && '--resolution lowest-direct' || '' }}
+
+    - name: Mypy Plugin Tests
+      shell: bash
+      run: uv run pytest tests/ext/ -v
+
+    - name: Tests
+      # FULL runs the adapter suite against the service containers; CORE and
+      # floors run the fast in-memory suite (the POSTGRES/etc. env below is
+      # simply unused there).
+      shell: bash
+      env:
+        POSTGRES_PASSWORD: postgres
+        POSTGRES_USER: postgres
+        POSTGRES_PORT: 55432
+        PGPASSWORD: postgres
+        REDIS_HOST: localhost
+        REDIS_PORT: 56379
+        MSSQL_PASSWORD: Protean123!
+        MSSQL_USER: sa
+        MSSQL_PORT: 51433
+        MSSQL_HOST: localhost
+      run: uv run protean test ${{ inputs.full == 'true' && '-c FULL' || '' }}
+
+    # Project coverage floor. `protean test -c FULL` already ran `coverage
+    # combine`, so the merged `.coverage` exists; re-report it with a hard
+    # threshold so a change that drops overall coverage fails. `success() &&`
+    # keeps it from running after the Tests step failed (no merged `.coverage`).
+    - name: Enforce coverage floor
+      if: ${{ success() && inputs.enforce-coverage == 'true' }}
+      shell: bash
+      run: uv run coverage report --fail-under=94
+
+    # Upload from the FULL leg even when tests fail, so partial coverage is
+    # visible; skip only on cancellation.
+    - name: CodeCOV
+      if: ${{ !cancelled() && inputs.upload-coverage == 'true' }}
+      uses: codecov/codecov-action@v7.0.0
+      with:
+        files: coverage.xml
+        token: ${{ inputs.codecov-token }}

--- a/.github/actions/test-suite/action.yml
+++ b/.github/actions/test-suite/action.yml
@@ -172,7 +172,7 @@ runs:
         enable-cache: true
         cache-dependency-glob: "uv.lock"
 
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@v7
       with:
         python-version: ${{ inputs.python-version }}
 

--- a/.github/actions/test-suite/action.yml
+++ b/.github/actions/test-suite/action.yml
@@ -237,10 +237,13 @@ runs:
       run: uv run coverage report --fail-under=94
 
     # Upload from the FULL leg even when tests fail, so partial coverage is
-    # visible; skip only on cancellation.
+    # visible; skip only on cancellation. `fail_ci_if_error` makes a rejected
+    # upload (missing/invalid token, Codecov outage) fail this leg instead of
+    # silently leaving the required `codecov/patch` check unreported.
     - name: CodeCOV
       if: ${{ !cancelled() && inputs.upload-coverage == 'true' }}
       uses: codecov/codecov-action@v7.0.0
       with:
         files: coverage.xml
         token: ${{ inputs.codecov-token }}
+        fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,229 +20,41 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Per-PR cost control. The full adapter suite (`-c FULL`, which spins up
+        # Per-PR cost control. The FULL adapter suite (`-c FULL`, which starts
         # Postgres/Redis/Elasticsearch/MSSQL/MessageDB) is the expensive part, so
-        # only the newest Python runs it; the older versions run the fast
-        # in-memory CORE suite with no Docker. The `floors` leg proves the
-        # dependency floors resolve and install on the newest Python (the binding
-        # constraint for C-extension wheels) by re-resolving to the lowest
-        # permitted versions (`--resolution lowest-direct`); it runs CORE so it
-        # stays cheap. The full `-c FULL` matrix across every Python runs nightly
-        # on `main` (nightly.yml), which is where a version-specific adapter
-        # regression on 3.11-3.13 is caught. See ADR-0020.
+        # only the newest Python runs it (check `Python 3.14 Full`); the older
+        # versions run the fast in-memory CORE suite with no Docker. The
+        # lowest-direct leg (`Python 3.14 Tests`) re-resolves the dependencies to
+        # their floor and runs CORE, proving the floors resolve/install on the
+        # newest Python without a Docker spin-up. The full `-c FULL` matrix across
+        # every Python runs nightly on `main` (nightly.yml), which is where a
+        # version-specific adapter regression on 3.11-3.13 is caught. See ADR-0020.
         include:
-          - { python-version: "3.11", suite: core }
-          - { python-version: "3.12", suite: core }
-          - { python-version: "3.13", suite: core }
-          - { python-version: "3.14", suite: full }
-          - { python-version: "3.14", suite: floors }
-    # CORE/FULL legs keep the name `Python X Tests` so the branch-protection
-    # required checks match; the floors leg gets a distinct (non-required) name.
-    name: ${{ matrix.suite == 'floors' && 'Python 3.14 Floors (lowest-direct)' || format('Python {0} Tests', matrix.python-version) }}
-
-    # one place to set the PyO3 flag; every step inherits it automatically
-    env:
-      PYO3_USE_ABI3_FORWARD_COMPATIBILITY: ${{ (matrix.python-version == '3.13' || matrix.python-version == '3.14') && '1' || '' }}
+          - { python-version: "3.11", full: false, resolution: highest }
+          - { python-version: "3.12", full: false, resolution: highest }
+          - { python-version: "3.13", full: false, resolution: highest }
+          - { python-version: "3.14", full: true, resolution: highest }
+          - { python-version: "3.14", full: false, resolution: lowest-direct }
+    # Check names are branch-protection contexts. The CORE legs and the
+    # lowest-direct leg on 3.14 are `Python X Tests`; the FULL adapter leg is
+    # `Python 3.14 Full` (add it to the required checks so it gates merges).
+    name: ${{ matrix.full && 'Python 3.14 Full' || (matrix.resolution == 'lowest-direct' && 'Python 3.14 Tests') || format('Python {0} Tests', matrix.python-version) }}
 
     steps:
-      # Service images are pulled from this org's public GHCR mirror (populated
-      # by mirror-images.yml), not Docker Hub. Public GHCR packages need no auth,
-      # so there is no login step and fork PRs pull them with zero secrets.
       - uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
-      # Service setup (this step through "Wait for services") runs only for the
-      # FULL leg; the CORE and floors legs need no Docker.
-      - name: Cache Docker images
-        id: docker-cache
-        if: matrix.suite == 'full'
-        uses: actions/cache@v6
-        with:
-          path: /tmp/docker-images
-          key: docker-images-${{ runner.os }}-v3
-
-      - name: Load or pull Docker images
-        if: matrix.suite == 'full'
-        run: |
-          IMAGES=(
-            "ghcr.io/proteanhq/mirror/postgres:16"
-            "ghcr.io/proteanhq/mirror/redis:7"
-            "ghcr.io/proteanhq/mirror/elasticsearch:8.7.0"
-            "ghcr.io/proteanhq/mirror/message-db:1.2.6"
-            "ghcr.io/proteanhq/mirror/mssql-server:2022-latest"
-          )
-
-          if [ "${{ steps.docker-cache.outputs.cache-hit }}" == "true" ]; then
-            echo "Loading cached Docker images..."
-            for f in /tmp/docker-images/*.tar; do
-              docker load -i "$f" &
-            done
-            wait
-          else
-            echo "Pulling Docker images..."
-            for img in "${IMAGES[@]}"; do
-              docker pull "$img" &
-            done
-            wait
-
-            echo "Saving Docker images to cache..."
-            mkdir -p /tmp/docker-images
-            for img in "${IMAGES[@]}"; do
-              name=$(echo "$img" | tr '/:' '_')
-              docker save "$img" -o "/tmp/docker-images/${name}.tar" &
-            done
-            wait
-          fi
-
-      - name: Configure sysctl limits
-        if: matrix.suite == 'full'
-        run: |
-          sudo swapoff -a
-          sudo sysctl -w vm.swappiness=1
-          sudo sysctl -w fs.file-max=262144
-          sudo sysctl -w vm.max_map_count=262144
-
-      - name: Start service containers
-        if: matrix.suite == 'full'
-        run: |
-          # Free the host ports below before binding them. Remove ALL containers
-          # left over from a previous run on this (potentially reused) runner:
-          # matching only our own names misses a container leaked under a
-          # different name, or one still shutting down, either of which can keep
-          # a port bound (e.g. the 59300 Elasticsearch transport port) and fail
-          # `docker run` with "address already in use".
-          leaked=$(docker ps -aq)
-          if [ -n "$leaked" ]; then
-            docker rm -f $leaked
-          fi
-
-          docker run -d --name postgres \
-            -p 55432:5432 \
-            -e POSTGRES_PASSWORD=postgres \
-            ghcr.io/proteanhq/mirror/postgres:16
-
-          docker run -d --name redis \
-            -p 56379:6379 \
-            ghcr.io/proteanhq/mirror/redis:7
-
-          docker run -d --name message-db \
-            -p 55433:5432 \
-            ghcr.io/proteanhq/mirror/message-db:1.2.6
-
-          docker run -d --name mssql \
-            -p 51433:1433 \
-            -e ACCEPT_EULA=Y \
-            -e "SA_PASSWORD=Protean123!" \
-            ghcr.io/proteanhq/mirror/mssql-server:2022-latest
-
-          docker run -d --name elasticsearch \
-            -p 59200:9200 \
-            -p 59300:9300 \
-            -e "discovery.type=single-node" \
-            -e "xpack.security.enabled=false" \
-            -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" \
-            ghcr.io/proteanhq/mirror/elasticsearch:8.7.0
-
-      - name: Wait for services
-        if: matrix.suite == 'full'
-        run: |
-          echo "Waiting for PostgreSQL..."
-          timeout 60 bash -c 'until docker exec postgres pg_isready -U postgres 2>/dev/null; do sleep 2; done'
-          echo "PostgreSQL is ready!"
-
-          echo "Waiting for Redis..."
-          timeout 30 bash -c 'until docker exec redis redis-cli ping 2>/dev/null; do sleep 2; done'
-          echo "Redis is ready!"
-
-          echo "Waiting for Message DB..."
-          timeout 60 bash -c 'until docker exec message-db pg_isready -U postgres 2>/dev/null; do sleep 2; done'
-          echo "Message DB is ready!"
-
-          echo "Waiting for MSSQL..."
-          timeout 60 bash -c 'until docker exec mssql /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "Protean123!" -Q "SELECT 1" -b -C 2>/dev/null; do sleep 2; done'
-          echo "MSSQL is ready!"
-
-          echo "Waiting for Elasticsearch..."
-          timeout 120 bash -c 'until curl -s http://localhost:59200/_cluster/health | grep -q "yellow\|green"; do sleep 2; done'
-          echo "Elasticsearch is ready!"
-
-          echo "All services are ready!"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
-
-      - uses: actions/setup-python@v7
+      - uses: ./.github/actions/test-suite
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Install Microsoft ODBC Driver 18 and tools
-        if: matrix.suite == 'full'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y curl gnupg apt-transport-https
-          curl -sSL https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc >/dev/null
-          curl -sSL https://packages.microsoft.com/config/ubuntu/24.04/prod.list | sudo tee /etc/apt/sources.list.d/microsoft-prod.list >/dev/null
-          sudo apt-get update
-          sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18 mssql-tools18 unixodbc-dev
-          echo "/opt/mssql-tools18/bin" >> $GITHUB_PATH
-
-      - name: Install dependencies
-        # The floors leg re-resolves to the lowest permitted versions (installing
-        # all extras so a floor without a wheel for the newest Python fails here);
-        # every other leg uses the locked (latest-compatible) resolution.
-        run: uv sync --all-extras --all-groups ${{ matrix.suite == 'floors' && '--resolution lowest-direct' || '' }}
-
-      - name: Mypy Plugin Tests
-        run: uv run pytest tests/ext/ -v
-
-      - name: Tests
-        # FULL runs the adapter suite against the service containers; CORE and
-        # floors run the fast in-memory suite (the POSTGRES/etc. env below is
-        # simply unused there).
-        run: uv run protean test ${{ matrix.suite == 'full' && '-c FULL' || '' }}
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_PORT: 55432
-          PGPASSWORD: postgres
-          REDIS_HOST: localhost
-          REDIS_PORT: 56379
-          MSSQL_PASSWORD: Protean123!
-          MSSQL_USER: sa
-          MSSQL_PORT: 51433
-          MSSQL_HOST: localhost
-
-      # Project coverage floor. `protean test -c FULL` already ran
-      # `coverage combine`, so the merged `.coverage` for this leg exists; re-report
-      # it with a hard threshold so a PR that drops overall coverage fails CI.
-      # This threshold lives here, not in `[tool.coverage.report]`, because that
-      # config is also read by the local `protean test` (CORE) run, whose
-      # in-memory-only coverage sits well below the full-suite figure — a global
-      # `fail_under` would break the primary dev command. Gated to one Python
-      # version: src/protean has no version-conditional code, so every leg's
-      # coverage is equivalent, and a single check avoids per-leg flake.
-      # `success() &&` is required: a custom `if` drops the implicit success guard,
-      # so without it this step would run even after the test step failed (when no
-      # merged `.coverage` exists) and report a confusing "no data" error.
-      # Gated to the FULL leg: it is the only per-PR leg that exercises the
-      # adapters, so it is the only one whose coverage reaches the full-suite
-      # figure the threshold assumes (the CORE legs sit well below it).
-      - name: Enforce coverage floor
-        if: success() && matrix.suite == 'full'
-        run: uv run coverage report --fail-under=94
-
-      # Upload coverage only from the FULL leg; the CORE legs' in-memory-only
-      # coverage would drag the merged report below the real figure.
-      - name: CodeCOV
-        if: (success() || failure()) && matrix.suite == 'full'
-        uses: codecov/codecov-action@v7.0.0
-        with:
-          files: coverage.xml
-          token: ${{ secrets.CODECOV_TOKEN }}
+          full: ${{ matrix.full }}
+          resolution: ${{ matrix.resolution }}
+          # Enforce + upload coverage only from the FULL adapter leg (the only
+          # per-PR leg that reaches the full-suite figure the threshold assumes).
+          enforce-coverage: ${{ matrix.full && matrix.resolution == 'highest' }}
+          upload-coverage: ${{ matrix.full && matrix.resolution == 'highest' }}
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   mypy:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,83 @@
+name: Nightly
+
+# The full `-c FULL` adapter suite across every supported Python. Per-PR CI runs
+# the adapter suite only on the newest Python (ci.yml) to keep PRs cheap; this
+# nightly run is where a version-specific adapter regression on 3.11-3.13 (or a
+# floor that only breaks against a real service) is caught. On failure the
+# `notify` job opens or updates a `ci-failure` issue so a red scheduled run is
+# visible without anyone watching the Actions tab.
+on:
+  schedule:
+    # 06:00 UTC daily. Adjust freely; scheduled runs only fire on the default branch.
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: nightly
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { python-version: "3.11", resolution: highest }
+          - { python-version: "3.12", resolution: highest }
+          - { python-version: "3.13", resolution: highest }
+          - { python-version: "3.14", resolution: highest }
+          # Adapter floors against real services, on the newest Python.
+          - { python-version: "3.14", resolution: lowest-direct }
+    name: ${{ matrix.resolution == 'lowest-direct' && format('Python {0} Full (lowest-direct)', matrix.python-version) || format('Python {0} Full', matrix.python-version) }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - uses: ./.github/actions/test-suite
+        with:
+          python-version: ${{ matrix.python-version }}
+          full: true
+          resolution: ${{ matrix.resolution }}
+
+  notify:
+    name: Report nightly failure
+    needs: test
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update the ci-failure issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          # Ensure the label exists (idempotent: --force also updates color/desc).
+          gh label create ci-failure --color B60205 \
+            --description "Automated: a scheduled CI run failed" --force >/dev/null 2>&1 || true
+
+          now="$(date -u '+%Y-%m-%d %H:%M UTC')"
+
+          # Reuse a single open issue rather than filing one every night.
+          existing="$(gh issue list --repo "$REPO" --label ci-failure --state open \
+            --json number,title \
+            --jq 'map(select(.title == "Nightly CI is failing")) | .[0].number // empty')"
+
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$REPO" \
+              --body "Still failing as of $now. Run: $RUN_URL"
+            echo "Commented on existing issue #$existing"
+          else
+            gh issue create --repo "$REPO" --title "Nightly CI is failing" --label ci-failure \
+              --body "$(printf 'The nightly full adapter matrix failed.\n\n- First seen: %s\n- Run: %s\n\nA `Python X Full` leg went red. This catches adapter regressions on the Python versions that per-PR CI exercises in-memory only, and floors that only break against a real service. Close this issue once the run is green again.' "$now" "$RUN_URL")"
+            echo "Opened a new ci-failure issue"
+          fi


### PR DESCRIPTION
## Why

Follow-up to #1227. That PR cut per-PR CI cost by running the full `-c FULL` adapter suite only on the newest Python and the fast in-memory CORE suite on the others. The trade was that a version-specific adapter regression on 3.11-3.13 would no longer be caught at PR time. This PR adds the safety net: a nightly full matrix on `main`, plus the shared setup and the leg renames you asked for.

## What changed

**Composite action (`.github/actions/test-suite`).** The service setup, install, and test steps now live in one composite action that both the per-PR CI and the nightly run call. This is a composite action rather than a reusable `workflow_call` on purpose: a called workflow prefixes its status-check name as `caller / job (matrix)`, which would break the exact branch-protection contexts (`Python 3.14 Tests`, `Python 3.14 Full`). A composite action keeps the job in the caller, so the caller owns the check name.

**Nightly run (`.github/workflows/nightly.yml`).** Runs `-c FULL` across every supported Python plus one lowest-direct FULL leg on 3.14, daily at 06:00 UTC (and on manual dispatch). On failure, a `notify` job opens or updates a single `ci-failure` issue with a link to the run, so a red scheduled run is visible without anyone watching the Actions tab. It reuses one open issue rather than filing one every night.

**3.14 leg renames.** The lowest-direct leg is now `Python 3.14 Tests`, and the FULL adapter leg is `Python 3.14 Full`.

## Action required after merge

- **Add `Python 3.14 Full` to the branch-protection required status checks.** The rename moves the adapter suite off the `Python 3.14 Tests` context, so without this it stops gating merges (a PR could go green with the adapter suite red). The four `Python X Tests` contexts still report and still match, so nothing is left waiting.
- The nightly cannot run before it is on `main` (GitHub only allows `workflow_dispatch` from the default branch), so its first run is the first post-merge schedule. You can also trigger it manually from the Actions tab once merged to confirm it end to end.

## Validation

The composite action is exercised by this PR's own CI: the three CORE legs and the `Python 3.14 Full` leg all call it, so both the in-memory and the full-adapter paths run here. The nightly is a thin caller of the same action.
