### PR TITLE
docs: reframe the community page around the single-maintainer model

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ you. The contributions below are genuinely valuable and actively wanted.
    through a public port contract and are verified by a conformance suite.
    Adapters live in their own packages, owned by their authors, rather than in
    the core. See
-   [Building Adapters](https://docs.proteanhq.com/community/contributing/adapters/).
+   [Building Adapters](https://docs.proteanhq.com/reference/adapters/building-adapters/).
 4. **Improve documentation.** Corrections and clarifications are welcome, and
    small doc fixes can go straight to a pull request.
 

--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -41,56 +41,49 @@ Click on the "watch" button at the top right in
 You will then receive notifications (in your email) whenever there's a new
 release (a new version) of Protean with bug fixes and new features.
 
-## Contribute to Protean
+## Contributing
 
-Protean is developed and maintained by a single maintainer, so the
-contributions that help most are bug reports, real-world use cases, and
-adapters. Here are the ways you can get involved:
+Protean is designed and maintained by a single maintainer, from one coherent
+view of the whole framework. This is a deliberate choice that keeps the design
+consistent and the correctness bar high. It does **not** mean the project is
+closed to you: the contributions below are genuinely valued.
 
-### Report issues
+### Report bugs
 
-Found a bug or want to suggest a new feature? You can report issues and feature
-requests on our [GitHub Issues](https://github.com/proteanhq/protean/issues)
-page. When reporting an issue, please include as much detail as possible to
-help us understand and resolve the problem quickly.
+A clear, reproducible bug report is the single most useful thing you can send.
+Real-world failure cases are how a framework earns its correctness. File bugs
+and feature requests on
+[GitHub Issues](https://github.com/proteanhq/protean/issues) with enough detail
+to reproduce the problem.
 
-### Contribute code
+### Share use cases and feedback
 
-Small, obvious fixes (typos, docstrings, a clearly correct one-line bug fix)
-are welcome directly as pull requests. For anything larger, such as a new
-feature, a behavioral change, or a refactor, please open an issue to discuss
-the approach first. Unsolicited large pull requests may not be merged, so
-starting with an issue saves everyone's time. See
-[CONTRIBUTING](https://github.com/proteanhq/protean/blob/main/CONTRIBUTING.md)
-for the full picture, and [set up Protean locally](./contributing/setup.md)
-once you are ready.
+Tell us where Protean fits your domain awkwardly, where an abstraction leaks, or
+where the docs mislead you. Open a
+[Discussion](https://github.com/proteanhq/protean/discussions) or an issue.
 
-### Triage Issues
+### Build adapters
 
-Help us manage and triage issues by labeling and categorizing them.
-This helps us prioritize and address the most critical issues effectively.
-You can start by browsing the
-[existing issues](https://github.com/proteanhq/protean/issues) and offering
-your input.
+Databases, brokers, event stores, and caches plug in through a public port
+contract and are verified by a conformance suite. Adapters live in their own
+packages, owned by their authors, rather than in the core, so you can extend
+Protean without touching it. See
+[Building Adapters](../reference/adapters/building-adapters.md) to get started.
 
-### Add Adapters
+### Improve documentation
 
-Protean is designed to be flexible and extensible. You can contribute by
-developing and adding new adapters to support various use cases and
-integrations. Check out [our guide](./contributing/adapters.md) on creating
-adapters to get started.
+Corrections and clarifications are welcome, and small doc fixes can go straight
+to a pull request.
 
-### Improve Documentation
+### Spread the word
 
-Good documentation is crucial for Protean's success. You can help by improving
-existing documentation, adding new tutorials, or creating examples that
-demonstrate how to use Protean effectively.
+Sharing your experience, writing about Protean, or speaking at events all help
+others discover the framework.
 
-Documentation contributions are highly valued and can be made directly to the
-Github repository.
+---
 
-### Spread the Word
-
-Help us grow the Protean community by sharing your experiences, writing blog
-posts, and speaking at events. Every mention helps to increase the visibility
-and adoption of Protean.
+**How code contributions are handled.** Small, obvious fixes are welcome
+directly as pull requests. Anything larger should start with an issue so the
+approach can be agreed first; unsolicited large pull requests may not be merged.
+The full policy, including the bar for AI-assisted pull requests, is in
+[CONTRIBUTING](https://github.com/proteanhq/protean/blob/main/CONTRIBUTING.md).

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -429,4 +429,4 @@ Design reasoning and internal architecture for contributors and advanced users.
 - [Development Setup](./community/contributing/setup.md) -- Set up Protean locally for contributing.
 - [Testing Protean](./community/contributing/testing.md) -- Test strategy, fixtures, and running the suite.
 - [Mutation Testing](./community/contributing/mutation-testing.md) -- Find under-asserted code paths with `make mutation` and close them with new tests.
-- [Building Adapters](./community/contributing/adapters.md) -- Overview of creating custom adapters for databases, brokers, event stores, and caches with links to per-port guides.
+- [Building Adapters](./reference/adapters/building-adapters.md) -- Overview of creating custom adapters for databases, brokers, event stores, and caches with links to per-port guides.

--- a/docs/guides/compose-a-domain/choosing-adapters.md
+++ b/docs/guides/compose-a-domain/choosing-adapters.md
@@ -226,4 +226,4 @@ see [Dual-Mode Testing](../../patterns/dual-mode-testing.md).
 - [Dual-Mode Testing](../../patterns/dual-mode-testing.md) — Running the same suite against memory and real adapters.
 - [Using the Outbox](../server/outbox.md) — Reliable event publishing over the broker port.
 - [Event Store Setup](../change-state/event-store-setup.md) — Detailed event store configuration and operations.
-- [Custom Adapters](../../community/contributing/adapters.md) — Writing your own for ports the built-in adapters don't cover.
+- [Custom Adapters](../../reference/adapters/building-adapters.md) — Writing your own for ports the built-in adapters don't cover.

--- a/docs/reference/adapters/building-adapters.md
+++ b/docs/reference/adapters/building-adapters.md
@@ -25,7 +25,7 @@ Each adapter package provides:
 Database adapters implement the `BaseProvider` interface and declare their
 capabilities through the `DatabaseCapabilities` flag system.
 
-See [Building Custom Database Adapters](../../reference/adapters/database/custom-databases.md)
+See [Building Custom Database Adapters](./database/custom-databases.md)
 for a complete guide with a worked DynamoDB example, including:
 
 - The five components to implement (Provider, DAO, DatabaseModel, Lookups,
@@ -39,7 +39,7 @@ for a complete guide with a worked DynamoDB example, including:
 Broker adapters implement the `BaseBroker` interface and declare their
 capabilities through the `BrokerCapabilities` tier system.
 
-See [Building Custom Brokers](../../reference/adapters/broker/custom-brokers.md)
+See [Building Custom Brokers](./broker/custom-brokers.md)
 for a complete guide with a worked Kafka example, including:
 
 - Required abstract methods
@@ -64,7 +64,7 @@ during development and in CI:
 protean test test-adapter --provider=your-adapter-name
 ```
 
-See [Adapter Conformance Testing](../../reference/testing/conformance.md) for
+See [Adapter Conformance Testing](../testing/conformance.md) for
 the full reference.
 
 ## Getting Help

--- a/docs/reference/adapters/index.md
+++ b/docs/reference/adapters/index.md
@@ -82,7 +82,7 @@ Current Implementations:
 
 !!!tip "Build your own"
     All adapter types support third-party extensions via Python entry points.
-    See [Building Adapters](../../community/contributing/adapters.md) for an
+    See [Building Adapters](./building-adapters.md) for an
     overview, or jump directly to
     [Custom Database Adapters](./database/custom-databases.md) or
     [Custom Brokers](./broker/custom-brokers.md) for detailed guides.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -349,6 +349,7 @@ nav:
       - reference/server/hardening.md
     - Adapters:
       - reference/adapters/index.md
+      - Building Adapters: reference/adapters/building-adapters.md
       - Database:
         - reference/adapters/database/index.md
         - reference/adapters/database/memory.md
@@ -552,9 +553,8 @@ nav:
 
   - Community:
     - community/index.md
-    - Contributing:
+    - Developer setup:
       - community/contributing/setup.md
       - community/contributing/testing.md
       - community/contributing/mutation-testing.md
-      - community/contributing/adapters.md
     - Quality Report: community/quality.md


### PR DESCRIPTION
## Why

The community page (`docs/community/`) read as an open invitation to contribute code, triage issues, and generally help run the project. That is out of step with the single-maintainer development model the repo already states plainly in `CONTRIBUTING.md`. The page was setting an expectation the project does not fulfil, which wastes contributors' effort and reads as inconsistent. This aligns the public page with the actual stance.

I chose to reframe rather than hide the page: hiding it would also remove the parts a solo-maintained, adoption-led project genuinely wants (bug reports, feature requests, adapter-building, the quality report), and a hidden-but-live page is just stale. The GitHub-side surfaces (`CONTRIBUTING.md`, README) are the real levers for contribution policy anyway; this makes the docs agree with them.

## What changed

- **Reframed the contribution section of `docs/community/index.md`.** It now leads with how Protean is developed (single maintainer) and lists the genuinely-valued contributions: report bugs, share use cases and feedback, build adapters, small doc fixes. The **"Triage Issues"** call to action is removed. Code contributions are folded into a single pointer to `CONTRIBUTING.md` (which already carries the full gated policy, including the AI-assisted-PR bar) instead of a standalone "contribute code" invite. Forum, star/watch, and quality report are kept.
- **Moved "Building Adapters" out of Community into Reference/Adapters** (`docs/reference/adapters/building-adapters.md`). Adapters live in their own packages and are a user extension, not a core contribution, so they belong with the rest of the adapter reference. All cross-references updated (`CONTRIBUTING.md`, `reference/adapters/index.md`, `contents.md`, `choosing-adapters.md`, and the page's own internal links).
- **Renamed the Community "Contributing" nav subsection to "Developer setup."** That subsection holds the setup/testing/mutation-testing guides, which are developer-environment docs, not a contribution invite. (I did not name it "Contribution policy" as first floated, because it is not policy; the policy lives on the index page and in `CONTRIBUTING.md`.)

## Validation

`mkdocs build` is clean: exit 0, no broken-link or nav warnings. The moved page renders at `reference/adapters/building-adapters/` and the old `community/contributing/adapters/` path is gone.
