### PR TITLE
Add a queryable behavioral view over the check analysis substrate

### DIFF
--- a/changes/1224.added.md
+++ b/changes/1224.added.md
@@ -1,0 +1,1 @@
+Added a queryable `BehavioralView` over the `protean check` source-analysis substrate, giving diagnostic rules one read-only façade for an element's methods, per-method behavioral facts, and intra-procedural dataflow (plus a `filter_call_sites` convenience), all over the builder's single parsed-source provider. Internal API.

--- a/docs/concepts/protean-check/behavioral-analysis.md
+++ b/docs/concepts/protean-check/behavioral-analysis.md
@@ -49,21 +49,32 @@ parsed again for its facts or its dataflow — one parse per run.
 ## A rule reading the view
 
 A diagnostic rule receives the view the way it receives the IR: as `self.view`,
-a lazily-built property on the builder. On top of the three families the view
-offers one convenience, `filter_call_sites(cls)`, which enumerates a repository's
-`filter` call-sites and the fields each filters on:
+a lazily-built property on the builder. Every rule is a `_diagnose_*(self, ir)`
+method that appends findings to `self._diagnostics`. On top of the three families
+the view offers one convenience, `filter_call_sites(cls)`, which enumerates a
+repository's `filter` call-sites and the fields each filters on:
 
 ```python
-def _diagnose_unindexed_filters(self, cls, indexed_fields):
+def _diagnose_unindexed_filters(self, ir):
     """Flag a repository filter on a field that carries no index."""
-    for site in self.view.filter_call_sites(cls):
-        for field in site.field_names:
-            if field not in indexed_fields:
-                self._emit(
-                    "UNINDEXED_FILTER",
-                    location=site.location,
-                    detail=f"{site.method_name} filters on unindexed {field!r}",
-                )
+    # Walking `ir` for each repository class and its indexed fields is elided
+    # here; the point is how the rule reads the view, then emits.
+    for cls, indexed_fields in repositories_and_indexes(ir):
+        for site in self.view.filter_call_sites(cls):
+            for field in site.field_names:
+                if field not in indexed_fields:
+                    self._diagnostics.append(
+                        {
+                            "code": "UNINDEXED_FILTER",
+                            "category": "performance",
+                            "element": f"{cls.__module__}.{cls.__qualname__}",
+                            "level": "warning",
+                            "message": (
+                                f"`{site.method_name}` filters on "
+                                f"`{field}`, which carries no index."
+                            ),
+                        }
+                    )
 ```
 
 The rule never reaches into `FactCatalog` or `ElementIndex` internals to assemble

--- a/docs/concepts/protean-check/behavioral-analysis.md
+++ b/docs/concepts/protean-check/behavioral-analysis.md
@@ -1,0 +1,72 @@
+# Behavioral analysis
+
+`protean check` reasons about a domain in two ways. Most rules read the
+**Intermediate Representation** (IR) — the structural model of aggregates,
+fields, handlers and flows. A smaller set of rules needs to know what a method
+*body* does: which fields it filters on, what it raises, how a name flows from
+one statement to the next. Those questions are answered by the **behavioral
+analysis substrate**, a stack of read-only layers over the domain's parsed
+source.
+
+!!! note "Internal API"
+    The substrate is machinery for Protean's own diagnostic rules. Nothing in
+    `protean.ir.analysis` is re-exported from `protean` or `protean.ir`, and its
+    shape is not a public contract. This page explains how the rules see it, not
+    an interface to build on.
+
+## The layers
+
+Each layer builds on the one below it, and every layer **fails open**: a class
+with no source, or a body it cannot analyze, yields an empty result rather than
+raising, so one unreadable module never aborts a diagnostics pass.
+
+| Layer | What it answers |
+|-------|-----------------|
+| `SourceProvider` | Parse a module to an `ast.Module`, once, cached. |
+| `ElementIndex` | Which classes and methods exist, and each method's role. |
+| `SymbolResolver` | What fully-qualified name does a name or attribute chain resolve to? |
+| `FactCatalog` | What does one method body do — its calls, attribute reads/writes, and constructions? |
+| `DataflowAnalyzer` | How do names and blocks flow inside one body — def-use, ordering, `with`/loop coverage? |
+
+## The view
+
+A rule rarely wants a single layer. To flag an unindexed filter it needs the
+element's methods (index), each method's facts (catalog) and, sometimes, the
+dataflow behind a receiver (analyzer). `BehavioralView` is the top layer: a
+read-only façade that a rule asks instead of wiring the layers together itself.
+
+The view groups the substrate into three query families:
+
+- **elements → methods** — `element_class_entry(cls)`, `element_methods(cls)`.
+- **per-method facts** — `element_facts(cls)` (name → `MethodFacts`),
+  `method_facts(module, node)`.
+- **dataflow** — `method_flow(module, node)` → `MethodFlow`.
+
+A single view is built once per `IRBuilder` and shares that build's one
+`SourceProvider` and `ElementIndex`, so a module a rule already read is not
+parsed again for its facts or its dataflow — one parse per run.
+
+## A rule reading the view
+
+A diagnostic rule receives the view the way it receives the IR: as `self.view`,
+a lazily-built property on the builder. On top of the three families the view
+offers one convenience, `filter_call_sites(cls)`, which enumerates a repository's
+`filter` call-sites and the fields each filters on:
+
+```python
+def _diagnose_unindexed_filters(self, cls, indexed_fields):
+    """Flag a repository filter on a field that carries no index."""
+    for site in self.view.filter_call_sites(cls):
+        for field in site.field_names:
+            if field not in indexed_fields:
+                self._emit(
+                    "UNINDEXED_FILTER",
+                    location=site.location,
+                    detail=f"{site.method_name} filters on unindexed {field!r}",
+                )
+```
+
+The rule never reaches into `FactCatalog` or `ElementIndex` internals to assemble
+that answer; it asks the view, and the view's determinism (methods in name order,
+call-sites in source order) means the same source always produces the same
+findings in the same order.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -465,6 +465,7 @@ nav:
       - concepts/internals/event-upcasting.md
       - concepts/internals/ir-specification.md
     - Architecture Checks:
+      - concepts/protean-check/behavioral-analysis.md
       - concepts/protean-check/rules/unbounded-indexed-string.md
 
   - Patterns & Recipes:

--- a/src/protean/ir/analysis/__init__.py
+++ b/src/protean/ir/analysis/__init__.py
@@ -32,9 +32,11 @@ from protean.ir.analysis.facts import (
 )
 from protean.ir.analysis.source_provider import SourceProvider
 from protean.ir.analysis.symbols import SymbolResolver
+from protean.ir.analysis.view import BehavioralView, FilterCallSite
 
 __all__ = [
     "AttributeFact",
+    "BehavioralView",
     "BlockCoverage",
     "CallFact",
     "ClassEntry",
@@ -44,6 +46,7 @@ __all__ = [
     "Definition",
     "ElementIndex",
     "FactCatalog",
+    "FilterCallSite",
     "MethodEntry",
     "MethodFacts",
     "MethodFlow",

--- a/src/protean/ir/analysis/view.py
+++ b/src/protean/ir/analysis/view.py
@@ -75,10 +75,11 @@ if TYPE_CHECKING:
     from protean.ir.analysis.element_index import ClassEntry, FunctionNode, MethodEntry
     from protean.ir.analysis.facts import MethodFacts
 
-#: The repository-query method whose call-sites :meth:`~BehavioralView.filter_
-#: call_sites` reports. ``filter`` is the ``QuerySet`` surface a rule reads to
-#: see which fields an element filters on; the other query methods
-#: (``find``/``get``/...) are recognized by the catalog but are not "filters".
+#: The repository-query method whose call-sites
+#: :meth:`~BehavioralView.filter_call_sites` reports. ``filter`` is the
+#: ``QuerySet`` surface a rule reads to see which fields an element filters
+#: on; the other query methods (``find``/``get``/...) are recognized by the
+#: catalog but are not "filters".
 _FILTER_METHOD = "filter"
 
 

--- a/src/protean/ir/analysis/view.py
+++ b/src/protean/ir/analysis/view.py
@@ -93,8 +93,10 @@ class FilterCallSite:
 
     #: The name of the element method the ``filter`` call is written in.
     method_name: str
-    #: The keyword field names the ``filter`` passes, in source order. Empty for
-    #: a ``**kwargs`` filter, which names no field statically.
+    #: The keyword field names the ``filter`` passes, in source order, plus any
+    #: names from an inline ``Q(field=...)``. A ``**kwargs`` star contributes
+    #: none, so this is empty for a purely dynamic ``filter(**kwargs)``. Carried
+    #: through unchanged from the underlying :class:`~protean.ir.analysis.facts.CallFact`.
     field_names: tuple[str, ...]
     location: SourceLocation
 

--- a/src/protean/ir/analysis/view.py
+++ b/src/protean/ir/analysis/view.py
@@ -1,0 +1,207 @@
+"""A queryable behavioral view for ``protean check`` diagnostic rules.
+
+:class:`BehavioralView` is the sixth and top layer of the ``protean check``
+behavioral substrate. The five below it turn a domain into parsed trees
+(:class:`~protean.ir.analysis.source_provider.SourceProvider`), a class/method
+index (:class:`~protean.ir.analysis.element_index.ElementIndex`), a name
+resolver (:class:`~protean.ir.analysis.symbols.SymbolResolver`), per-method
+behavioral facts (:class:`~protean.ir.analysis.facts.FactCatalog`) and
+intra-procedural dataflow
+(:class:`~protean.ir.analysis.dataflow.DataflowAnalyzer`). This one adds no
+analysis of its own: it is a read-only façade that gives a ``_diagnose_*`` rule
+one object to ask, so a rule reaches an answer through the view rather than by
+wiring the five layers together itself.
+
+Internal API. Nothing here is re-exported from ``protean`` or ``protean.ir``.
+
+Three query families, plus one convenience
+------------------------------------------
+The view groups the substrate the way a behavioral rule reads it:
+
+- **elements → methods** — :meth:`element_class_entry` and :meth:`element_methods`
+  answer "what are this element's methods?", straight from the index.
+- **per-method facts** — :meth:`element_facts` (name → :class:`MethodFacts`) and
+  :meth:`method_facts` answer "what does this method body do?", from the catalog.
+- **dataflow** — :meth:`method_flow` answers "how do names and blocks flow inside
+  this body?", from the analyzer.
+
+On top of those, :meth:`filter_call_sites` is the one ergonomic convenience the
+epic's acceptance test names directly: an element's repository ``filter``
+call-sites and the fields each filters on, built from the first two families so a
+rule never reaches into :class:`FactCatalog`/:class:`ElementIndex` internals to
+assemble it.
+
+One parse per run
+-----------------
+The view owns one resolver, one catalog and one analyzer, all built over the
+**same** provider and index it is given — the builder's, when the builder
+constructs it — so a module a rule already read through the index is not parsed a
+second time for its facts or its dataflow. Passing a provider and index in is how
+that sharing is guaranteed; omit them and the view builds fresh ones, which is
+only right for a standalone view with no builder to share with.
+
+Contracts
+---------
+- **Fail open.** Every query delegates to a layer that fails open — an element
+  with no source yields empty methods, empty facts and an empty
+  :class:`MethodFlow`, never a raise — so the view fails open too, adding no IO
+  or lookup of its own that could throw.
+- **Deterministic.** The view introduces no ordering: each family's order is the
+  layer's (methods and facts by name, facts within a method by ``(line, col)``),
+  and :meth:`filter_call_sites` preserves it, enumerating methods in name order
+  and call-sites within a method in source order.
+- **Read-only.** The nodes and facts handed back belong to the provider's cached
+  trees and the layers' caches; a rule must treat them as immutable, as it must
+  with the layers directly.
+- **Single-threaded.** One view per :class:`~protean.ir.builder.IRBuilder`,
+  sharing that build's provider and index; give each thread its own, as with
+  every layer below it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from protean.ir.analysis.dataflow import DataflowAnalyzer
+from protean.ir.analysis.element_index import ElementIndex
+from protean.ir.analysis.facts import FactCatalog, ReceiverRole, SourceLocation
+from protean.ir.analysis.source_provider import SourceProvider
+from protean.ir.analysis.symbols import SymbolResolver
+
+if TYPE_CHECKING:
+    from protean.domain import Domain
+    from protean.ir.analysis.dataflow import MethodFlow
+    from protean.ir.analysis.element_index import ClassEntry, FunctionNode, MethodEntry
+    from protean.ir.analysis.facts import MethodFacts
+
+#: The repository-query method whose call-sites :meth:`~BehavioralView.filter_
+#: call_sites` reports. ``filter`` is the ``QuerySet`` surface a rule reads to
+#: see which fields an element filters on; the other query methods
+#: (``find``/``get``/...) are recognized by the catalog but are not "filters".
+_FILTER_METHOD = "filter"
+
+
+@dataclass(frozen=True, slots=True)
+class FilterCallSite:
+    """One repository ``filter`` call inside an element's method.
+
+    Assembled by :meth:`BehavioralView.filter_call_sites` from the element's
+    per-method facts, so a rule gets the enclosing method, the fields the call
+    filters on, and where it is, without touching the catalog.
+    """
+
+    #: The name of the element method the ``filter`` call is written in.
+    method_name: str
+    #: The keyword field names the ``filter`` passes, in source order. Empty for
+    #: a ``**kwargs`` filter, which names no field statically.
+    field_names: tuple[str, ...]
+    location: SourceLocation
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return f"<FilterCallSite {self.method_name} line {self.location.line}>"
+
+
+class BehavioralView:
+    """A read-only façade over the behavioral substrate, for diagnostic rules.
+
+    One view per :class:`~protean.ir.builder.IRBuilder`, sharing that builder's
+    provider and index so the modules a rule already read are not parsed again
+    for its facts or dataflow. Each underlying layer computes on first request
+    and caches, so a build whose rules never ask the view pays nothing.
+    """
+
+    def __init__(
+        self,
+        domain: Domain,
+        provider: SourceProvider | None = None,
+        index: ElementIndex | None = None,
+    ) -> None:
+        self._domain = domain
+        self._provider = provider if provider is not None else SourceProvider(domain)
+        self._index = (
+            index if index is not None else ElementIndex(domain, self._provider)
+        )
+        # One resolver, shared by the catalog and the analyzer, so a module's
+        # symbol table is built once for both.
+        self._resolver = SymbolResolver(domain, self._provider)
+        self._facts = FactCatalog(domain, self._provider, self._index, self._resolver)
+        self._dataflow = DataflowAnalyzer(domain, self._provider, self._resolver)
+
+    # ------------------------------------------------------------------
+    # Elements → methods
+    # ------------------------------------------------------------------
+
+    def element_class_entry(self, cls: type) -> ClassEntry | None:
+        """The indexed class for ``cls``, or ``None`` (fail open).
+
+        ``None`` when the class has no source, no resolvable module, or a
+        qualname the index cannot pin — the same conditions the index reports it
+        under.
+        """
+        return self._index.element_class_entry(cls)
+
+    def element_methods(self, cls: type) -> tuple[MethodEntry, ...]:
+        """The methods of ``cls`` as written, sorted by name.
+
+        Empty for a class the index cannot resolve; a rule may loop over the
+        result without a guard.
+        """
+        return self._index.element_methods(cls)
+
+    # ------------------------------------------------------------------
+    # Per-method facts
+    # ------------------------------------------------------------------
+
+    def element_facts(self, cls: type) -> dict[str, MethodFacts]:
+        """Every method of ``cls``, name → its :class:`MethodFacts`.
+
+        In method-name order, empty for an element the index cannot resolve.
+        Delegates to the shared catalog, so facts a rule already asked for are
+        served from its cache.
+        """
+        return self._facts.element_facts(cls)
+
+    def method_facts(self, module: str, method: FunctionNode) -> MethodFacts:
+        """The facts of one method body, by its module name and node.
+
+        For a rule holding a method node (from :meth:`element_methods` or the
+        index) that wants that one body's facts without the whole element map.
+        """
+        return self._facts.method_facts(module, method)
+
+    # ------------------------------------------------------------------
+    # Dataflow
+    # ------------------------------------------------------------------
+
+    def method_flow(self, module: str, method: FunctionNode) -> MethodFlow:
+        """The intra-procedural dataflow of one method body.
+
+        The :class:`MethodFlow` answers def-use, statement ordering and
+        ``with``/loop coverage for names inside ``method``'s body. An
+        unanalyzable body yields an empty flow, never a raise.
+        """
+        return self._dataflow.analyze(module, method)
+
+    # ------------------------------------------------------------------
+    # Convenience
+    # ------------------------------------------------------------------
+
+    def filter_call_sites(self, cls: type) -> tuple[FilterCallSite, ...]:
+        """Every repository ``filter`` call written in ``cls``'s methods.
+
+        For each method of ``cls`` (in name order), the ``filter`` calls whose
+        receiver the catalog recognized as a repository query
+        (:attr:`ReceiverRole.REPOSITORY_QUERY`), each carrying the fields it
+        filters on. Empty for an element with no such call-site or no source.
+        This is the ergonomic parity the issue asks for: a rule that checks
+        filtered fields gets them from the view, never by walking
+        :class:`MethodFacts` itself.
+        """
+        return tuple(
+            FilterCallSite(method_name, call.field_names, call.location)
+            for method_name, facts in self.element_facts(cls).items()
+            for call in facts.calls
+            if call.method == _FILTER_METHOD
+            and call.receiver_role is ReceiverRole.REPOSITORY_QUERY
+        )

--- a/src/protean/ir/builder.py
+++ b/src/protean/ir/builder.py
@@ -31,7 +31,7 @@ from protean.fields.embedded import ValueObject
 from protean.fields.resolved import ResolvedField
 from protean.fields.spec import _UNSET
 from protean.ir import SCHEMA_VERSION
-from protean.ir.analysis import ElementIndex, SourceProvider
+from protean.ir.analysis import BehavioralView, ElementIndex, SourceProvider
 from protean.ir.constants import VOLATILE_IR_KEYS
 from protean.utils import fqn
 from protean.utils.container import Element, OptionsMixin
@@ -177,6 +177,7 @@ class IRBuilder:
         self._diagnostics: list[dict[str, Any]] = []
         self._source: SourceProvider | None = None
         self._index: ElementIndex | None = None
+        self._view: BehavioralView | None = None
 
     @property
     def source(self) -> SourceProvider:
@@ -204,6 +205,21 @@ class IRBuilder:
         if self._index is None:
             self._index = ElementIndex(self._domain, self.source)
         return self._index
+
+    @property
+    def view(self) -> BehavioralView:
+        """Queryable behavioral view over the parsed sources, for rules.
+
+        One view per builder, sharing this builder's :attr:`source` provider and
+        :attr:`index`, so the modules a rule already read are not parsed again
+        for their facts or dataflow. It is the single object a ``_diagnose_*``
+        rule asks for method-level facts and flow, the way it reads the IR —
+        created on first use, and each layer under it stays lazy, so a build
+        whose rules never ask for it costs nothing.
+        """
+        if self._view is None:
+            self._view = BehavioralView(self._domain, self.source, self.index)
+        return self._view
 
     # ------------------------------------------------------------------
     # Public API

--- a/tests/ir/analysis/test_view.py
+++ b/tests/ir/analysis/test_view.py
@@ -1,0 +1,193 @@
+"""BehavioralView: the three query families, the filter convenience, sharing.
+
+The view is a read-only façade over the five substrate layers. These tests prove
+it surfaces each family (elements → methods, per-method facts, dataflow), that
+its ``filter_call_sites`` convenience returns the exact fields an element filters
+on, that it reuses the builder's one provider/index (a module is parsed once),
+and that it fails open on a class with no source. The behavior corpus is
+registered as a real domain so a construction resolves and a repository query is
+recognized, exactly as the fact-catalog tests do.
+"""
+
+import pytest
+
+import protean
+import protean.ir
+from protean import Domain
+from protean.ir.analysis import (
+    BehavioralView,
+    ElementIndex,
+    FilterCallSite,
+    ReceiverRole,
+    SourceProvider,
+)
+from protean.ir.analysis.dataflow import MethodFlow
+from protean.ir.builder import IRBuilder
+from tests.ir.support import behavioral_domain
+from tests.ir.support.behavioral_domain import behavior
+
+pytestmark = pytest.mark.no_test_domain
+
+#: The behavior module under the name Python resolves it by — the name whose
+#: FQNs match what the registry recorded, which a package walk's name does not.
+BEHAVIOR_MODULE = behavior.__name__
+
+PACKAGE_ROOT = str(behavioral_domain.__file__).rsplit("/", 1)[0]
+
+
+@pytest.fixture(scope="module")
+def order_domain():
+    """The behavior fixture registered as a real domain."""
+    domain = Domain(name="ViewBehavioral", root_path=PACKAGE_ROOT)
+    domain.register(behavior.Order)
+    domain.register(behavior.OrderShipped, part_of=behavior.Order)
+    domain.register(behavior.OrderRepository, part_of=behavior.Order)
+    domain.init(traverse=False)
+    return domain
+
+
+@pytest.fixture(scope="module")
+def view(order_domain):
+    """A view built the way a builder builds it, over its own provider/index."""
+    return IRBuilder(order_domain).view
+
+
+class TestElementsToMethods:
+    def test_element_methods_returns_the_written_methods(self, view):
+        """The first family: an element's methods, straight from the index."""
+        methods = view.element_methods(behavior.OrderRepository)
+
+        assert len(methods) > 0, "OrderRepository must have indexed methods"
+        names = {method.name for method in methods}
+        assert {"active", "by_reference", "dynamic", "seed"} <= names
+
+    def test_element_class_entry_is_the_indexed_class(self, view):
+        entry = view.element_class_entry(behavior.OrderRepository)
+
+        assert entry is not None
+        assert entry.qualname == "OrderRepository"
+        assert entry.module == BEHAVIOR_MODULE
+
+
+class TestPerMethodFacts:
+    def test_element_facts_maps_names_to_facts(self, view):
+        """The second family: name -> MethodFacts, from the catalog."""
+        facts = view.element_facts(behavior.OrderRepository)
+
+        assert set(facts) >= {"active", "by_reference", "dynamic"}
+        query = next(c for c in facts["active"].calls if c.method == "filter")
+        assert query.receiver_role is ReceiverRole.REPOSITORY_QUERY
+        assert query.field_names == ("status",)
+
+    def test_method_facts_by_node_matches_the_element_map(self, view):
+        """A method node fetched from the index gives the same facts."""
+        entry = view.element_class_entry(behavior.OrderRepository)
+        node = entry.method("active").node
+
+        by_node = view.method_facts(entry.module, node)
+        by_element = view.element_facts(behavior.OrderRepository)["active"]
+
+        assert by_node == by_element
+        assert len(by_node.calls) > 0
+
+
+class TestFilterCallSites:
+    def test_filter_call_sites_reports_each_site_and_its_fields(self, view):
+        """The headline convenience: the element's ``filter`` sites and fields.
+
+        ``active`` filters on ``status``; ``dynamic`` filters on ``**filters`` so
+        names no field. ``by_reference`` uses ``find``, not ``filter``, so it is
+        not a filter call-site.
+        """
+        sites = view.filter_call_sites(behavior.OrderRepository)
+
+        assert len(sites) > 0, "OrderRepository has filter call-sites"
+        for site in sites:
+            assert isinstance(site, FilterCallSite)
+        pairs = {(site.method_name, site.field_names) for site in sites}
+        assert pairs == {("active", ("status",)), ("dynamic", ())}
+
+    def test_filter_call_sites_carry_a_location(self, view):
+        """Each site names where it is, so a rule can report the finding there."""
+        sites = view.filter_call_sites(behavior.OrderRepository)
+        active = next(s for s in sites if s.method_name == "active")
+
+        assert active.location.line > 0
+        assert active.location.path is not None
+        assert active.location.path.endswith("behavior.py")
+
+    def test_a_find_is_not_reported_as_a_filter_site(self, view):
+        """``by_reference`` queries with ``find``; it names no filter site."""
+        sites = view.filter_call_sites(behavior.OrderRepository)
+
+        assert "by_reference" not in {site.method_name for site in sites}
+
+
+class TestDataflowSurface:
+    def test_method_flow_surfaces_dataflow_for_a_body(self, view):
+        """The third family: the analyzer's MethodFlow, reached through the view."""
+        entry = view.element_class_entry(behavior.OrderRepository)
+        node = entry.method("by_reference").node
+
+        flow = view.method_flow(entry.module, node)
+
+        assert isinstance(flow, MethodFlow)
+        assert len(flow.statements()) > 0
+        # ``by_reference(self, reference)`` — its parameters are dataflow bindings
+        # the view now exposes, proving #1223 is surfaced, not re-implemented.
+        assert "reference" in {param.name for param in flow.parameters}
+
+
+class TestSharedProviderAndIndex:
+    def test_the_view_is_cached_and_reuses_the_builders_provider_and_index(
+        self, order_domain
+    ):
+        """ "Built once per run": one view, over the builder's one provider/index.
+
+        If the view built its own provider a module would parse twice; the shared
+        identity is what the "one parse per run" contract rests on.
+        """
+        builder = IRBuilder(order_domain)
+
+        first = builder.view
+        assert builder.view is first, "the view is built once and cached"
+        assert first._provider is builder.source, "shares the builder's provider"
+        assert first._index is builder.index, "shares the builder's index"
+
+    def test_the_facts_and_dataflow_share_the_one_provider(self, order_domain):
+        """The catalog and analyzer under the view use the same provider too."""
+        builder = IRBuilder(order_domain)
+        view = builder.view
+
+        assert view._facts._provider is builder.source
+        assert view._dataflow._provider is builder.source
+        assert view._facts._index is builder.index
+
+    def test_a_standalone_view_builds_its_own_provider_and_index(self, order_domain):
+        """With no provider/index passed, the view builds fresh ones and still
+        answers — the default path for a view with no builder to share with."""
+        view = BehavioralView(order_domain)
+
+        assert isinstance(view._provider, SourceProvider)
+        assert isinstance(view._index, ElementIndex)
+        assert view.filter_call_sites(behavior.OrderRepository) != ()
+
+
+class TestFailOpen:
+    def test_a_class_with_no_source_yields_empty_from_every_query(self, view):
+        """Negative: a dynamically-created class has no source, so every element
+        query returns empty rather than raising."""
+        ghost = type("Ghost", (), {})
+
+        assert view.element_class_entry(ghost) is None
+        assert view.element_methods(ghost) == ()
+        assert view.element_facts(ghost) == {}
+        assert view.filter_call_sites(ghost) == ()
+
+
+class TestInternalSurface:
+    def test_the_view_is_not_re_exported_from_protean(self):
+        """The view is internal: it must not leak onto ``protean``/``protean.ir``."""
+        assert "BehavioralView" not in getattr(protean, "__all__", [])
+        assert not hasattr(protean, "BehavioralView")
+        assert not hasattr(protean.ir, "BehavioralView")

--- a/tests/ir/analysis/test_view.py
+++ b/tests/ir/analysis/test_view.py
@@ -9,6 +9,8 @@ registered as a real domain so a construction resolves and a repository query is
 recognized, exactly as the fact-catalog tests do.
 """
 
+from pathlib import Path
+
 import pytest
 
 import protean
@@ -32,7 +34,7 @@ pytestmark = pytest.mark.no_test_domain
 #: FQNs match what the registry recorded, which a package walk's name does not.
 BEHAVIOR_MODULE = behavior.__name__
 
-PACKAGE_ROOT = str(behavioral_domain.__file__).rsplit("/", 1)[0]
+PACKAGE_ROOT = str(Path(behavioral_domain.__file__).parent)
 
 
 @pytest.fixture(scope="module")

--- a/tests/ir/analysis/test_view.py
+++ b/tests/ir/analysis/test_view.py
@@ -79,33 +79,54 @@ class TestPerMethodFacts:
         assert query.receiver_role is ReceiverRole.REPOSITORY_QUERY
         assert query.field_names == ("status",)
 
-    def test_method_facts_by_node_matches_the_element_map(self, view):
-        """A method node fetched from the index gives the same facts."""
+    def test_method_facts_by_node_returns_that_bodys_facts(self, view):
+        """The by-node door resolves a method node to its own body's facts.
+
+        Asserts the concrete values ``method_facts`` computes for ``between``
+        (its two repository ``filter`` calls, in source order) rather than
+        comparing to ``element_facts``, which is the same cached object by
+        construction and so would match under any regression.
+        """
         entry = view.element_class_entry(behavior.OrderRepository)
-        node = entry.method("active").node
+        node = entry.method("between").node
 
-        by_node = view.method_facts(entry.module, node)
-        by_element = view.element_facts(behavior.OrderRepository)["active"]
+        facts = view.method_facts(entry.module, node)
 
-        assert by_node == by_element
-        assert len(by_node.calls) > 0
+        filters = [c for c in facts.calls if c.method == "filter"]
+        assert [c.field_names for c in filters] == [
+            ("status", "channel"),
+            ("reference",),
+        ]
+        assert all(c.receiver_role is ReceiverRole.REPOSITORY_QUERY for c in filters)
 
 
 class TestFilterCallSites:
-    def test_filter_call_sites_reports_each_site_and_its_fields(self, view):
-        """The headline convenience: the element's ``filter`` sites and fields.
+    def test_filter_call_sites_reports_each_site_and_its_fields_in_order(self, view):
+        """The headline convenience: the element's ``filter`` sites and fields,
+        in the order the contract promises — methods by name, then call-sites
+        within a method in source order.
 
-        ``active`` filters on ``status``; ``dynamic`` filters on ``**filters`` so
-        names no field. ``by_reference`` uses ``find``, not ``filter``, so it is
-        not a filter call-site.
+        ``active`` filters on ``status``; ``between`` filters twice
+        (``status`` + ``channel``, then ``reference``), which pins both
+        field-name order and call-site-within-a-method order; ``dynamic``
+        filters on ``**filters`` so names no field. ``by_reference`` uses
+        ``find``, not ``filter``, so it is not a filter call-site.
         """
         sites = view.filter_call_sites(behavior.OrderRepository)
 
         assert len(sites) > 0, "OrderRepository has filter call-sites"
         for site in sites:
             assert isinstance(site, FilterCallSite)
-        pairs = {(site.method_name, site.field_names) for site in sites}
-        assert pairs == {("active", ("status",)), ("dynamic", ())}
+        # An ordered sequence, not a set: the assertion pins the view's
+        # determinism contract (name order across methods, source order within
+        # a method) and the source order of a multi-field filter's field names.
+        pairs = [(site.method_name, site.field_names) for site in sites]
+        assert pairs == [
+            ("active", ("status",)),
+            ("between", ("status", "channel")),
+            ("between", ("reference",)),
+            ("dynamic", ()),
+        ]
 
     def test_filter_call_sites_carry_a_location(self, view):
         """Each site names where it is, so a rule can report the finding there."""
@@ -121,6 +142,29 @@ class TestFilterCallSites:
         sites = view.filter_call_sites(behavior.OrderRepository)
 
         assert "by_reference" not in {site.method_name for site in sites}
+
+    def test_a_non_repository_filter_is_not_reported_as_a_filter_site(self, view):
+        """A ``.filter(...)`` on a plain local is a filter call but not a
+        repository one, so the view excludes it.
+
+        ``stale`` calls ``rows.filter(...)`` on a parameter, so its receiver
+        role is ``UNKNOWN``, not ``REPOSITORY_QUERY``. This guards the
+        ``receiver_role is REPOSITORY_QUERY`` half of the predicate: without it
+        a plain-object ``.filter`` would be misreported as a repository filter
+        site.
+        """
+        # The call really is a ``filter`` fact — only its receiver role differs,
+        # so the exclusion is proven to hinge on the role, not the method name.
+        stale_call = next(
+            c
+            for c in view.element_facts(behavior.OrderRepository)["stale"].calls
+            if c.method == "filter"
+        )
+        assert stale_call.receiver_role is ReceiverRole.UNKNOWN
+
+        sites = view.filter_call_sites(behavior.OrderRepository)
+
+        assert "stale" not in {site.method_name for site in sites}
 
 
 class TestDataflowSurface:

--- a/tests/ir/support/behavioral_domain/behavior.py
+++ b/tests/ir/support/behavioral_domain/behavior.py
@@ -15,6 +15,12 @@ Each method carries a deliberate shape a test asserts:
   grammar models as a store and the catalog records as a write.
 - ``OrderRepository.active`` — a recognized repository query on ``self._dao``,
   naming the ``status`` field.
+- ``OrderRepository.between`` — two repository queries in one body: the first
+  names two fields (``status``, ``channel``), the second one (``reference``), so
+  field-name order and call-site order within a method are both observable.
+- ``OrderRepository.stale`` — a ``.filter(...)`` on a plain parameter, not
+  ``self._dao``: its receiver stays ``UNKNOWN``, so it is a ``filter`` call that
+  is *not* a repository filter site.
 - ``OrderRepository.by_reference`` — a query whose field comes from an inline
   ``Q(reference=...)``.
 - ``OrderRepository.dynamic`` — a ``**filters`` query that names no field.
@@ -57,6 +63,19 @@ class OrderRepository(BaseRepository):
     def active(self) -> None:
         """A recognized repository query naming the ``status`` field."""
         self._dao.filter(status="active")
+
+    def between(self) -> None:
+        """Two repository queries in one body: the first names two fields, so
+        field-name order is pinned; the second names one, so call-site order
+        within a method is observable too."""
+        self._dao.filter(status="open", channel="web")
+        self._dao.filter(reference="latest")
+
+    def stale(self, rows: list) -> None:
+        """A ``.filter(...)`` on a plain parameter, not the repository DAO: its
+        receiver stays ``UNKNOWN``, so it is a ``filter`` call that is not a
+        repository filter site."""
+        rows.filter(status="stale")
 
     def by_reference(self, reference: str) -> None:
         """A query whose field comes from an inline ``Q(reference=...)``."""

--- a/tests/ir/support/behavioral_domain/behavior.py
+++ b/tests/ir/support/behavioral_domain/behavior.py
@@ -29,6 +29,8 @@ Each method carries a deliberate shape a test asserts:
 - ``OrderRepository.in_transaction`` — a call on a ``UnitOfWork()`` receiver.
 """
 
+from typing import Any
+
 from protean.core.aggregate import BaseAggregate
 from protean.core.event import BaseEvent
 from protean.core.repository import BaseRepository
@@ -71,7 +73,7 @@ class OrderRepository(BaseRepository):
         self._dao.filter(status="open", channel="web")
         self._dao.filter(reference="latest")
 
-    def stale(self, rows: list) -> None:
+    def stale(self, rows: Any) -> None:
         """A ``.filter(...)`` on a plain parameter, not the repository DAO: its
         receiver stays ``UNKNOWN``, so it is a ``filter`` call that is not a
         repository filter site."""


### PR DESCRIPTION
## Summary
- Adds `BehavioralView`, a read-only façade over the `protean check` source-analysis substrate that gives diagnostic rules one place to query an element's methods, per-method behavioral facts, and intra-procedural dataflow, plus a `filter_call_sites` convenience — all built lazily over the builder's single parsed-source provider.
- Wires the view into `IRBuilder` as a lazy `view` property, sharing the builder's `source` and `index` so modules already parsed by a rule aren't re-parsed.
- Internal substrate only; no existing diagnostics change.

## Test plan
- [x] `protean test` core suite passes
- [x] `tests/ir/analysis/test_view.py` and `tests/ir/analysis/test_facts.py` pass

Closes #1224