### PR TITLE
Advance the aggregate root's version on a child-only edit (fix silent lost update)

### DIFF
--- a/changes/1245.fixed.md
+++ b/changes/1245.fixed.md
@@ -1,0 +1,1 @@
+Editing a field of a child entity (a `HasMany`/`HasOne` member, at any depth) now advances the owning aggregate root's version, treating the root as the optimistic-concurrency boundary. Two concurrent edits of the same child now conflict with an `ExpectedVersionError` instead of one silently overwriting the other.

--- a/docs/adr/0013-optimistic-concurrency-and-claim-contract.md
+++ b/docs/adr/0013-optimistic-concurrency-and-claim-contract.md
@@ -129,6 +129,42 @@ unconditionally) would *not* hold: two transactions can both read the same
 version and both write, silently losing one update — the failure the guarded
 `UPDATE` prevents.
 
+**The aggregate root is the concurrency boundary — including child changes.**
+The version guard above protects the root's own fields, but an aggregate can be
+modified purely through a child entity (a `HasMany`/`HasOne` member): a change to
+a line item's quantity, with no root-field change and no event. Such a change
+persists the child through the un-versioned path (`_update(expected_version=None)`
+— a child entity is not an aggregate, so `_validate_and_update_version` does not
+run for it), and `Repository._do_add` re-saves the root only when the root itself
+is new or changed. A child-only change would therefore leave the root's version
+untouched, and two concurrent child-only updates would both succeed — the child
+counterpart of the lost update above. We treat the aggregate root as the unit of
+concurrency control: `Repository._do_add` re-saves the root not only when the
+root's own fields changed but also when any persisted child was directly edited
+(`_has_changed_child`, which mirrors the direct-update detection already in
+`_sync_children`), so the guarded root save runs and advances `_version`. This
+covers a child's scalar, value-object, and reference fields uniformly, because
+the check reads the child's own `state_.is_changed` rather than the field kind.
+Under a transactional provider the child writes and the root version bump commit
+together in the Unit of Work.
+
+Adding or removing a `HasMany` child through the `add_`/`remove_` collection
+methods is deliberately out of scope: those methods do not mark the root changed,
+`mark_changed` no-ops while a freshly added child is new (so it does not trip
+`_has_changed_child`), and concurrent adds of distinct children do not race the
+way concurrent edits of the same existing data do. Assigning or replacing a
+`HasOne` child (`aggregate.child = ...`) is different — it goes through the root's
+own `__setattr__`, marks the root changed, and is version-guarded like any
+root-field change.
+
+Because an aggregate that has child rows forces its root `UPDATE` out at
+`repo.add` time (a flush to materialize the parent row before the child inserts
+that reference it, since Protean emits no SQLAlchemy foreign-key metadata to let
+the ORM order them) rather than at commit, a child-only version conflict can
+surface at that forced flush instead of at commit. The SQLAlchemy `_flush`
+translates the resulting `StaleDataError` to `ExpectedVersionError` there, the
+same mapping the commit path applies.
+
 ## Consequences
 
 - The outbox poll path drops from `1 + N` round trips to one (fast path) or

--- a/src/protean/adapters/repository/sqlalchemy.py
+++ b/src/protean/adapters/repository/sqlalchemy.py
@@ -44,6 +44,7 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.exc import DatabaseError
 from sqlalchemy.orm import Session, scoped_session, sessionmaker
+from sqlalchemy.orm.exc import StaleDataError
 from sqlalchemy.pool import QueuePool
 from sqlalchemy.schema import CreateIndex
 from sqlalchemy.types import CHAR, TypeDecorator
@@ -1006,8 +1007,27 @@ class SADAO(BaseDAO):
           until a flush runs. Forcing a flush lets the repository read the
           generated value back onto the aggregate inside the transaction — under
           both a standalone add and an add nested in an outer UnitOfWork.
+
+        This is a shared primitive: it is called from ``Repository._do_add`` (the
+        parent-before-child flush), from the recursive grandchild-ordering flushes
+        in ``_sync_children``, and from ``BaseDAO.create``/``save`` (auto-increment
+        materialization). A concurrent-conflict ``StaleDataError`` can surface at
+        any of them — most commonly the ``version_id_col`` mismatch when the forced
+        flush re-saves an aggregate root whose version a concurrent commit already
+        advanced (e.g. a child-only aggregate change routed through the root save),
+        but also a delete whose row a concurrent writer already removed (SQLAlchemy
+        raises ``StaleDataError`` on a zero-row confirmed delete regardless of
+        ``version_id_col``). Either is an optimistic-concurrency conflict, so
+        translate it to :class:`ExpectedVersionError` — the same mapping the
+        UnitOfWork commit applies to the deferred flush that has no association
+        rows to order.
         """
-        self._get_session().flush()
+        conn = self._get_session()
+        try:
+            conn.flush()
+        except StaleDataError as exc:
+            self._rollback_if_standalone(conn)
+            raise ExpectedVersionError(str(exc)) from None
 
     def _create(self, model_obj: typing.Any) -> typing.Any:
         """Add a new record to the sqlalchemy database"""

--- a/src/protean/core/repository.py
+++ b/src/protean/core/repository.py
@@ -256,50 +256,65 @@ class BaseRepository(Element, OptionsMixin):
             own_current_uow = UnitOfWork()
             own_current_uow.start()
 
-        # Persist the aggregate/projection FIRST so that it exists in the data
-        # store before any child entities that hold a foreign-key reference to
-        # it.  This is required for databases that enforce FK constraints
-        # immediately (MSSQL, MySQL/InnoDB, SQLite with PRAGMA foreign_keys).
-        root_persisted = False
-        if (not item.state_.is_persisted) or (
-            item.state_.is_persisted and item.state_.is_changed
-        ):
-            self._dao.save(item)
-            root_persisted = True
+        try:
+            # Persist the aggregate/projection FIRST so that it exists in the data
+            # store before any child entities that hold a foreign-key reference to
+            # it.  This is required for databases that enforce FK constraints
+            # immediately (MSSQL, MySQL/InnoDB, SQLite with PRAGMA foreign_keys).
+            root_persisted = False
+            if (not item.state_.is_persisted) or (
+                item.state_.is_persisted
+                and (item.state_.is_changed or self._has_changed_child(item))
+            ):
+                self._dao.save(item)
+                root_persisted = True
 
-            # If Aggregate has signed up Fact Events, raise them now
-            if item.element_type == DomainObjects.AGGREGATE and item.meta_.fact_events:
-                payload = item.to_dict()
+                # If Aggregate has signed up Fact Events, raise them now
+                if (
+                    item.element_type == DomainObjects.AGGREGATE
+                    and item.meta_.fact_events
+                ):
+                    payload = item.to_dict()
 
-                # Remove internal attributes from the payload, as they are not needed for the Fact Event
-                payload.pop("state_", None)
-                payload.pop("_version", None)
+                    # Remove internal attributes from the payload, as they are not needed for the Fact Event
+                    payload.pop("state_", None)
+                    payload.pop("_version", None)
 
-                # Construct and raise the Fact Event
-                fact_event = item._fact_event_cls(**payload)
-                item.raise_(fact_event)
-        elif item.element_type == DomainObjects.AGGREGATE and item._events:
-            # Aggregate has pending events but no own-field changes (e.g., events
-            # raised by child entities).  We still need to persist the aggregate so
-            # that _version is incremented, and track it in the identity map so that
-            # _gather_events picks up these events on commit.
-            self._dao.save(item)
-            root_persisted = True
+                    # Construct and raise the Fact Event
+                    fact_event = item._fact_event_cls(**payload)
+                    item.raise_(fact_event)
+            elif item.element_type == DomainObjects.AGGREGATE and item._events:
+                # Aggregate has pending events but no own-field changes (e.g., events
+                # raised by child entities).  We still need to persist the aggregate so
+                # that _version is incremented, and track it in the identity map so that
+                # _gather_events picks up these events on commit.
+                self._dao.save(item)
+                root_persisted = True
 
-        # Now sync child entities (HasMany/HasOne) — the parent row exists, so
-        # child inserts referencing it will satisfy FK constraints.
-        if has_association_fields(item):
-            # Under an active UoW the save above is only buffered (no flush),
-            # so force the root row to materialize in the transaction before
-            # child inserts. Without FK metadata on the generated models, the
-            # ORM cannot order parent-before-child at commit-time flush itself.
-            if root_persisted:
-                self._dao._flush()
-            self._sync_children(item)
+            # Now sync child entities (HasMany/HasOne) — the parent row exists, so
+            # child inserts referencing it will satisfy FK constraints.
+            if has_association_fields(item):
+                # Under an active UoW the save above is only buffered (no flush),
+                # so force the root row to materialize in the transaction before
+                # child inserts. Without FK metadata on the generated models, the
+                # ORM cannot order parent-before-child at commit-time flush itself.
+                if root_persisted:
+                    self._dao._flush()
+                self._sync_children(item)
 
-        # If we started a UnitOfWork, commit it now
-        if own_current_uow:
-            own_current_uow.commit()
+            # If we started a UnitOfWork, commit it now
+            if own_current_uow:
+                own_current_uow.commit()
+        except Exception:
+            # A save/flush here can raise (e.g. ``ExpectedVersionError`` on a
+            # concurrent conflict, now reachable for child-only changes). If we
+            # started the UnitOfWork, roll it back so a standalone ``add`` does
+            # not leave a dangling in-progress UoW (and, on SQLAlchemy, a session
+            # needing rollback) for the next operation. A caller-supplied UoW is
+            # left for the caller's own ``with`` block to unwind.
+            if own_current_uow and own_current_uow.in_progress:
+                own_current_uow.rollback()
+            raise
 
         return item
 
@@ -318,6 +333,33 @@ class BaseRepository(Element, OptionsMixin):
         Internal counterpart to ``_persist_child`` for removals.
         """
         self._domain.repository_for(child_cls)._dao.delete(item)
+
+    def _has_changed_child(self, entity: Any) -> bool:
+        """Return ``True`` if a descendant entity has been directly changed.
+
+        The aggregate root is the optimistic-concurrency boundary, so a change
+        confined to a child — at any depth — with no change to a root field must
+        still re-save the root to advance its ``_version``. This mirrors the
+        direct-update detection in :meth:`_sync_children`: a child whose own
+        attribute was edited carries ``state_.is_changed``, and the recursion
+        walks nested children the same way ``_sync_children`` does. Children newly
+        added via ``add_``/``remove_`` are excluded — ``mark_changed`` no-ops
+        while an entity is new, so their ``is_changed`` stays ``False`` — because
+        adding a child is handled separately and does not race the way concurrent
+        edits of the same existing data do.
+        """
+        for field_name, field in association_fields(entity).items():
+            if isinstance(field, HasMany):
+                for child in getattr(entity, field_name):
+                    if child.state_.is_changed or self._has_changed_child(child):
+                        return True
+            elif isinstance(field, HasOne):
+                child = getattr(entity, field_name)
+                if child is not None and (
+                    child.state_.is_changed or self._has_changed_child(child)
+                ):
+                    return True
+        return False
 
     def _sync_children(self, entity: Any) -> None:
         """Recursively sync child entities to the persistence store.

--- a/src/protean/core/repository.py
+++ b/src/protean/core/repository.py
@@ -342,10 +342,12 @@ class BaseRepository(Element, OptionsMixin):
         still re-save the root to advance its ``_version``. This mirrors the
         direct-update detection in :meth:`_sync_children`: a child whose own
         attribute was edited carries ``state_.is_changed``, and the recursion
-        walks nested children the same way ``_sync_children`` does. Children newly
-        added via ``add_``/``remove_`` are excluded — ``mark_changed`` no-ops
-        while an entity is new, so their ``is_changed`` stays ``False`` — because
-        adding a child is handled separately and does not race the way concurrent
+        walks nested children the same way ``_sync_children`` does. Structural
+        ``add_``/``remove_`` changes to a collection are excluded for two distinct
+        reasons: a freshly *added* child is new, so ``mark_changed`` no-ops and its
+        ``is_changed`` stays ``False``; a *removed* child is no longer in the
+        collection this walks (it lives in the association's temp cache until the
+        sync). Those are handled separately and do not race the way concurrent
         edits of the same existing data do.
         """
         for field_name, field in association_fields(entity).items():

--- a/tests/adapters/repository/generic/test_optimistic_locking.py
+++ b/tests/adapters/repository/generic/test_optimistic_locking.py
@@ -1,7 +1,8 @@
 """Generic optimistic locking tests that run against all database providers.
 
-Covers version increment on save, concurrent update detection, and version
-preservation through persist/retrieve round-trips.
+Covers version increment on save, concurrent update detection, version
+preservation through persist/retrieve round-trips, and that a change confined
+to a child entity still advances the aggregate root's version.
 """
 
 from uuid import uuid4
@@ -9,9 +10,12 @@ from uuid import uuid4
 import pytest
 
 from protean.core.aggregate import BaseAggregate
+from protean.core.entity import BaseEntity
 from protean.core.unit_of_work import UnitOfWork
+from protean.core.value_object import BaseValueObject
 from protean.exceptions import ExpectedVersionError, ObjectNotFoundError
-from protean.fields import Integer, String
+from protean.fields import HasMany, HasOne, Integer, Reference, String, ValueObject
+from protean.utils.globals import current_uow
 
 
 class Counter(BaseAggregate):
@@ -19,9 +23,64 @@ class Counter(BaseAggregate):
     value: Integer(default=0)
 
 
+class Money(BaseValueObject):
+    currency: String(max_length=3)
+    amount: Integer()
+
+
+class Order(BaseAggregate):
+    label: String(max_length=50, required=False)
+    lines = HasMany("OrderLine")
+
+
+class OrderLine(BaseEntity):
+    sku: String(max_length=20, required=True)
+    quantity: Integer(default=1)
+    price = ValueObject(Money)
+
+    order = Reference(Order)
+
+
+class Account(BaseAggregate):
+    label: String(max_length=50, required=False)
+    profile = HasOne("Profile")
+
+
+class Profile(BaseEntity):
+    handle: String(max_length=50, required=True)
+
+    account = Reference(Account)
+
+
+class Warehouse(BaseAggregate):
+    label: String(max_length=50, required=False)
+    zones = HasMany("Zone")
+
+
+class Zone(BaseEntity):
+    name: String(max_length=50, required=True)
+    bins = HasMany("Bin")
+
+    warehouse = Reference(Warehouse)
+
+
+class Bin(BaseEntity):
+    code: String(max_length=50, required=True)
+
+    zone = Reference(Zone)
+
+
 @pytest.fixture(autouse=True)
 def register_elements(test_domain):
     test_domain.register(Counter)
+    test_domain.register(Money)
+    test_domain.register(Order)
+    test_domain.register(OrderLine, part_of=Order)
+    test_domain.register(Account)
+    test_domain.register(Profile, part_of=Account)
+    test_domain.register(Warehouse)
+    test_domain.register(Zone, part_of=Warehouse)
+    test_domain.register(Bin, part_of=Zone)
     test_domain.init(traverse=False)
 
 
@@ -217,3 +276,178 @@ class TestStandaloneStaleWrite:
         second.value = 2
         with pytest.raises(ExpectedVersionError):
             dao.save(second)
+
+
+@pytest.mark.basic_storage
+class TestChildOnlyMutationVersioning:
+    """The aggregate root is the concurrency boundary: a change confined to a
+    child entity's own field must advance the root's _version, so a stale
+    child-only write is rejected instead of silently overwriting."""
+
+    def _seed_order(self, test_domain):
+        """Persist an order with a single line at version 0; return its id."""
+        with UnitOfWork():
+            order = Order(label="seed")
+            order.add_lines(
+                OrderLine(sku="A", quantity=1, price=Money(currency="USD", amount=5))
+            )
+            test_domain.repository_for(Order).add(order)
+        return order.id
+
+    def test_child_scalar_edit_bumps_root_version(self, test_domain):
+        order_id = self._seed_order(test_domain)
+        assert test_domain.repository_for(Order).get(order_id)._version == 0
+
+        with UnitOfWork():
+            loaded = test_domain.repository_for(Order).get(order_id)
+            loaded.lines[0].quantity = 99
+            test_domain.repository_for(Order).add(loaded)
+
+        persisted = test_domain.repository_for(Order).get(order_id)
+        assert persisted._version == 1
+        assert persisted.lines[0].quantity == 99
+
+    def test_child_value_object_edit_bumps_root_version(self, test_domain):
+        """A value-object field edit on a child is a child change too — it must
+        advance the root version, not just scalar-field edits."""
+        order_id = self._seed_order(test_domain)
+
+        with UnitOfWork():
+            loaded = test_domain.repository_for(Order).get(order_id)
+            loaded.lines[0].price = Money(currency="EUR", amount=20)
+            test_domain.repository_for(Order).add(loaded)
+
+        persisted = test_domain.repository_for(Order).get(order_id)
+        assert persisted._version == 1
+        assert persisted.lines[0].price == Money(currency="EUR", amount=20)
+
+    def test_hasone_child_edit_bumps_root_version(self, test_domain):
+        """A change confined to a HasOne child advances the root version too."""
+        with UnitOfWork():
+            account = Account(label="seed")
+            account.profile = Profile(handle="original")
+            test_domain.repository_for(Account).add(account)
+        account_id = account.id
+        assert test_domain.repository_for(Account).get(account_id)._version == 0
+
+        with UnitOfWork():
+            loaded = test_domain.repository_for(Account).get(account_id)
+            loaded.profile.handle = "updated"
+            test_domain.repository_for(Account).add(loaded)
+
+        persisted = test_domain.repository_for(Account).get(account_id)
+        assert persisted._version == 1
+        assert persisted.profile.handle == "updated"
+
+    def test_nested_grandchild_edit_bumps_root_version(self, test_domain):
+        """The root is the boundary for the whole tree: an edit confined to a
+        grandchild (a child of a child) advances the root version too."""
+        with UnitOfWork():
+            warehouse = Warehouse(label="seed")
+            zone = Zone(name="A")
+            zone.add_bins(Bin(code="A-1"))
+            warehouse.add_zones(zone)
+            test_domain.repository_for(Warehouse).add(warehouse)
+        warehouse_id = warehouse.id
+        assert test_domain.repository_for(Warehouse).get(warehouse_id)._version == 0
+
+        with UnitOfWork():
+            loaded = test_domain.repository_for(Warehouse).get(warehouse_id)
+            loaded.zones[0].bins[0].code = "A-2"
+            test_domain.repository_for(Warehouse).add(loaded)
+
+        persisted = test_domain.repository_for(Warehouse).get(warehouse_id)
+        assert persisted._version == 1
+        assert persisted.zones[0].bins[0].code == "A-2"
+
+    def test_unmodified_reload_does_not_bump_version(self, test_domain):
+        """A load-and-re-add with no change must not advance the version — the
+        re-save only fires on an actual child mutation."""
+        order_id = self._seed_order(test_domain)
+
+        with UnitOfWork():
+            unchanged = test_domain.repository_for(Order).get(order_id)
+            assert not unchanged.state_.is_changed
+            test_domain.repository_for(Order).add(unchanged)
+
+        assert test_domain.repository_for(Order).get(order_id)._version == 0
+
+    def test_adding_a_child_alone_does_not_bump_version(self, test_domain):
+        """Adding a HasMany child (no edit to an existing child) is out of scope:
+        it persists the new child but does not advance the root version."""
+        order_id = self._seed_order(test_domain)
+
+        with UnitOfWork():
+            loaded = test_domain.repository_for(Order).get(order_id)
+            loaded.add_lines(OrderLine(sku="B", quantity=2))
+            test_domain.repository_for(Order).add(loaded)
+
+        persisted = test_domain.repository_for(Order).get(order_id)
+        assert persisted._version == 0  # add is out of scope, no bump
+        assert len(persisted.lines) == 2  # but the new child was persisted
+
+    def test_removing_a_child_alone_does_not_bump_version(self, test_domain):
+        """Removing a HasMany child is out of scope too: it deletes the child row
+        but does not advance the root version."""
+        with UnitOfWork():
+            order = Order(label="seed")
+            order.add_lines(OrderLine(sku="A", quantity=1))
+            order.add_lines(OrderLine(sku="B", quantity=2))
+            test_domain.repository_for(Order).add(order)
+        order_id = order.id
+
+        with UnitOfWork():
+            loaded = test_domain.repository_for(Order).get(order_id)
+            loaded.remove_lines(loaded.lines[0])
+            test_domain.repository_for(Order).add(loaded)
+
+        persisted = test_domain.repository_for(Order).get(order_id)
+        assert persisted._version == 0  # remove is out of scope, no bump
+        assert len(persisted.lines) == 1  # but the child was removed
+
+    def test_stale_child_only_write_raises_expected_version_error(self, test_domain):
+        order_id = self._seed_order(test_domain)
+
+        # Two copies both loaded at version 0.
+        copy1 = test_domain.repository_for(Order).get(order_id)
+        copy2 = test_domain.repository_for(Order).get(order_id)
+
+        # First copy mutates a child field and wins.
+        copy1.lines[0].quantity = 10
+        with UnitOfWork():
+            test_domain.repository_for(Order).add(copy1)
+
+        # Second copy is stale; a child-only mutation must still be rejected.
+        copy2.lines[0].quantity = 20
+        with pytest.raises(ExpectedVersionError), UnitOfWork():
+            test_domain.repository_for(Order).add(copy2)
+
+        # The first writer's value survived.
+        final = test_domain.repository_for(Order).get(order_id)
+        assert final._version == 1
+        assert final.lines[0].quantity == 10
+
+    def test_standalone_stale_child_write_does_not_leak_uow(self, test_domain):
+        """A stale child-only write through a standalone ``add`` (no enclosing
+        UoW) raises ExpectedVersionError and leaves no dangling in-progress UoW,
+        so the next operation runs cleanly rather than inside a poisoned one."""
+        order_id = self._seed_order(test_domain)
+
+        copy1 = test_domain.repository_for(Order).get(order_id)
+        copy2 = test_domain.repository_for(Order).get(order_id)
+
+        # Standalone add (no UnitOfWork wrapper); first writer wins.
+        copy1.lines[0].quantity = 10
+        test_domain.repository_for(Order).add(copy1)
+
+        copy2.lines[0].quantity = 20
+        with pytest.raises(ExpectedVersionError):
+            test_domain.repository_for(Order).add(copy2)
+
+        # The internally-started UoW was rolled back, not left in progress.
+        assert not (current_uow and current_uow.in_progress)
+
+        # A subsequent operation still works and sees the winner's value.
+        final = test_domain.repository_for(Order).get(order_id)
+        assert final._version == 1
+        assert final.lines[0].quantity == 10

--- a/tests/adapters/repository/sqlalchemy_repo/postgresql/test_postgresql_occ_concurrency.py
+++ b/tests/adapters/repository/sqlalchemy_repo/postgresql/test_postgresql_occ_concurrency.py
@@ -19,9 +19,10 @@ from sqlalchemy import text
 
 from protean import Domain
 from protean.core.aggregate import BaseAggregate
+from protean.core.entity import BaseEntity
 from protean.core.unit_of_work import UnitOfWork
 from protean.exceptions import ExpectedVersionError
-from protean.fields import Integer, String
+from protean.fields import HasMany, Integer, Reference, String
 from tests.shared import POSTGRES_PORT
 
 # This module builds its own Domain (``concurrency_domain``), so skip the autouse
@@ -34,6 +35,19 @@ _WORKERS = 8
 class OCCCounter(BaseAggregate):
     label: String(max_length=20, required=False)
     value: Integer(default=0)
+
+
+class OCCOrder(BaseAggregate):
+    label: String(max_length=20, required=False)
+    lines = HasMany("OCCLine")
+
+
+class OCCLine(BaseEntity):
+    sku: String(max_length=20, required=True)
+    quantity: Integer(default=0)
+
+    # Named to match the HasMany back-reference derived from ``OCCOrder``.
+    occ_order = Reference(OCCOrder)
 
 
 @pytest.fixture
@@ -56,12 +70,16 @@ def concurrency_domain():
         },
     )
     domain.register(OCCCounter)
+    domain.register(OCCOrder)
+    domain.register(OCCLine, part_of=OCCOrder)
     domain.init(traverse=False)
 
     provider = domain.providers["default"]
-    # Touch the DAO so the SQLAlchemy model + its table are materialized into
-    # the provider metadata before create_all.
+    # Touch each DAO so the SQLAlchemy models + their tables are materialized
+    # into the provider metadata before create_all.
     domain.repository_for(OCCCounter)._dao
+    domain.repository_for(OCCOrder)._dao
+    domain.repository_for(OCCLine)._dao
     provider._metadata.create_all(provider._engine)
     try:
         with domain.domain_context():
@@ -69,6 +87,15 @@ def concurrency_domain():
     finally:
         provider._metadata.drop_all(provider._engine)
         provider.close()
+
+
+def _seed_occ_order(domain):
+    """Persist an OCCOrder with a single line at version 0; return its id."""
+    with UnitOfWork():
+        seed = OCCOrder(label="seed")
+        seed.add_lines(OCCLine(sku="A", quantity=0))
+        domain.repository_for(OCCOrder).add(seed)
+    return seed.id
 
 
 @pytest.mark.postgresql
@@ -168,3 +195,110 @@ def test_flush_time_version_conflict_raises_expected_version_error(concurrency_d
                 )
                 conn.commit()
             # Exiting the UoW commits -> flush -> StaleDataError -> translated.
+
+
+@pytest.mark.postgresql
+def test_concurrent_child_only_updates_do_not_silently_lose_writes(concurrency_domain):
+    """The aggregate root is the concurrency boundary: when every worker changes
+    only a *child* field (no root-field change, no event), the root's version
+    must still guard the write. Without the child->root propagation the root is
+    never re-saved, so all writers "win" and updates are silently lost."""
+    domain = concurrency_domain
+
+    order_id = _seed_occ_order(domain)
+
+    # Every worker loads version 0 before any of them commits. Each worker
+    # writes its own distinct child value (worker_no + 1) so the surviving value
+    # identifies which writer actually won.
+    load_barrier = threading.Barrier(_WORKERS, timeout=20)
+    results: list[tuple[int, str]] = []
+    results_lock = threading.Lock()
+
+    def worker(worker_no: int) -> None:
+        outcome: str
+        try:
+            with domain.domain_context(), UnitOfWork():
+                repo = domain.repository_for(OCCOrder)
+                order = repo.get(order_id)
+                # Mutate ONLY the child line's field — the root is untouched.
+                order.lines[0].quantity = worker_no + 1
+                load_barrier.wait()
+                repo.add(order)
+            outcome = "success"
+        except ExpectedVersionError:
+            outcome = "conflict"
+        except Exception as exc:  # reported via the assertion below
+            outcome = f"error:{type(exc).__name__}"
+        with results_lock:
+            results.append((worker_no, outcome))
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(_WORKERS)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+
+    winners = [w for w, o in results if o == "success"]
+    conflict = sum(1 for _, o in results if o == "conflict")
+
+    assert len(results) == _WORKERS, results
+    assert all(o in ("success", "conflict") for _, o in results), results
+
+    with UnitOfWork():
+        final = domain.repository_for(OCCOrder).get(order_id)
+
+    # The invariant the bug violated: a child-only change advances the root
+    # version, so exactly one writer wins the race for version 0 and the rest
+    # conflict. A silent lost update would report more successes than the final
+    # version.
+    assert len(winners) == final._version, (
+        f"lost update: {len(winners)} successes but version is {final._version}"
+    )
+    assert len(winners) == 1
+    assert conflict == _WORKERS - 1
+    # The surviving child value belongs to the single winning writer — not just
+    # any writer (which would also catch a version bumped without the write).
+    assert final.lines[0].quantity == winners[0] + 1
+
+
+@pytest.mark.postgresql
+def test_child_only_flush_conflict_raises_expected_version_error(concurrency_domain):
+    """Deterministic, single-threaded exercise of the child-only flush guard.
+
+    A child-only change re-saves the root, and because the aggregate has child
+    rows to order, the root UPDATE is forced out at ``repo.add`` time via
+    ``_flush`` (not at UoW commit). A version bump committed out-of-band between
+    the read and that flush makes the version_id_col predicate match zero rows;
+    the resulting StaleDataError must surface as ExpectedVersionError from the
+    forced flush, just as the commit path translates it."""
+    domain = concurrency_domain
+
+    order_id = _seed_occ_order(domain)
+
+    with pytest.raises(ExpectedVersionError):
+        with UnitOfWork():
+            repo = domain.repository_for(OCCOrder)
+            order = repo.get(order_id)
+            order.lines[0].quantity = 5
+
+            # Advance the root's version through an independent connection, after
+            # the in-UoW read+mutation but before the forced flush at add time.
+            provider = domain.providers["default"]
+            with provider._engine.connect() as conn:
+                conn.execute(
+                    text("UPDATE occ_order SET _version = _version + 1 WHERE id = :id"),
+                    {"id": order_id},
+                )
+                conn.commit()
+
+            # The child-only add re-saves the root and flushes -> StaleDataError
+            # -> translated to ExpectedVersionError.
+            repo.add(order)
+
+    # The conflicting UoW rolled back: the in-flight child edit (quantity=5) was
+    # discarded and the row reflects only the out-of-band version bump (0 -> 1),
+    # not a second bump from the failed add.
+    with UnitOfWork():
+        final = domain.repository_for(OCCOrder).get(order_id)
+    assert final._version == 1
+    assert final.lines[0].quantity == 0


### PR DESCRIPTION
## Summary

Closes #1245. The child-entity counterpart of #1087. An aggregate can be modified purely through a **child** entity (a `HasMany`/`HasOne` member) — editing a line item's quantity, with no root-field change and no event. That change was persisted through the **un-versioned** path (a child entity is not an aggregate, so `_validate_and_update_version` never runs for it) while `Repository._do_add` re-saved the root only when the root itself was new or changed. So the root's `_version` was never advanced and **two concurrent child-only edits both succeeded, silently losing one write** with no `ExpectedVersionError`.

## The fix

**Treat the aggregate root as the concurrency boundary for the whole tree.** `Repository._do_add` now re-saves the root when any persisted descendant was directly edited, so the existing version-guarded root save runs and advances `_version`:

- **`Repository._has_changed_child`** (`core/repository.py`) — recursively walks `HasMany`/`HasOne` descendants and returns `True` if any carries `state_.is_changed`. It mirrors the direct-update detection already in `_sync_children`, and reads the child's own `is_changed` rather than the field kind, so it covers a child's **scalar, value-object, and reference** fields uniformly, and **nested grandchildren** at any depth. Newly added children are excluded for free (`mark_changed` no-ops while an entity is `_new`).
- **`SADAO._flush`** (`adapters/repository/sqlalchemy.py`) — translates `StaleDataError` → `ExpectedVersionError`. An aggregate that has child rows forces its root `UPDATE` out at `repo.add`-time flush (parent-before-child ordering), so a child-only version conflict surfaces there rather than at the UoW commit (which already translated it). This also closes a latent bug where a raw `StaleDataError` leaked across the port boundary from any forced flush.
- **`Repository._do_add` rollback on error** — the internally-started UnitOfWork (standalone `add`, no enclosing UoW) is now rolled back if a save/flush raises. Without this, the newly-reachable `ExpectedVersionError` left a dangling in-progress UoW (and, on SQLAlchemy, a session needing rollback) that poisoned the next operation — exactly the retry the changelog tells callers to do.

**Scope.** Editing a child field is guarded. Adding/removing a `HasMany` child through the `add_`/`remove_` collection methods is deliberately out of scope (it does not advance the root version — concurrent adds of distinct children do not race the way concurrent edits of the same data do). Assigning/replacing a `HasOne` child (`aggregate.child = ...`) already goes through the root's own `__setattr__`, so it marks the root changed and is version-guarded like any root-field change. ADR-0013 records the boundary and rationale.

**Adapters.** Memory (atomic in-process check) and Elasticsearch (native `if_seq_no`) already raise `ExpectedVersionError` at `save()`; MSSQL/SQLite share the SADAO `_flush`. Event-sourced aggregates use a separate repository and are unaffected.

## Test plan

- [x] Core tests pass
- [x] Full adapter suite passes
- [x] 100% patch coverage

- **`test_optimistic_locking.py`** (generic, runs on memory/sqlite/postgres via `basic_storage`): child scalar / value-object / HasOne / nested-grandchild edits each bump the root version and a stale child-only write raises `ExpectedVersionError`; negative guards that a no-op re-add, a `HasMany` add-alone, and a `HasMany` remove-alone do **not** bump the version; a standalone stale child write raises and leaves no dangling UoW.
- **`test_postgresql_occ_concurrency.py`**: an 8-worker barrier-synchronized concurrency test (asserts exactly one winner and that the surviving child value is the winner's), plus a deterministic single-threaded flush-conflict test that also asserts the UoW rolled back.
- Adversarial red-team (revert-checked: the behavioral tests go red with the fix off; the boundary guards stay green) surfaced and fixed the standalone-UoW-leak regression, the missing add/remove negative tests, and a documentation overclaim (HasOne assignment is guarded, only HasMany add/remove is out of scope).

## Known limitation (follow-up)

A `HasMany` `remove_` racing a concurrent edit of the same child is not version-guarded (the removal deletes the child row through the un-versioned path). This is the same out-of-scope boundary as add/remove above; version-guarding `HasMany` structural changes is a separate design decision worth its own issue.
