### PR TITLE
Fix lost updates in the Memory adapter's optimistic locking (#1258)

### DIFF
--- a/changes/1258.fixed.md
+++ b/changes/1258.fixed.md
@@ -1,0 +1,1 @@
+Fixed the in-memory database adapter silently losing concurrent updates to the same aggregate. Its optimistic-locking commit is now a real compare-and-set against the live store, so a stale concurrent write raises `ExpectedVersionError` instead of overwriting the winner, and writers to different records no longer clobber each other.

--- a/docs/adr/0013-optimistic-concurrency-and-claim-contract.md
+++ b/docs/adr/0013-optimistic-concurrency-and-claim-contract.md
@@ -73,10 +73,12 @@ hands them back — one round trip, no TOCTOU window. `RETURNING` does not
 preserve the inner `ORDER BY`, so the returned batch is re-sorted in Python to
 honour `order_by`.
 
-**Memory adapter.** Holds the provider's `threading.Lock` across the whole
-read-and-claim section and delegates to the portable default. The lock
-serializes concurrent claimers in-process, which is the strongest guarantee the
-single-process store can offer.
+**Memory adapter.** Holds the provider's reentrant lock (`threading.RLock`)
+across the whole read-and-claim section and delegates to the portable default.
+The lock serializes concurrent claimers in-process, which is the strongest
+guarantee the single-process store can offer. It is reentrant because the
+adapter's compare-and-set commit re-acquires the same lock on the same thread
+when the claim commits standalone.
 
 **MySQL/MariaDB, SQL Server, SQLite, Elasticsearch, and other dialects** use the
 portable default. MySQL and MariaDB have `SKIP LOCKED` but no

--- a/docs/reference/guarantees.md
+++ b/docs/reference/guarantees.md
@@ -66,7 +66,7 @@ the root's `_version`.
 
 | Adapter | Ordering (no `order_by`) | Write atomicity / visibility | OCC & consistency | Isolation / concurrency model |
 |---|---|---|---|---|
-| **Memory** | Insertion order (not a promise) | Copy-on-write session; visible at commit; `rollback()` is a no-op | Real OCC: commit is a compare-and-set that re-checks the version against the live store under the provider lock and merges per record; a stale write raises `ExpectedVersionError` (see below) | Single process; per-provider lock (no MVCC) |
+| **Memory** | Insertion order (not a promise) | Copy-on-write session; visible at commit; `rollback()` discards the session's pending changes | Real OCC: commit is a compare-and-set that re-checks the version against the live store under the provider lock and merges per record; a stale write raises `ExpectedVersionError` (see below) | Single process; per-provider lock (no MVCC) |
 | **SQLAlchemy** (PostgreSQL / MSSQL) | No guaranteed order | Session-scoped writes deferred to the flush at commit (AUTOCOMMIT engine, `autoflush=False`) | OCC via `version_id_col` → `UPDATE … WHERE _version = :expected`; a zero-row match raises `ExpectedVersionError` | **READ COMMITTED or stronger** (see below) |
 | **SQLAlchemy** (SQLite) | No guaranteed order | Session autoflushes; write visible in-session | Same `version_id_col` OCC | Writers serialized; a contended write raises `SQLITE_BUSY` (no READ COMMITTED level) |
 | **Elasticsearch** | No guaranteed order | No multi-document transaction; each write forced `refresh=True` | OCC via `if_seq_no` / `if_primary_term`; a 409 conflict raises `ExpectedVersionError` | None (no transactions) |

--- a/docs/reference/guarantees.md
+++ b/docs/reference/guarantees.md
@@ -66,7 +66,7 @@ the root's `_version`.
 
 | Adapter | Ordering (no `order_by`) | Write atomicity / visibility | OCC & consistency | Isolation / concurrency model |
 |---|---|---|---|---|
-| **Memory** | Insertion order (not a promise) | Copy-on-write session; visible at commit; `rollback()` is a no-op | OCC via a version check under a process-local lock — **holds only single-threaded** (see below) | Single process; per-provider lock (no MVCC) |
+| **Memory** | Insertion order (not a promise) | Copy-on-write session; visible at commit; `rollback()` is a no-op | Real OCC: commit is a compare-and-set that re-checks the version against the live store under the provider lock and merges per record; a stale write raises `ExpectedVersionError` (see below) | Single process; per-provider lock (no MVCC) |
 | **SQLAlchemy** (PostgreSQL / MSSQL) | No guaranteed order | Session-scoped writes deferred to the flush at commit (AUTOCOMMIT engine, `autoflush=False`) | OCC via `version_id_col` → `UPDATE … WHERE _version = :expected`; a zero-row match raises `ExpectedVersionError` | **READ COMMITTED or stronger** (see below) |
 | **SQLAlchemy** (SQLite) | No guaranteed order | Session autoflushes; write visible in-session | Same `version_id_col` OCC | Writers serialized; a contended write raises `SQLITE_BUSY` (no READ COMMITTED level) |
 | **Elasticsearch** | No guaranteed order | No multi-document transaction; each write forced `refresh=True` | OCC via `if_seq_no` / `if_primary_term`; a 409 conflict raises `ExpectedVersionError` | None (no transactions) |
@@ -91,14 +91,20 @@ Work, every repository *on a given provider* shares one session.
 
 Across UoW boundaries, relational adapters see only committed state.
 
-**Memory OCC is single-threaded only.** The Memory adapter takes a per-provider
-lock around the version check, but each session works on a deep-copied snapshot
-and commits by replacing the whole store, so two overlapping sessions can each
-pass the check against their own snapshot and the second commit clobbers the
-first — a lost update with no conflict raised. Memory is a single-writer test/dev
-store; do not rely on its OCC under concurrent sessions (use a real database to
-exercise concurrency — this is why the no-lost-update property test runs on
-PostgreSQL).
+**Memory OCC holds under concurrent sessions.** Each session still works on a
+deep-copied snapshot, but commit is no longer a wholesale replacement: it is a
+compare-and-set. Under the per-provider lock, `MemorySession.commit` re-checks
+each aggregate's `_version` against the *live* store and then merges only the
+records this session changed, key by key. So two overlapping sessions that both
+passed the snapshot check no longer both win — the second commit finds the
+version already moved and raises `ExpectedVersionError`, and sessions writing
+*different* records never clobber each other. This holds on the same
+version-guarded write paths as every adapter (`repository.add` and the DAO's
+`update()`, both through `save()`), with the same root-boundary caveat above
+(independent child changes are guarded only through the root's version). Memory
+is still a single-process test/dev store (no MVCC, no cross-process
+coordination), but on that path its no-lost-update behavior now matches a real
+database, so aggregate-level concurrency tests can run against it.
 
 **Ordering.** A query without an explicit `order_by` has **no guaranteed order**.
 Some adapters are incidentally stable (SQLAlchemy appends `ORDER BY <pk> ASC`,
@@ -133,7 +139,7 @@ stream pages by its per-stream `position`; a category or `$all` read pages by
 
 | Adapter | Per-stream order | Global / `$all` order | Append & OCC | Consistency |
 |---|---|---|---|---|
-| **Memory** | Gapless per-stream `position`, ascending | `global_position` ascending; no gaps (single process, no rollback) | Version check + append atomic under a class lock (conflict raises) **for single-threaded use** — like the repository Memory adapter, the append commits outside the lock, so overlapping sessions can lose an append with no conflict raised | Read-your-writes (in process); single-writer test/dev store |
+| **Memory** | Gapless per-stream `position`, ascending | `global_position` ascending; no gaps (single process, no rollback) | Version check + append atomic under a class lock (conflict raises) **for single-threaded use**. When the append is deferred into an enclosing Unit of Work it publishes after that class lock is released, so overlapping UoWs on the same stream are not serialized — do not rely on the Memory event store under concurrent writers | Read-your-writes (in process); single-writer test/dev store |
 | **MessageDB** | Gapless per-stream `position`, ascending | `global_position` ascending, strictly increasing. **Globally** it may contain gaps — a rolled-back append permanently consumes a value. **Within a single category it is gap-free**: MessageDB serializes same-category writes with a per-category advisory lock held to commit. | `write_message(… expected_version)` stored proc; conflict raises | Read-your-writes (committed before `append` returns) |
 
 **Append is per message.** A Unit of Work that raises N events performs N
@@ -310,6 +316,7 @@ deployment is configured to persist.
 | **#1087** | *No lost update.* The aggregate OCC check is atomic with the write (`UPDATE … WHERE _version = :expected`), so two concurrent updates can no longer both succeed and silently drop one. Holds at READ COMMITTED on PostgreSQL / MSSQL. |
 | **#1249** ([ADR-0024](../adr/0024-event-store-read-position-contract.md)) | *Correct read position.* Category and `$all` reads page by `global_position`, inclusive and ordered, uniformly across adapters — the substrate the no-skip guarantee is expressed on. |
 | **#1088** ([ADR-0025](../adr/0025-all-subscription-gap-safety.md)) | *No silent skip for `$all`.* A late-committing lower `global_position` is no longer stepped over; the cursor holds at the gap until it fills or times out. |
+| **#1258** | *No lost update on the Memory adapter.* `MemorySession.commit` is now a compare-and-set: it re-checks each aggregate's version against the live store under the provider lock and merges only the records it changed, so two concurrent sessions can no longer both succeed and silently drop one. Makes the in-memory adapter a faithful concurrency stand-in (single process, no MVCC). |
 
 ---
 

--- a/src/protean/adapters/repository/memory.py
+++ b/src/protean/adapters/repository/memory.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 from collections.abc import Sequence
 from datetime import date, datetime
 from itertools import count
-from threading import Lock
+from threading import RLock
 from typing import cast
 from uuid import UUID
 
@@ -82,8 +82,34 @@ class MemoryModel(BaseDatabaseModel):
 
 
 class MemorySession:
-    # Heterogeneous session store: ``data`` (the copied databases), ``lock``
-    # (a ``threading.Lock``) and ``counters`` (auto-increment counters).
+    """A copy-on-write view over the provider's in-memory store.
+
+    On construction the session takes a private deep copy of the whole store
+    (``data``); all reads and writes made through it operate on that copy, so a
+    concurrent session never sees this one's uncommitted changes. The changes
+    are published to the shared store only on :meth:`commit`.
+
+    Committing is a **compare-and-set against the live store**, not a wholesale
+    replacement. All writes go through :meth:`write` / :meth:`delete`, which
+    mutate the session copy *and* record the change in one step, so a mutation
+    can never be silently dropped by forgetting to track it. ``commit``
+    re-validates the recorded optimistic-concurrency versions against the *live*
+    store under the provider lock and then merges only the changed records,
+    key-by-key. This is what makes the in-memory provider a faithful stand-in
+    for optimistic locking: two overlapping writers of the same aggregate no
+    longer both "win" (the stale one raises
+    :class:`~protean.exceptions.ExpectedVersionError`), and writers touching
+    *different* records no longer clobber each other on commit.
+    """
+
+    # Heterogeneous session store:
+    #   ``data``           the deep-copied databases this session reads/writes
+    #   ``lock``           a reentrant lock shared per provider
+    #   ``counters``       auto-increment counters
+    #   ``ops``            pending changeset ``(schema, identifier)`` -> "write"
+    #                      | "delete"; last op per record wins
+    #   ``version_checks`` ``(schema, identifier)`` -> expected ``_version`` the
+    #                      live store must still hold for the commit to apply
     _db: dict[str, typing.Any]
 
     def __init__(
@@ -99,22 +125,111 @@ class MemorySession:
                 MemorySession, current_uow._sessions[self._provider.name]
             )._db
         else:
+            lock = self._provider._locks.setdefault(self._provider.name, RLock())
+            # Snapshot under the lock: ``commit`` now mutates the live store in
+            # place (a per-record merge, not a wholesale replacement), so an
+            # unlocked deepcopy could iterate a dict another thread's commit is
+            # resizing and raise "dictionary changed size during iteration". The
+            # lock is reentrant, so taking it here is safe even when the caller
+            # (e.g. ``_claim``) already holds it on this thread.
+            with lock:
+                data = copy.deepcopy(self._provider._databases)
             self._db = {
-                "data": copy.deepcopy(self._provider._databases),
-                "lock": self._provider._locks.setdefault(self._provider.name, Lock()),
+                "data": data,
+                "lock": lock,
                 "counters": self._provider._counters,
+                "ops": {},
+                "version_checks": {},
+                "created": set(),
             }
 
+    def write(
+        self,
+        schema: str,
+        identifier: typing.Any,
+        record: typing.Any,
+        is_new: bool = False,
+    ) -> None:
+        """Store ``record`` in the session copy and mark it for the commit merge.
+
+        The single entry point for creating/updating a record, so a mutation of
+        the session copy is always paired with the tracking ``commit`` needs.
+        ``is_new=True`` marks a record this session *created* (an insert), which
+        exempts it from the commit-time version check: it has no prior version in
+        the live store to match, so ``None`` there is expected, not a conflict.
+        """
+        self._db["data"][schema][identifier] = record
+        self._db["ops"][(schema, identifier)] = "write"
+        if is_new:
+            self._db["created"].add((schema, identifier))
+
+    def delete(self, schema: str, identifier: typing.Any) -> None:
+        """Drop ``identifier`` from the session copy and mark it for the merge."""
+        self._db["data"][schema].pop(identifier, None)
+        self._db["ops"][(schema, identifier)] = "delete"
+
+    def record_version_check(
+        self, schema: str, identifier: typing.Any, expected_version: int
+    ) -> None:
+        """Record the version the live store must still hold for a safe commit.
+
+        Keeps the *first* expected version seen for a record (via
+        ``setdefault``): if the same aggregate is updated twice in one session,
+        the version the live store must match is the one it had when the session
+        started, not the intermediate version produced by the first update.
+
+        A record this session created (then updated in the same session) is
+        skipped: it is not yet in the live store, so there is no prior version
+        to compare against — checking would spuriously conflict on the ``None``.
+        """
+        if (schema, identifier) in self._db["created"]:
+            return
+        self._db["version_checks"].setdefault((schema, identifier), expected_version)
+
+    def _clear_changeset(self) -> None:
+        self._db["ops"].clear()
+        self._db["version_checks"].clear()
+        self._db["created"].clear()
+
     def commit(self) -> None:
-        if current_uow and self._provider.name in current_uow._sessions:
-            cast(MemorySession, current_uow._sessions[self._provider.name])._db[
-                "data"
-            ] = self._db["data"]
-        else:
-            self._provider._databases = self._db["data"]
+        """Validate optimistic-concurrency versions and merge changes to the store.
+
+        Runs the version checks and the merge together under the provider lock,
+        so the whole compare-and-set is atomic with respect to other sessions'
+        commits. A version mismatch raises :class:`ExpectedVersionError` and
+        leaves the live store untouched.
+        """
+        with self._db["lock"]:
+            live = self._provider._databases
+            data = self._db["data"]
+
+            # Compare: every recorded version must still match the live store.
+            for (schema, identifier), expected in self._db["version_checks"].items():
+                stored = live.get(schema, {}).get(identifier)
+                stored_version = stored.get("_version") if stored is not None else None
+                if stored_version != expected:
+                    raise ExpectedVersionError(
+                        f"Wrong expected version: {expected} "
+                        f"(Schema: {schema}, Identifier: {identifier}, "
+                        f"Version: {stored_version})"
+                    )
+
+            # Set: merge this session's changes into the live store record by
+            # record, so concurrent writes to other records are preserved.
+            for (schema, identifier), op in self._db["ops"].items():
+                if op == "write":
+                    live[schema][identifier] = data[schema][identifier]
+                elif schema in live:  # op == "delete"
+                    live[schema].pop(identifier, None)
+
+            # Clear the changeset so a repeated commit is a no-op.
+            self._clear_changeset()
 
     def rollback(self) -> None:
-        pass
+        # Changes live only in this session's ``data`` copy and its pending
+        # changeset until ``commit`` publishes them, so discarding the changeset
+        # (never applying it) is the rollback.
+        self._clear_changeset()
 
     def close(self) -> None:
         pass
@@ -127,7 +242,18 @@ class MemoryProvider(BaseProvider):
 
     @property
     def capabilities(self) -> DatabaseCapabilities:
-        """Memory provider supports basic storage with simulated transactions."""
+        """Basic storage, simulated transactions, and real optimistic locking.
+
+        ``OPTIMISTIC_LOCKING`` is a genuine guarantee here, not just for the
+        sequential case: on the version-guarded write path (``repository.add``
+        and the DAO's ``update()``, both through ``save()``),
+        :meth:`MemorySession.commit` validates the aggregate version against the
+        live store under the provider lock, so two overlapping writers of the
+        same aggregate cannot both succeed — the stale one raises
+        :class:`~protean.exceptions.ExpectedVersionError`. The aggregate root is
+        the concurrency boundary, so independent child changes are guarded only
+        through the root's version; see ``docs/reference/guarantees.md``.
+        """
         return DatabaseCapabilities.IN_MEMORY
 
     def __init__(
@@ -140,7 +266,10 @@ class MemoryProvider(BaseProvider):
 
         # Global in-memory store of dict data.
         self._databases: dict[str, dict[typing.Any, typing.Any]] = defaultdict(dict)
-        self._locks: dict[str, Lock] = defaultdict(Lock)
+        # Reentrant so a method that already holds the lock (e.g. ``_claim``) can
+        # call through to a standalone ``commit`` — which re-acquires it — in the
+        # same thread without deadlocking.
+        self._locks: dict[str, RLock] = defaultdict(RLock)
         self._counters: dict[str, count[int]] = defaultdict(count)
 
         # A temporary cache of already constructed model classes
@@ -166,7 +295,7 @@ class MemoryProvider(BaseProvider):
     def _data_reset(self) -> None:
         """Reset data"""
         self._databases = defaultdict(dict)
-        self._locks = defaultdict(Lock)
+        self._locks = defaultdict(RLock)
         self._counters = defaultdict(count)
 
         # Discard any active Unit of Work
@@ -456,7 +585,7 @@ class DictDAO(BaseDAO):
             self._check_unique_indexes(
                 model_obj, conn._db["data"][self.schema_name], identifier
             )
-            conn._db["data"][self.schema_name][identifier] = model_obj
+            conn.write(self.schema_name, identifier, model_obj, is_new=True)
 
         self._commit_if_standalone(conn)
 
@@ -604,7 +733,13 @@ class DictDAO(BaseDAO):
                     f"does not exist."
                 )
 
-            # Atomic version check under lock
+            # Version check against this session's snapshot. This catches a
+            # stale write early (the common sequential case, where the snapshot
+            # already reflects a newer committed version). The authoritative
+            # check for the *concurrent* case runs again against the live store
+            # in ``MemorySession.commit`` — two writers that both pass here
+            # against their own snapshots are reconciled there, so the stale one
+            # still raises rather than silently losing its update.
             if expected_version is not None:
                 stored = conn._db["data"][self.schema_name][identifier]
                 stored_version = stored.get("_version")
@@ -614,6 +749,9 @@ class DictDAO(BaseDAO):
                         f"(Aggregate: {self.entity_cls.__name__}({identifier}), "
                         f"Version: {stored_version})"
                     )
+                conn.record_version_check(
+                    self.schema_name, identifier, expected_version
+                )
 
             # Reject updates that would collide with another row on a declared
             # unique index, mirroring the relational adapters' DDL enforcement.
@@ -621,7 +759,7 @@ class DictDAO(BaseDAO):
                 model_obj, conn._db["data"][self.schema_name], identifier
             )
 
-            conn._db["data"][self.schema_name][identifier] = model_obj
+            conn.write(self.schema_name, identifier, model_obj)
 
         self._commit_if_standalone(conn)
 
@@ -639,7 +777,7 @@ class DictDAO(BaseDAO):
             item = items[key]
             item.update(*args)
             item.update(kwargs)
-            conn._db["data"][self.schema_name][key] = item
+            conn.write(self.schema_name, key, item)
 
             update_count += 1
 
@@ -658,13 +796,14 @@ class DictDAO(BaseDAO):
 
         The memory adapter has no row-level locking, and its ``_update_all`` is
         not atomic across threads (it reads-then-writes). Holding the provider's
-        ``threading.Lock`` across the whole read-and-claim section serializes
-        concurrent claimers in-process, which is the strongest guarantee the
-        single-process memory store can offer. With the lock held, the portable
+        lock across the whole read-and-claim section serializes concurrent
+        claimers in-process, which is the strongest guarantee the single-process
+        memory store can offer. With the lock held, the portable
         :meth:`BaseDAO._claim` default is race-free.
 
-        The lock is non-reentrant; neither ``_filter`` nor ``_update_all``
-        (which the default delegates to) reacquires it, so there is no deadlock.
+        The lock is a reentrant ``RLock``: ``_update_all`` commits standalone,
+        and :meth:`MemorySession.commit` re-acquires the same lock on this
+        thread to run its compare-and-set, so it must nest without deadlocking.
         """
         conn = self._get_session()
         assert conn is not None
@@ -687,7 +826,7 @@ class DictDAO(BaseDAO):
                     f"does not exist."
                 )
 
-            del conn._db["data"][self.schema_name][identifier]
+            conn.delete(self.schema_name, identifier)
 
         self._commit_if_standalone(conn)
 
@@ -739,7 +878,7 @@ class DictDAO(BaseDAO):
 
             to_delete = keys[:limit]
             for identifier in to_delete:
-                conn._db["data"][self.schema_name].pop(identifier, None)
+                conn.delete(self.schema_name, identifier)
 
         self._commit_if_standalone(conn)
 
@@ -758,11 +897,14 @@ class DictDAO(BaseDAO):
             # Delete all the matching identifiers
             with conn._db["lock"]:
                 for identifier in items:
-                    conn._db["data"][self.schema_name].pop(identifier, None)
+                    conn.delete(self.schema_name, identifier)
         else:
+            # Delete every record one at a time (rather than dropping the whole
+            # schema) so the commit merge removes exactly what this session saw
+            # and does not clobber records another session inserted concurrently.
             with conn._db["lock"]:
-                if self.schema_name in conn._db["data"]:
-                    del conn._db["data"][self.schema_name]
+                for identifier in list(conn._db["data"].get(self.schema_name, {})):
+                    conn.delete(self.schema_name, identifier)
 
         self._commit_if_standalone(conn)
 

--- a/src/protean/adapters/repository/memory.py
+++ b/src/protean/adapters/repository/memory.py
@@ -903,7 +903,8 @@ class DictDAO(BaseDAO):
             # schema) so the commit merge removes exactly what this session saw
             # and does not clobber records another session inserted concurrently.
             with conn._db["lock"]:
-                for identifier in list(conn._db["data"].get(self.schema_name, {})):
+                items = list(conn._db["data"].get(self.schema_name, {}))
+                for identifier in items:
                     conn.delete(self.schema_name, identifier)
 
         self._commit_if_standalone(conn)

--- a/src/protean/core/unit_of_work.py
+++ b/src/protean/core/unit_of_work.py
@@ -378,6 +378,17 @@ class UnitOfWork:
                 g._access_log_uow_outcome = "committed"
 
             logger.debug("uow.commit_successful")
+        except ExpectedVersionError as exc:
+            # An adapter may detect an optimistic-concurrency conflict directly
+            # at commit time and raise ExpectedVersionError itself — the
+            # in-memory provider does this in its compare-and-set commit. That
+            # is a concurrency conflict, not a generic transaction failure, so
+            # propagate it unchanged for the version-retry machinery (mirrors
+            # the StaleDataError translation below). Without this, the generic
+            # handler would wrap it in TransactionError.
+            logger.exception("uow.commit_failed", exc_info=True)
+            set_span_error(span, exc)
+            raise
         except ValueError as exc:
             logger.exception("uow.commit_failed", exc_info=True)
             set_span_error(span, exc)

--- a/tests/adapters/repository/memory/test_memory_dict_dao.py
+++ b/tests/adapters/repository/memory/test_memory_dict_dao.py
@@ -10,3 +10,17 @@ class User(BaseAggregate):
 def test_memory_dao_repr(test_domain):
     dao = test_domain.repository_for(User)._dao
     assert str(dao) == "DictDAO <User>"
+
+
+def test_delete_all_without_criteria_returns_deleted_count(test_domain):
+    """``_delete_all()`` with no criteria returns the number of records removed,
+    matching the SQLAlchemy and Elasticsearch adapters (it used to return 0)."""
+    dao = test_domain.repository_for(User)._dao
+    dao.create(email="a@example.com", password="x")
+    dao.create(email="b@example.com", password="y")
+    dao.create(email="c@example.com", password="z")
+
+    deleted = dao._delete_all()
+
+    assert deleted == 3
+    assert dao.query.all().total == 0

--- a/tests/adapters/repository/memory/test_memory_occ_concurrency.py
+++ b/tests/adapters/repository/memory/test_memory_occ_concurrency.py
@@ -70,11 +70,18 @@ def _seed_order(test_domain):
 
 
 def _run_workers(worker):
-    threads = [threading.Thread(target=worker, args=(i,)) for i in range(_WORKERS)]
+    threads = [
+        threading.Thread(target=worker, args=(i,), daemon=True) for i in range(_WORKERS)
+    ]
     for thread in threads:
         thread.start()
     for thread in threads:
         thread.join(timeout=30)
+    # A thread still alive means it hung past the join timeout; fail loudly here
+    # rather than letting a live thread mutate shared state under later asserts.
+    assert not any(thread.is_alive() for thread in threads), (
+        "a worker thread did not finish within the join timeout"
+    )
 
 
 def test_concurrent_updates_do_not_silently_lose_writes(test_domain):

--- a/tests/adapters/repository/memory/test_memory_occ_concurrency.py
+++ b/tests/adapters/repository/memory/test_memory_occ_concurrency.py
@@ -1,0 +1,279 @@
+"""Concurrency regression for the in-memory adapter's optimistic locking.
+
+The bug (#1258): a ``MemorySession`` deep-copied the whole store and committed
+by replacing it wholesale. Two overlapping writers each passed the version
+check against their own private copy and the last commit clobbered the rest,
+with no ``ExpectedVersionError`` raised — a silent lost update.
+
+The fix makes ``MemorySession.commit`` a real compare-and-set: it re-validates
+each aggregate's version against the *live* store under the provider lock and
+merges only its own changed records, key-by-key. So exactly one concurrent
+writer of an aggregate wins and the rest raise ``ExpectedVersionError``, and
+writers touching *different* records never clobber each other.
+
+These tests contrast with ``test_postgresql_occ_concurrency.py``: that suite
+proves the same property on a real relational backend; before this fix the
+in-memory adapter could not stand in for it.
+"""
+
+import threading
+
+import pytest
+
+from protean.core.aggregate import BaseAggregate
+from protean.core.entity import BaseEntity
+from protean.core.unit_of_work import UnitOfWork
+from protean.exceptions import ExpectedVersionError
+from protean.fields import HasMany, Integer, Reference, String
+
+_WORKERS = 8
+
+
+class Counter(BaseAggregate):
+    label: String(max_length=20, required=False)
+    value: Integer(default=0)
+
+
+class Order(BaseAggregate):
+    label: String(max_length=20, required=False)
+    lines = HasMany("OrderLine")
+
+
+class OrderLine(BaseEntity):
+    sku: String(max_length=20, required=True)
+    quantity: Integer(default=0)
+
+    order = Reference(Order)
+
+
+@pytest.fixture(autouse=True)
+def register_elements(test_domain):
+    test_domain.register(Counter)
+    test_domain.register(Order)
+    test_domain.register(OrderLine, part_of=Order)
+    test_domain.init(traverse=False)
+
+
+def _seed_counter(test_domain):
+    with UnitOfWork():
+        seed = Counter(value=0)
+        test_domain.repository_for(Counter).add(seed)
+    return seed.id
+
+
+def _seed_order(test_domain):
+    with UnitOfWork():
+        seed = Order(label="seed")
+        seed.add_lines(OrderLine(sku="A", quantity=0))
+        test_domain.repository_for(Order).add(seed)
+    return seed.id
+
+
+def _run_workers(worker):
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(_WORKERS)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+
+
+def test_concurrent_updates_do_not_silently_lose_writes(test_domain):
+    """Every worker loads version 0 before any commits, so the writes race.
+    Exactly one wins; the rest raise ExpectedVersionError. Before the fix all
+    eight "succeeded" and the version advanced once — seven lost updates."""
+    counter_id = _seed_counter(test_domain)
+
+    load_barrier = threading.Barrier(_WORKERS, timeout=20)
+    results: list[tuple[int, str]] = []
+    results_lock = threading.Lock()
+
+    def worker(worker_no: int) -> None:
+        try:
+            with test_domain.domain_context(), UnitOfWork():
+                repo = test_domain.repository_for(Counter)
+                counter = repo.get(counter_id)
+                counter.label = f"w{worker_no}"
+                counter.value = worker_no + 1
+                load_barrier.wait()
+                repo.add(counter)
+            outcome = "success"
+        except ExpectedVersionError:
+            outcome = "conflict"
+        except Exception as exc:  # surfaced via the assertion below
+            outcome = f"error:{type(exc).__name__}:{exc}"
+        with results_lock:
+            results.append((worker_no, outcome))
+
+    _run_workers(worker)
+
+    winners = [w for w, o in results if o == "success"]
+    conflict = sum(1 for _, o in results if o == "conflict")
+
+    assert len(results) == _WORKERS, results
+    assert all(o in ("success", "conflict") for _, o in results), results
+
+    with UnitOfWork():
+        final = test_domain.repository_for(Counter).get(counter_id)
+
+    # The invariant the bug violated: each success advances the version once, so
+    # successes == final version. A silent lost update reports more successes.
+    assert len(winners) == final._version, (
+        f"lost update: {len(winners)} successes but version is {final._version}"
+    )
+    assert len(winners) == 1, results
+    assert conflict == _WORKERS - 1, results
+    # The surviving value belongs to the single winning writer — not just "some
+    # writer's value", which a version bumped without the write would also pass.
+    assert final.value == winners[0] + 1, (winners, final.value)
+
+
+def test_concurrent_child_only_updates_do_not_silently_lose_writes(test_domain):
+    """The aggregate root is the concurrency boundary: when every worker changes
+    only a *child* line, the root's version must still guard the write."""
+    order_id = _seed_order(test_domain)
+
+    load_barrier = threading.Barrier(_WORKERS, timeout=20)
+    results: list[tuple[int, str]] = []
+    results_lock = threading.Lock()
+
+    def worker(worker_no: int) -> None:
+        try:
+            with test_domain.domain_context(), UnitOfWork():
+                repo = test_domain.repository_for(Order)
+                order = repo.get(order_id)
+                order.lines[0].quantity = worker_no + 1
+                load_barrier.wait()
+                repo.add(order)
+            outcome = "success"
+        except ExpectedVersionError:
+            outcome = "conflict"
+        except Exception as exc:  # surfaced via the assertion below
+            outcome = f"error:{type(exc).__name__}:{exc}"
+        with results_lock:
+            results.append((worker_no, outcome))
+
+    _run_workers(worker)
+
+    winners = [w for w, o in results if o == "success"]
+    conflict = sum(1 for _, o in results if o == "conflict")
+
+    assert len(results) == _WORKERS, results
+    assert all(o in ("success", "conflict") for _, o in results), results
+
+    with UnitOfWork():
+        final = test_domain.repository_for(Order).get(order_id)
+
+    assert len(winners) == final._version, (
+        f"lost update: {len(winners)} successes but version is {final._version}"
+    )
+    assert len(winners) == 1, results
+    assert conflict == _WORKERS - 1, results
+    # The surviving child value belongs to the single winning writer.
+    assert final.lines[0].quantity == winners[0] + 1
+
+
+def test_concurrent_updates_to_distinct_aggregates_all_succeed(test_domain):
+    """Writers touching *different* aggregates must not conflict or clobber each
+    other. Under the old wholesale-replace commit, one committer's snapshot
+    overwrote the whole store and silently dropped the others' rows."""
+    ids = [_seed_counter(test_domain) for _ in range(_WORKERS)]
+
+    load_barrier = threading.Barrier(_WORKERS, timeout=20)
+    results: list[str] = []
+    results_lock = threading.Lock()
+
+    def worker(worker_no: int) -> None:
+        try:
+            with test_domain.domain_context(), UnitOfWork():
+                repo = test_domain.repository_for(Counter)
+                counter = repo.get(ids[worker_no])
+                counter.value = worker_no + 100
+                load_barrier.wait()
+                repo.add(counter)
+            outcome = "success"
+        except Exception as exc:  # surfaced via the assertion below
+            outcome = f"error:{type(exc).__name__}:{exc}"
+        with results_lock:
+            results.append(outcome)
+
+    _run_workers(worker)
+
+    assert results == ["success"] * _WORKERS, results
+
+    # Every distinct aggregate advanced to version 1 and kept its own value —
+    # nothing was clobbered by a concurrent committer.
+    with UnitOfWork():
+        repo = test_domain.repository_for(Counter)
+        for worker_no, identifier in enumerate(ids):
+            final = repo.get(identifier)
+            assert final._version == 1, (worker_no, final._version)
+            assert final.value == worker_no + 100, (worker_no, final.value)
+
+
+def test_commit_time_version_conflict_raises_expected_version_error(test_domain):
+    """Deterministic exercise of the commit-time version check.
+
+    A version bump applied to the *live* store after the in-UoW read+add but
+    before the UoW commit makes the compare-and-set find a version it did not
+    expect, so the commit raises ExpectedVersionError."""
+    counter_id = _seed_counter(test_domain)
+    provider = test_domain.providers["default"]
+
+    with pytest.raises(ExpectedVersionError):
+        with UnitOfWork():
+            repo = test_domain.repository_for(Counter)
+            counter = repo.get(counter_id)
+            counter.value = 5
+            repo.add(counter)
+
+            # Advance the live row's version out-of-band (the memory analog of a
+            # commit from an independent connection). The UoW's snapshot still
+            # shows the old version, so only the commit-time check catches it.
+            provider._databases["counter"][counter_id]["_version"] += 1
+            # Exiting the UoW commits -> compare-and-set fails -> raises.
+
+    # The conflicting UoW did not publish its change: value stays 0, and the
+    # only version change is the out-of-band bump (0 -> 1).
+    with UnitOfWork():
+        final = test_domain.repository_for(Counter).get(counter_id)
+    assert final._version == 1
+    assert final.value == 0
+
+
+def test_commit_time_vanished_record_raises_expected_version_error(test_domain):
+    """A record deleted from the live store between the in-UoW read+add and the
+    UoW commit makes the version check find nothing where it expected a version,
+    which is a concurrency conflict -> ExpectedVersionError."""
+    counter_id = _seed_counter(test_domain)
+    provider = test_domain.providers["default"]
+
+    with pytest.raises(ExpectedVersionError):
+        with UnitOfWork():
+            repo = test_domain.repository_for(Counter)
+            counter = repo.get(counter_id)
+            counter.value = 5
+            repo.add(counter)
+
+            # Delete the live row out-of-band before the commit.
+            del provider._databases["counter"][counter_id]
+
+    # The row stays gone; the failed commit did not resurrect it.
+    assert counter_id not in provider._databases["counter"]
+
+
+def test_create_then_update_same_aggregate_in_one_uow_commits_cleanly(test_domain):
+    """A record created and then updated in the SAME UnitOfWork must commit
+    cleanly. The commit-time version check must not treat the not-yet-published
+    record as a concurrent conflict: it was created in this session, so it has
+    no prior live version and the ``None`` there is expected, not a conflict."""
+    with UnitOfWork():
+        repo = test_domain.repository_for(Counter)
+        counter = Counter(value=1)
+        repo.add(counter)  # create
+        counter.value = 2
+        repo.add(counter)  # update the same aggregate, still in this UoW
+    counter_id = counter.id
+
+    # Committed without a spurious ExpectedVersionError, and the update stuck.
+    persisted = test_domain.repository_for(Counter).get(counter_id)
+    assert persisted.value == 2

--- a/tests/adapters/repository/memory/test_memory_session_uow.py
+++ b/tests/adapters/repository/memory/test_memory_session_uow.py
@@ -102,7 +102,13 @@ def test_memory_session_new_connection_bypasses_uow(test_domain):
 
 
 def test_memory_session_commit_without_uow(test_domain):
-    """Test that MemorySession.commit works when no UoW is active"""
+    """Test that MemorySession.commit works when no UoW is active.
+
+    ``commit`` merges the session's recorded changeset into the live store
+    (a compare-and-set). Writes go through ``session.write``, which mutates the
+    session copy and records the change together — exactly what the DAO write
+    paths do.
+    """
     # Create a product without UoW
     product = Product(name="Monitor", price=200)
     test_domain.repository_for(Product).add(product)
@@ -110,12 +116,14 @@ def test_memory_session_commit_without_uow(test_domain):
     provider = test_domain.providers["default"]
     session = provider.get_session()
 
-    # Modify data in the session
+    # Modify data in the session through the write choke-point (as the DAO does)
     schema_name = "product"
     product_id = next(iter(session._db["data"][schema_name].keys()))
-    session._db["data"][schema_name][product_id]["price"] = 250
+    record = session._db["data"][schema_name][product_id]
+    record["price"] = 250
+    session.write(schema_name, product_id, record)
 
-    # Commit should update the provider's database directly
+    # Commit should merge the recorded change into the provider's database
     session.commit()
 
     # Verify the provider's database has the updated data

--- a/tests/adapters/repository/memory/test_memory_session_uow.py
+++ b/tests/adapters/repository/memory/test_memory_session_uow.py
@@ -101,6 +101,20 @@ def test_memory_session_new_connection_bypasses_uow(test_domain):
         )  # Data in UoW session
 
 
+def test_create_then_delete_same_aggregate_in_one_uow_persists_nothing(test_domain):
+    """Creating and then deleting the same aggregate within one UnitOfWork
+    commits cleanly and persists nothing. At commit the record's op is a delete
+    and its schema was never published to the live store, so the merge has
+    nothing to pop and simply skips it."""
+    with UnitOfWork():
+        repo = test_domain.repository_for(Product)
+        product = Product(name="Ephemeral", price=1)
+        repo.add(product)
+        repo._dao.delete(product)
+
+    assert test_domain.repository_for(Product)._dao.query.all().total == 0
+
+
 def test_memory_session_commit_without_uow(test_domain):
     """Test that MemorySession.commit works when no UoW is active.
 


### PR DESCRIPTION
## Summary

The Memory repository adapter advertised `OPTIMISTIC_LOCKING` but silently lost concurrent updates. A `MemorySession` deep-copied the whole store and committed by replacing it wholesale, so two overlapping writers each passed the version check against their own snapshot and the last commit clobbered the rest, with no `ExpectedVersionError` raised.

This makes the Memory adapter's optimistic locking real, so it is a faithful stand-in for concurrency tests (single process):

- `MemorySession.commit` is now a compare-and-set. Under the per-provider lock it re-checks each aggregate's `_version` against the **live** store, then merges only the records this session changed, key by key. A stale writer now raises `ExpectedVersionError`; writers touching different records no longer clobber each other.
- Writes go through `MemorySession.write()` / `delete()` choke-points that mutate the session copy and record the change together, so a mutation can't be dropped by forgetting to track it.
- The session snapshot (`deepcopy`) is now taken under the lock, because commit mutates the live store in place. The lock is an `RLock` so `_claim` (which holds it and calls through to a standalone commit) doesn't deadlock.
- `UnitOfWork._do_commit` now lets an `ExpectedVersionError` raised at commit time propagate instead of wrapping it in `TransactionError`, matching the existing `StaleDataError` handling, so the version-retry machinery sees the conflict.

## Design note

Issue #1258 offered two directions: (a) make the compare-and-set real, or (b) drop the `OPTIMISTIC_LOCKING` capability and document memory as single-writer. Option (a) was chosen so the in-memory adapter can stand in for concurrency tests.

## Scope / known limitations (unchanged by this PR)

These are pre-existing and out of scope; the guarantees doc already scopes them:

- The guarantee holds on the version-guarded write paths (`repository.add` and the DAO's `update()`, both through `save()`). Independent child-only changes are guarded only through the root's version, same as every adapter.
- Deletes are not version-guarded, so a delete racing a write is not caught. This matches existing delete semantics across adapters.
- Cross-provider atomicity is not guaranteed (simulated transactions): if one provider's session merges and a second raises a conflict, the first is already applied.
- The Memory event store's stream-version check is a separate mechanism and remains single-writer only; concurrent appends to the same stream deferred into an enclosing UoW are still not serialized. The guarantees doc says not to rely on the Memory event store under concurrent writers.

## Test plan

- [x] New concurrency tests in `tests/adapters/repository/memory/test_memory_occ_concurrency.py`: barrier-forced concurrent same-aggregate update, concurrent child-only update, concurrent updates to distinct aggregates (no false conflict/clobber), deterministic commit-time version conflict, deterministic vanished-record conflict, and a create-then-update-in-one-UoW regression guard.
- [x] Revert check: reverting only the source fix makes the 5 conflict tests go red with the exact lost-update symptom; they pass again when restored.
- [x] Core suite (`protean test`) passes.
- [x] Full adapter matrix (`protean test -c FULL`) passes for memory, PostgreSQL, SQLite, Elasticsearch, Redis, and MessageDB. MSSQL could not run in the local environment (no ODBC driver installed); CI verifies it.
- [x] `ruff` + `mypy --strict` clean.
- [x] 100% patch coverage.

Closes #1258
