### PR TITLE
fix: make generated example domain traversable

### DIFF
--- a/changes/1316.fixed.md
+++ b/changes/1316.fixed.md
@@ -1,0 +1,1 @@
+Fix `protean new` so the generated example project initialises through a normal `domain.init()` (and passes `protean check`). The scaffold previously shipped package re-exports that broke traversal, plus a projector and projection with a missing-module import, an aggregate referenced by name instead of class, and no identifier field.

--- a/src/protean/template/domain_template/src/{{package_name}}/{% if include_example %}example{% endif %}/__init__.py.jinja
+++ b/src/protean/template/domain_template/src/{{package_name}}/{% if include_example %}example{% endif %}/__init__.py.jinja
@@ -1,23 +1,6 @@
-"""Example aggregate module."""
+"""Example aggregate package.
 
-from .aggregate import Example
-from .command_handlers import ExampleCommandHandler
-from .commands import ActivateExample, ArchiveExample, CreateExample
-from .event_handlers import ExampleEventHandler
-from .events import ExampleActivated, ExampleArchived, ExampleCreated
-from .repository import ExampleRepository
-from .value_objects import Address
-
-__all__ = [
-    "Example",
-    "ExampleRepository",
-    "CreateExample",
-    "ActivateExample",
-    "ArchiveExample",
-    "ExampleCreated",
-    "ExampleActivated",
-    "ExampleArchived",
-    "ExampleCommandHandler",
-    "ExampleEventHandler",
-    "Address",
-]
+Modules are discovered independently by ``domain.init()``. Keep this package
+initializer side-effect free so relative imports during traversal cannot create
+partially initialized-module cycles.
+"""

--- a/src/protean/template/domain_template/src/{{package_name}}/{% if include_example %}example{% endif %}/projection.py.jinja
+++ b/src/protean/template/domain_template/src/{{package_name}}/{% if include_example %}example{% endif %}/projection.py.jinja
@@ -6,13 +6,14 @@ from typing import Annotated
 from pydantic import Field
 
 from {{ package_name }}.domain import {{ domain_name }}
+from protean.fields import Identifier
 
 
 @{{ domain_name }}.projection
 class ExampleSummary:
     """Read-optimized projection of Example aggregates."""
 
-    example_id: str
+    example_id: Identifier(identifier=True)
     name: Annotated[str, Field(max_length=100)]
     status: str
     created_at: datetime

--- a/src/protean/template/domain_template/src/{{package_name}}/{% if include_example %}example{% endif %}/projectors.py.jinja
+++ b/src/protean/template/domain_template/src/{{package_name}}/{% if include_example %}example{% endif %}/projectors.py.jinja
@@ -2,14 +2,15 @@
 
 from datetime import UTC, datetime
 
-from protean import on
+from protean.core.projector import on
 
 from {{ package_name }}.domain import {{ domain_name }}
+from .aggregate import Example
 from {{ package_name }}.example.events import ExampleActivated, ExampleArchived, ExampleCreated
-from .example_summary import ExampleSummary
+from .projection import ExampleSummary
 
 
-@{{ domain_name }}.projector(projector_for=ExampleSummary, aggregates=["Example"])
+@{{ domain_name }}.projector(projector_for=ExampleSummary, aggregates=[Example])
 class ExampleProjector:
     """Update ExampleSummary projection based on Example events."""
 

--- a/tests/cli/test_new_generates_a_working_project.py
+++ b/tests/cli/test_new_generates_a_working_project.py
@@ -40,7 +40,16 @@ OFFLINE_CHOICES: list[tuple[str, list[str]]] = [
 _INIT = (
     "import sys; sys.path.insert(0, 'src')\n"
     "from {pkg}.domain import {pkg} as domain\n"
-    "domain.init(traverse=False)\n"
+    "domain.init()\n"
+    "print('initialised')\n"
+)
+
+_INIT_REVERSED = (
+    "import os; _listdir = os.listdir; "
+    "os.listdir = lambda path: list(reversed(_listdir(path)))\n"
+    "import sys; sys.path.insert(0, 'src')\n"
+    "from {pkg}.domain import {pkg} as domain\n"
+    "domain.init()\n"
     "print('initialised')\n"
 )
 
@@ -75,6 +84,23 @@ class TestGeneratedProjectStarts:
         assert completed.returncode == 0, (
             f"`protean new` with {label} generates a project whose domain does "
             f"not initialise:\n{completed.stderr}"
+        )
+        assert "initialised" in completed.stdout
+
+    def test_domain_initialises_with_reverse_discovery_order(self, tmp_path):
+        """Package discovery must not depend on filesystem enumeration order."""
+        project = _generate(tmp_path, [])
+
+        completed = subprocess.run(
+            [sys.executable, "-c", _INIT_REVERSED.format(pkg="scaffolded")],
+            cwd=project,
+            capture_output=True,
+            text=True,
+        )
+
+        assert completed.returncode == 0, (
+            "The generated domain must initialise when module discovery order "
+            f"is reversed:\n{completed.stderr}"
         )
         assert "initialised" in completed.stdout
 

--- a/tests/cli/test_new_generates_a_working_project.py
+++ b/tests/cli/test_new_generates_a_working_project.py
@@ -46,7 +46,7 @@ _INIT = (
 
 _INIT_REVERSED = (
     "import os; _listdir = os.listdir; "
-    "os.listdir = lambda path: list(reversed(_listdir(path)))\n"
+    "os.listdir = lambda *args, **kwargs: list(reversed(_listdir(*args, **kwargs)))\n"
     "import sys; sys.path.insert(0, 'src')\n"
     "from {pkg}.domain import {pkg} as domain\n"
     "domain.init()\n"


### PR DESCRIPTION
## What

Fixes #1316.

Make default `protean new` example project load successfully through normal `domain.init()` traversal.

## Why this shape

Scaffold had five traversal blockers: package re-exports could create partially initialized-module cycles; projector referenced missing projection module; `on` came from non-exported top-level location; projection lacked identifier; projector passed aggregate name string where stream metadata requires aggregate class. Fix aligns generated code with existing APIs, removes side-effectful package re-exports, and adds no framework behavior changes.

Acceptance test also reverses `os.listdir()` order to prevent filesystem-order false greens.

## Test plan

- `uv run pytest -q tests/cli/test_new_generates_a_working_project.py` — **17 passed**
- `uv run pytest -q tests/projector` — **61 passed, 1 skipped**
- `uv run ruff check src/protean/template/domain_template tests/cli/test_new_generates_a_working_project.py` — pass
- `uv run ruff format --check tests/cli/test_new_generates_a_working_project.py` — pass
- `uv build --clear --no-create-gitignore --no-sources` — pass
- `git diff --check` — pass

Full suite baseline note: **11,610 passed, 833 skipped, 1 xfailed**, with one unrelated existing `test_load_env_vars` fixture-value mismatch.
