### PR TITLE
Add a Roadmap link to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Tests](https://img.shields.io/badge/tests-12%2C000%2B-brightgreen)](https://docs.proteanhq.com/community/quality/)
 [![Maintainability](https://img.shields.io/badge/maintainability-A-brightgreen)](https://docs.proteanhq.com/community/quality/)
 
-**🗺️ Roadmap:** [where Protean is headed next](https://github.com/proteanhq/protean/discussions/1356), and the [current 0.18 milestone](https://github.com/proteanhq/protean/milestone/21) for the detail.
+**🗺️ Roadmap:** [where Protean is headed next](https://github.com/proteanhq/protean/discussions/1356), and the [current milestone](https://github.com/proteanhq/protean/milestones) for the issue-by-issue detail.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 [![Tests](https://img.shields.io/badge/tests-12%2C000%2B-brightgreen)](https://docs.proteanhq.com/community/quality/)
 [![Maintainability](https://img.shields.io/badge/maintainability-A-brightgreen)](https://docs.proteanhq.com/community/quality/)
 
+**🗺️ Roadmap:** [where Protean is headed next](https://github.com/proteanhq/protean/discussions/1356), and the [current 0.18 milestone](https://github.com/proteanhq/protean/milestone/21) for the detail.
+
 ## Installation
 
 Protean is available on PyPI:


### PR DESCRIPTION
Adds a short Roadmap callout near the top of the README, linking to:

- the roadmap discussion (the narrative: where things are headed and why)
- the current 0.18 milestone (the live, issue-by-issue detail)

This makes Protean's near-term direction one click from the landing page. The discussion is the curated narrative; the milestone stays the source of truth for what is actually in a release.