### PR TITLE
Right-size the runtime dependency surface behind feature extras

### DIFF
--- a/changes/1000.changed.md
+++ b/changes/1000.changed.md
@@ -1,0 +1,3 @@
+**Breaking.** Right-sized the runtime dependency surface: `fastapi`, `uvicorn`, `jinja2`, `ipython`, and `copier` moved out of the core install into feature extras (`protean[server]`, `protean[shell]`, `protean[scaffold]`), with `protean[cli]` and `protean[all]` convenience bundles. A plain `pip install protean` is now lean. Running `protean observatory`/`shell`/`new` or importing `protean.integrations.fastapi` without the matching extra now fails with an actionable "install protean[extra]" message instead of a raw `ModuleNotFoundError`. `protean[all]` restores the pre-0.18 install.
+
+**Migration:** [Right-size the runtime dependency surface](https://docs.proteanhq.com/reference/migration/v0-18/#what-moved-behind-extras)

--- a/docs/adr/0029-runtime-dependency-boundary-and-extras.md
+++ b/docs/adr/0029-runtime-dependency-boundary-and-extras.md
@@ -1,0 +1,133 @@
+# ADR-0029: Runtime Dependency Boundary and Feature Extras
+
+**Status:** Accepted
+
+**Date:** August 2026
+
+## Context
+
+A plain `pip install protean` used to pull a web server, an ASGI stack, a Jinja
+template engine, an interactive REPL, a project scaffolder, and an HTML
+sanitizer, whether or not the consumer ever ran a server, opened a shell, or
+generated a project. The adapter ecosystem was already right: `postgresql`,
+`redis`, `elasticsearch`, `flask`, and `sendgrid` are extras, installed only
+when the consumer talks to that infrastructure. But several install-time-optional
+concerns were hard runtime dependencies in `[project].dependencies`:
+
+- `fastapi`, `uvicorn`, `jinja2` — the HTTP/ASGI/observatory stack, used only by
+  `protean observatory` and `protean.integrations.fastapi`.
+- `ipython` — the interactive shell, used only by `protean shell`.
+- `copier` — project scaffolding, used only by `protean new`.
+
+None of these are imported by `import protean` — the imports were already lazy,
+gated behind a CLI subcommand or an opt-in integration module. So the cost was
+not import coupling; it was **install footprint** and the dependency-conflict
+surface every consumer inherited. FastAPI itself models the fix (it pushes
+`uvicorn` into `fastapi[standard]`); Requests keeps its core at a handful of
+dependencies.
+
+Two more packages were candidates but stay in core after review. `bleach` (HTML
+sanitization) looked optional — used only for String/Text field sanitization —
+until you notice that `String()` and `Text()` default to `sanitize=True`. Nearly
+every domain has a string field, so bleach runs for nearly every domain; moving
+it behind an extra would make that extra a de-facto requirement and would
+silently stop sanitizing for anyone who missed it. `werkzeug` is a genuine
+import-time need (it backs `current_domain`/`current_uow`). Both stay in core.
+
+Moving a package out of `[project].dependencies` is a Tier-1 breaking change
+under [ADR-0004](0004-release-workflow-and-breaking-change-policy.md): code that
+worked on a fat install can fail on a lean one. The question was how to draw the
+core/extras boundary, what happens when a feature is used without its extra, and
+how to land the break without stranding upgraders.
+
+## Decision
+
+**Draw the core at the domain-modeling and message-processing essentials, and
+move the five install-time-optional packages behind feature extras.**
+
+Core (`pip install protean`) keeps only what every consumer needs to define a
+domain, persist through the memory adapter, and run the async engine:
+`inflection`, `marshmallow`, `python-dateutil`, `typer` (the CLI framework
+itself), `structlog`, `werkzeug`, `bleach`, `pydantic`, `greenlet`, and `cffi`.
+
+The feature extras:
+
+| Extra | Packages | Gates |
+|-------|----------|-------|
+| `server` | `fastapi`, `uvicorn`, `jinja2` | `protean observatory`, `protean.integrations.fastapi` |
+| `shell` | `ipython` | `protean shell` |
+| `scaffold` | `copier` | `protean new` |
+
+And two convenience bundles:
+
+| Extra | Expands to | Purpose |
+|-------|------------|---------|
+| `cli` | `shell` + `scaffold` | the full interactive `protean new` / `protean shell` experience |
+| `all` | `server` + `cli` | everything that shipped in the pre-0.18 core; the one-line upgrade |
+
+**When a feature is used without its extra, fail with an actionable message that
+names the extra to install, never a bare `ModuleNotFoundError`.** The single
+message builder lives in `protean.utils.dependencies.missing_dependency_message`,
+so the wording is identical everywhere. The CLI commands (`new`, `shell`,
+`observatory`) import their optional stack lazily inside the command body and, on
+`ImportError`, print `Error: … requires the '<pkg>' package. Install it with
+'pip install "protean[<extra>]"'.` and exit non-zero. The check only translates
+the *expected* missing package; any other `ImportError` is re-raised so a genuine
+bug inside the imported module is not masked as a missing extra. The FastAPI
+integration package applies the same guard at import.
+
+**Land the break cleanly in 0.18.0.** Because the imports were already lazy,
+there is no `import protean` code path on which to emit a pre-removal
+`DeprecationWarning` — the deps simply were not loaded at import. A staged
+"warn then move" runway would keep the fat install for a release while warning
+about a change whose fix is a single word, adding cycle time for no real
+protection. Instead: move to extras in 0.18.0, ship the `all` extra as the
+one-line restore of the previous behavior, provide the actionable errors, and
+document the change in the 0.18 migration guide. The actionable error plus the
+`all` extra **is** the Tier-1 mitigation.
+
+## Consequences
+
+- A plain `pip install protean` is markedly smaller and carries a smaller
+  dependency-conflict surface. Consumers opt into the web stack, the shell, and
+  the scaffolder only when they use them.
+- Consumers who ran `protean observatory`, `protean shell`, or `protean new`, or
+  imported `protean.integrations.fastapi`, must install the matching extra. They
+  get a message that tells them exactly which one; a project that wants the old
+  behavior wholesale adds `protean[all]`.
+- CI and dev environments that already run `uv sync --all-extras` are unaffected;
+  the new extras are picked up automatically.
+- Deriving the boundary per feature (rather than one big `cli` bucket) means more
+  extra names to document, but each install stays minimal — a REPL user does not
+  drag in the scaffolder.
+- `bleach`, `werkzeug`, `cffi`, and `greenlet` stay in core. `bleach` because
+  String/Text fields sanitize by default (see Context); `werkzeug` because it
+  backs `current_domain`/`current_uow` via `LocalProxy`/`LocalStack`. `cffi` and
+  `greenlet` are not imported directly by `src/protean` and appear to be
+  transitive-only. Whether `werkzeug` can be replaced by `contextvars`, and
+  whether `cffi`/`greenlet` can leave core, is deferred to a separate review so
+  this change stays a packaging change and does not touch the context system's
+  semantics.
+
+## Alternatives Considered
+
+- **One coarse `cli` extra covering shell + scaffold.** Fewer names to document,
+  but it couples unrelated concerns: a user who only wants a REPL would install
+  the scaffolder. Rejected in favor of precise extras plus the `cli`/`all`
+  bundles.
+- **Move `bleach` behind a `[sanitize]` extra and fail fast when a `sanitize=True`
+  field is defined without it.** Rejected: `String()` and `Text()` default to
+  `sanitize=True`, so bleach runs for nearly every domain. The extra would become
+  a de-facto requirement, and the "fail fast" would fire on the *default* field
+  declaration, not an opt-in one. Moving it out of core would also mean flipping
+  the `sanitize` default to `False` — a separate, security-relevant behavioral
+  break (string fields silently stop HTML-escaping) that does not belong in a
+  packaging change. bleach stays in core; revisit if that default ever flips.
+- **Replace `werkzeug` with `contextvars` in this change to shrink core further.**
+  Reimplementing the nested push/pop semantics of the domain-context and
+  Unit-of-Work stacks is a real refactor with behavioral risk; folding it into a
+  packaging change would put an unrelated correctness risk in the same PR.
+  Deferred to its own issue.
+- **A staged Tier-1 deprecation (warn in 0.18, move in 0.19).** Rejected: with the
+  imports already lazy there is no natural code path to warn on, and the fix is a
+  one-word extra. The runway would add a release cycle without protecting anyone.

--- a/docs/adr/0029-runtime-dependency-boundary-and-extras.md
+++ b/docs/adr/0029-runtime-dependency-boundary-and-extras.md
@@ -7,19 +7,19 @@
 ## Context
 
 A plain `pip install protean` used to pull a web server, an ASGI stack, a Jinja
-template engine, an interactive REPL, a project scaffolder, and an HTML
-sanitizer, whether or not the consumer ever ran a server, opened a shell, or
-generated a project. The adapter ecosystem was already right: `postgresql`,
-`redis`, `elasticsearch`, `flask`, and `sendgrid` are extras, installed only
-when the consumer talks to that infrastructure. But several install-time-optional
-concerns were hard runtime dependencies in `[project].dependencies`:
+template engine, an interactive REPL, and a project scaffolder, whether or not
+the consumer ever ran a server, opened a shell, or generated a project. The
+adapter ecosystem was already right: `postgresql`, `redis`, `elasticsearch`,
+`flask`, and `sendgrid` are extras, installed only when the consumer talks to
+that infrastructure. But several install-time-optional concerns were hard runtime
+dependencies in `[project].dependencies`:
 
-- `fastapi`, `uvicorn`, `jinja2` — the HTTP/ASGI/observatory stack, used only by
+- `fastapi`, `uvicorn`, `jinja2`: the HTTP/ASGI/observatory stack, used only by
   `protean observatory` and `protean.integrations.fastapi`.
-- `ipython` — the interactive shell, used only by `protean shell`.
-- `copier` — project scaffolding, used only by `protean new`.
+- `ipython`: the interactive shell, used only by `protean shell`.
+- `copier`: project scaffolding, used only by `protean new`.
 
-None of these are imported by `import protean` — the imports were already lazy,
+None of these are imported by `import protean`. The imports were already lazy,
 gated behind a CLI subcommand or an opt-in integration module. So the cost was
 not import coupling; it was **install footprint** and the dependency-conflict
 surface every consumer inherited. FastAPI itself models the fix (it pushes
@@ -27,7 +27,7 @@ surface every consumer inherited. FastAPI itself models the fix (it pushes
 dependencies.
 
 Two more packages were candidates but stay in core after review. `bleach` (HTML
-sanitization) looked optional — used only for String/Text field sanitization —
+sanitization) looked optional, used only for String/Text field sanitization,
 until you notice that `String()` and `Text()` default to `sanitize=True`. Nearly
 every domain has a string field, so bleach runs for nearly every domain; moving
 it behind an extra would make that extra a de-facto requirement and would
@@ -66,19 +66,30 @@ And two convenience bundles:
 | `all` | `server` + `cli` | everything that shipped in the pre-0.18 core; the one-line upgrade |
 
 **When a feature is used without its extra, fail with an actionable message that
-names the extra to install, never a bare `ModuleNotFoundError`.** The single
-message builder lives in `protean.utils.dependencies.missing_dependency_message`,
-so the wording is identical everywhere. The CLI commands (`new`, `shell`,
-`observatory`) import their optional stack lazily inside the command body and, on
-`ImportError`, print `Error: … requires the '<pkg>' package. Install it with
-'pip install "protean[<extra>]"'.` and exit non-zero. The check only translates
-the *expected* missing package; any other `ImportError` is re-raised so a genuine
-bug inside the imported module is not masked as a missing extra. The FastAPI
-integration package applies the same guard at import.
+names the extra to install, never a bare `ModuleNotFoundError`.** The message
+builder lives in `protean.utils.dependencies.missing_dependency_message`, and
+`FEATURE_EXTRA_MODULES` in the same module maps each extra to the packages it
+provides, so both facts live in one place. The CLI commands (`new`, `shell`,
+`observatory`) import their optional stack lazily inside the command body; on
+`ImportError` they hand off to `abort_for_missing_dependency`, which prints
+`Error: … requires the '<pkg>' package. Install it with 'pip install
+"protean[<extra>]"'.` and exits non-zero.
+
+To decide whether a package is actually missing, the guard uses
+`importlib.util.find_spec` over the extra's packages, not the `ImportError`'s
+name. An `ImportError` from a package that is installed but broken (an
+incompatible version, a renamed symbol) names that same package, so a name-based
+check would tell the user to install what they already have; and a package such
+as `jinja2` that is re-raised by a third party with no `name` at all would be
+missed. When every package the extra provides is importable, the `ImportError`
+is a real bug inside the feature and is re-raised unchanged. The FastAPI
+integration applies the same `find_spec` guard at import, raising a clear
+`ImportError` rather than a `typer.Abort` (a library import must not abort the
+process).
 
 **Land the break cleanly in 0.18.0.** Because the imports were already lazy,
 there is no `import protean` code path on which to emit a pre-removal
-`DeprecationWarning` — the deps simply were not loaded at import. A staged
+`DeprecationWarning`; the deps simply were not loaded at import. A staged
 "warn then move" runway would keep the fat install for a release while warning
 about a change whose fix is a single word, adding cycle time for no real
 protection. Instead: move to extras in 0.18.0, ship the `all` extra as the
@@ -98,7 +109,7 @@ document the change in the 0.18 migration guide. The actionable error plus the
 - CI and dev environments that already run `uv sync --all-extras` are unaffected;
   the new extras are picked up automatically.
 - Deriving the boundary per feature (rather than one big `cli` bucket) means more
-  extra names to document, but each install stays minimal — a REPL user does not
+  extra names to document, but each install stays minimal: a REPL user does not
   drag in the scaffolder.
 - `bleach`, `werkzeug`, `cffi`, and `greenlet` stay in core. `bleach` because
   String/Text fields sanitize by default (see Context); `werkzeug` because it
@@ -120,9 +131,15 @@ document the change in the 0.18 migration guide. The actionable error plus the
   `sanitize=True`, so bleach runs for nearly every domain. The extra would become
   a de-facto requirement, and the "fail fast" would fire on the *default* field
   declaration, not an opt-in one. Moving it out of core would also mean flipping
-  the `sanitize` default to `False` — a separate, security-relevant behavioral
+  the `sanitize` default to `False`, a separate and security-relevant behavioral
   break (string fields silently stop HTML-escaping) that does not belong in a
   packaging change. bleach stays in core; revisit if that default ever flips.
+- **Detect the missing package from `ImportError.name` instead of `find_spec`.**
+  Simpler, but wrong for the case that matters most: a package that is installed
+  but broken raises an `ImportError` naming itself, so a name check would tell the
+  user to reinstall a package they already have, and a `jinja2` miss re-raised
+  without a `name` would be missed entirely. `find_spec` distinguishes absent from
+  present-but-broken directly.
 - **Replace `werkzeug` with `contextvars` in this change to shrink core further.**
   Reimplementing the nested push/pop semantics of the domain-context and
   Unit-of-Work stacks is a real refactor with behavioral risk; folding it into a

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -99,3 +99,4 @@ See `TEMPLATE.md` in the `adr/` directory for the ADR template.
 | [0026](0026-max-length-bounds-the-sanitized-value.md) | Sanitized String Values Satisfy Their Field's Length Bounds |
 | [0027](0027-unit-of-work-is-a-real-transaction.md) | The Unit of Work is a Real Database Transaction |
 | [0028](0028-partition-per-key-sequential-processing.md) | Partition-Per-Key Sequential Processing (`sequential_by`) |
+| [0029](0029-runtime-dependency-boundary-and-extras.md) | Runtime Dependency Boundary and Feature Extras |

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -403,7 +403,7 @@ Design reasoning and internal architecture for contributors and advanced users.
 ## Migration
 
 - [Compatibility Reference](./reference/compatibility/index.md) -- Breaking change rules, three-tier taxonomy, deprecation lifecycle, and config.toml reference.
-- [Migrating to 0.18](./reference/migration/v0-18.md) -- Upgrade guide for the 0.18 release. Covers the right-sized dependency surface: the web/observatory stack, the shell, the scaffolder, and HTML sanitization move behind install extras.
+- [Migrating to 0.18](./reference/migration/v0-18.md) -- Upgrade guide for the 0.18 release. Covers the right-sized dependency surface: the web/observatory stack, the shell, and the scaffolder move behind install extras.
 - [Migrating to 0.17](./reference/migration/v0-17.md) -- Upgrade guide for the 0.17 API-consolidation release. Covers the `event_sourced` option rename, the internalized `is_fact_event` option, and the email subsystem deprecation.
 - [Migrating to 0.16](./reference/migration/v0-16.md) -- Upgrade guide for the 0.16 stability release. Covers the outbox column-bounds structural change and its per-backend `ALTER TABLE` recipes.
 - [Migrating to 0.15](./reference/migration/v0-15.md) -- Upgrade guide for the Pydantic v2 foundation release. Covers breaking changes, field style migration, and new features.

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -403,6 +403,7 @@ Design reasoning and internal architecture for contributors and advanced users.
 ## Migration
 
 - [Compatibility Reference](./reference/compatibility/index.md) -- Breaking change rules, three-tier taxonomy, deprecation lifecycle, and config.toml reference.
+- [Migrating to 0.18](./reference/migration/v0-18.md) -- Upgrade guide for the 0.18 release. Covers the right-sized dependency surface: the web/observatory stack, the shell, the scaffolder, and HTML sanitization move behind install extras.
 - [Migrating to 0.17](./reference/migration/v0-17.md) -- Upgrade guide for the 0.17 API-consolidation release. Covers the `event_sourced` option rename, the internalized `is_fact_event` option, and the email subsystem deprecation.
 - [Migrating to 0.16](./reference/migration/v0-16.md) -- Upgrade guide for the 0.16 stability release. Covers the outbox column-bounds structural change and its per-backend `ALTER TABLE` recipes.
 - [Migrating to 0.15](./reference/migration/v0-15.md) -- Upgrade guide for the Pydantic v2 foundation release. Covers breaking changes, field style migration, and new features.

--- a/docs/guides/getting-started/installation.md
+++ b/docs/guides/getting-started/installation.md
@@ -66,7 +66,7 @@ Install the extra for what you use:
 | `cli` | `pip install "protean[cli]"` | the full interactive CLI (`shell` + `scaffold`) |
 | `all` | `pip install "protean[all]"` | all of the above |
 
-Adapters are extras too — for example `pip install "protean[postgresql]"` or
+Adapters are extras too, for example `pip install "protean[postgresql]"` or
 `pip install "protean[redis]"`. You can combine extras:
 `pip install "protean[server,postgresql]"`.
 

--- a/docs/guides/getting-started/installation.md
+++ b/docs/guides/getting-started/installation.md
@@ -49,6 +49,30 @@ Within the activated environment, install Protean with the following command:
 $ pip install protean
 ```
 
+This installs a lean core: everything you need to define a domain, persist
+through the in-memory adapter, and run the async engine (`protean server`).
+
+## Optional features
+
+Some features live behind install extras so the core stays small (see
+[ADR-0029](https://github.com/proteanhq/protean/blob/main/docs/adr/0029-runtime-dependency-boundary-and-extras.md)).
+Install the extra for what you use:
+
+| Extra | Install | Enables |
+|-------|---------|---------|
+| `server` | `pip install "protean[server]"` | the Observatory dashboard (`protean observatory`) and the FastAPI integration |
+| `shell` | `pip install "protean[shell]"` | the interactive domain shell (`protean shell`) |
+| `scaffold` | `pip install "protean[scaffold]"` | project scaffolding (`protean new`) |
+| `cli` | `pip install "protean[cli]"` | the full interactive CLI (`shell` + `scaffold`) |
+| `all` | `pip install "protean[all]"` | all of the above |
+
+Adapters are extras too — for example `pip install "protean[postgresql]"` or
+`pip install "protean[redis]"`. You can combine extras:
+`pip install "protean[server,postgresql]"`.
+
+If you run a command without its extra, Protean tells you which one to install
+rather than failing with a raw import error.
+
 ## Verifying
 
 Use the ``protean`` CLI to verify the installation:

--- a/docs/reference/migration/index.md
+++ b/docs/reference/migration/index.md
@@ -2,6 +2,7 @@
 
 Guides for upgrading between Protean versions.
 
+- [**v0.18 Migration**](./v0-18.md): The runtime dependency surface is right-sized — the web/observatory stack, the interactive shell, the project scaffolder, and HTML sanitization move behind install extras.
 - [**v0.17 Migration**](./v0-17.md): The Unit of Work becomes a real transaction, the 1.0 API surface (`event_sourced` option, internalized `is_fact_event`), stream trimming, and the email subsystem deprecation.
 - [**v0.16 Migration**](./v0-16.md): Outbox column bounds and upgrade steps for v0.16.
 - [**v0.15 Migration**](./v0-15.md): Breaking changes and upgrade steps for v0.15.

--- a/docs/reference/migration/index.md
+++ b/docs/reference/migration/index.md
@@ -2,7 +2,7 @@
 
 Guides for upgrading between Protean versions.
 
-- [**v0.18 Migration**](./v0-18.md): The runtime dependency surface is right-sized — the web/observatory stack, the interactive shell, the project scaffolder, and HTML sanitization move behind install extras.
+- [**v0.18 Migration**](./v0-18.md): The runtime dependency surface is right-sized: the web/observatory stack, the interactive shell, and the project scaffolder move behind install extras.
 - [**v0.17 Migration**](./v0-17.md): The Unit of Work becomes a real transaction, the 1.0 API surface (`event_sourced` option, internalized `is_fact_event`), stream trimming, and the email subsystem deprecation.
 - [**v0.16 Migration**](./v0-16.md): Outbox column bounds and upgrade steps for v0.16.
 - [**v0.15 Migration**](./v0-15.md): Breaking changes and upgrade steps for v0.15.

--- a/docs/reference/migration/v0-18.md
+++ b/docs/reference/migration/v0-18.md
@@ -34,12 +34,12 @@ Five packages that used to be hard runtime dependencies are now install extras:
 
 Two convenience bundles are also available:
 
-- `protean[cli]` — the full interactive CLI experience (`shell` + `scaffold`).
-- `protean[all]` — everything that used to ship in the core install
+- `protean[cli]`: the full interactive CLI experience (`shell` + `scaffold`).
+- `protean[all]`: everything that used to ship in the core install
   (`server` + `cli`).
 
 `import protean` and defining a domain, persisting through the memory adapter,
-and running `protean server` (the async engine) need **none** of these — they
+and running `protean server` (the async engine) need **none** of these: they
 were already lazy, and they stay in the lean core.
 
 ## The one-line fix

--- a/docs/reference/migration/v0-18.md
+++ b/docs/reference/migration/v0-18.md
@@ -1,0 +1,90 @@
+# Migrating to 0.18
+
+!!! abstract "From 0.17 to 0.18"
+
+Protean 0.18 right-sizes the runtime dependency surface. A plain
+`pip install protean` no longer forces a web server, an ASGI stack, an
+interactive REPL, and a project scaffolder onto every install. Those concerns
+now live behind install extras, matching how the database and broker adapters
+have always worked. See
+[ADR-0029](https://github.com/proteanhq/protean/blob/main/docs/adr/0029-runtime-dependency-boundary-and-extras.md)
+for the boundary and the rationale.
+
+**This is a Tier-1 breaking change**, but a small one: nothing in your code
+changes, and the fix when you hit it is a one-word extra. If a feature you use
+now needs an extra, the CLI or the import tells you exactly which one.
+
+**On this page:**
+
+- [What moved behind extras](#what-moved-behind-extras)
+- [The one-line fix](#the-one-line-fix): `protean[all]` restores the old install
+- [What each feature needs now](#what-each-feature-needs-now)
+
+---
+
+## What moved behind extras
+
+Five packages that used to be hard runtime dependencies are now install extras:
+
+| Package(s) | Extra | Feature it gates |
+|------------|-------|------------------|
+| `fastapi`, `uvicorn`, `jinja2` | `protean[server]` | `protean observatory`, `protean.integrations.fastapi` |
+| `ipython` | `protean[shell]` | `protean shell` |
+| `copier` | `protean[scaffold]` | `protean new` |
+
+Two convenience bundles are also available:
+
+- `protean[cli]` — the full interactive CLI experience (`shell` + `scaffold`).
+- `protean[all]` — everything that used to ship in the core install
+  (`server` + `cli`).
+
+`import protean` and defining a domain, persisting through the memory adapter,
+and running `protean server` (the async engine) need **none** of these — they
+were already lazy, and they stay in the lean core.
+
+## The one-line fix
+
+If your project relied on the old fat install and you would rather not think
+about which extras you need, install `all`:
+
+```shell
+pip install "protean[all]"
+```
+
+That restores every package that shipped in the 0.17 core. From there you can
+trim to the specific extras you actually use whenever you like.
+
+## What each feature needs now
+
+You only need to act if you use one of these features **and** you install a
+trimmed set of dependencies (for example in a production image that installs
+`protean` without `[all]`):
+
+- **Running the Observatory** (`protean observatory`) or using the FastAPI
+  integration (`from protean.integrations.fastapi import ...`):
+
+  ```shell
+  pip install "protean[server]"
+  ```
+
+- **Opening the domain shell** (`protean shell`):
+
+  ```shell
+  pip install "protean[shell]"
+  ```
+
+- **Scaffolding a project** (`protean new`):
+
+  ```shell
+  pip install "protean[scaffold]"
+  ```
+
+If you run one of these without its extra, the command fails with a clear
+message naming the extra to install, not a raw `ModuleNotFoundError`:
+
+```text
+Error: 'protean observatory' requires the 'fastapi' package. Install it with 'pip install "protean[server]"'.
+```
+
+Field sanitization is unaffected: `bleach` stays in the core install, because
+String and Text fields sanitize by default.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -385,6 +385,7 @@ nav:
       - reference/compatibility/index.md
     - Migration:
       - reference/migration/index.md
+      - reference/migration/v0-18.md
       - reference/migration/v0-17.md
       - reference/migration/v0-16.md
       - reference/migration/v0-15.md
@@ -419,6 +420,7 @@ nav:
       - adr/0026-max-length-bounds-the-sanitized-value.md
       - adr/0027-unit-of-work-is-a-real-transaction.md
       - adr/0028-partition-per-key-sequential-processing.md
+      - adr/0029-runtime-dependency-boundary-and-extras.md
     - Troubleshooting:
       - reference/troubleshooting.md
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,17 +56,17 @@ classifiers = [
 # license classifier. Neither `uv build` nor `twine check` catches the clash
 # locally, so it would surface only when pushing the release tag.
 
+# The lean runtime core. Install-time-optional concerns (the web/ASGI stack, the
+# interactive shell, the project scaffolder) live behind the extras below so a
+# plain `pip install protean` does not drag them onto every consumer. `bleach`
+# stays here: String/Text fields sanitize by default, so it is a genuine runtime
+# need for nearly every domain. See ADR-0029 for the boundary and the rationale.
 dependencies = [
     "bleach>=6.1.0",
-    "copier>=9.4.0,<10",
     "inflection>=0.5.1",
-    "ipython>=9.0.0,<10.0",
     "marshmallow>=4.0.0",
     "python-dateutil>=2.8.2",
     "typer>=0.16.0",
-    "fastapi>=0.139.0",
-    "jinja2>=3.1.6",
-    "uvicorn>=0.30.0",
     "structlog>=24.1.0",
     "werkzeug>=3.1.0",
     "cffi>=2.0.0",
@@ -75,6 +75,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# Adapter extras — the infrastructure a domain talks to.
 elasticsearch = ["elasticsearch>=8.18.0,<9.0.0"]
 redis = ["redis>=8.0.0,<8.2.0"]
 postgresql = ["sqlalchemy>=2.0.36,<2.1", "psycopg2-binary>=2.9.11"]
@@ -83,6 +84,17 @@ mssql = ["sqlalchemy>=2.0.36,<2.1", "pyodbc>=5.3.0"]
 message-db = ["message-db-py>=0.3.4"]
 flask = ["flask>=3.0.0"]
 sendgrid = ["sendgrid>=6.11.0"]
+# Runtime feature extras — right-sized out of the lean core (ADR-0029). Each
+# gates a feature whose CLI command or import fails with an actionable
+# "install protean[<extra>]" message when the extra is absent.
+server = ["fastapi>=0.139.0", "uvicorn>=0.30.0", "jinja2>=3.1.6"]  # `protean observatory`, the FastAPI integration
+shell = ["ipython>=9.0.0,<10.0"]  # `protean shell`
+scaffold = ["copier>=9.4.0,<10"]  # `protean new`
+# Convenience bundles. `cli` is the full interactive CLI experience; `all`
+# restores everything that shipped in the pre-0.18 core (the one-line upgrade for
+# projects that relied on the fat install).
+cli = ["protean[shell,scaffold]"]
+all = ["protean[server,cli]"]
 dev = ["watchfiles>=1.2.0"]
 telemetry = [
     "opentelemetry-api>=1.36.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# Adapter extras — the infrastructure a domain talks to.
+# Adapter extras: the infrastructure a domain talks to.
 elasticsearch = ["elasticsearch>=8.18.0,<9.0.0"]
 redis = ["redis>=8.0.0,<8.2.0"]
 postgresql = ["sqlalchemy>=2.0.36,<2.1", "psycopg2-binary>=2.9.11"]
@@ -84,7 +84,7 @@ mssql = ["sqlalchemy>=2.0.36,<2.1", "pyodbc>=5.3.0"]
 message-db = ["message-db-py>=0.3.4"]
 flask = ["flask>=3.0.0"]
 sendgrid = ["sendgrid>=6.11.0"]
-# Runtime feature extras — right-sized out of the lean core (ADR-0029). Each
+# Runtime feature extras, right-sized out of the lean core (ADR-0029). Each
 # gates a feature whose CLI command or import fails with an actionable
 # "install protean[<extra>]" message when the extra is absent.
 server = ["fastapi>=0.139.0", "uvicorn>=0.30.0", "jinja2>=3.1.6"]  # `protean observatory`, the FastAPI integration

--- a/src/protean/cli/_helpers.py
+++ b/src/protean/cli/_helpers.py
@@ -9,12 +9,13 @@ import functools
 import sys
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NoReturn
 
 import typer
 from rich import print
 
 from protean.exceptions import NoDomainException
+from protean.utils.dependencies import missing_dependency_message
 from protean.utils.domain_discovery import derive_domain
 from protean.utils.logging import get_logger
 
@@ -44,6 +45,37 @@ def cli_exception_handler(command: str) -> Iterator[None]:
     except Exception:
         logger.exception("cli.command_failed", command=command, argv=sys.argv)
         raise
+
+
+def abort_for_missing_dependency(
+    extra: str,
+    feature: str,
+    modules: tuple[str, ...],
+    exc: ImportError,
+) -> NoReturn:
+    """Turn an absent optional dependency into a clean install hint and abort.
+
+    Call this from a subcommand's ``except ImportError`` block after a lazy
+    import of a feature's optional stack (``copier`` for ``protean new``,
+    ``IPython`` for ``protean shell``, the FastAPI stack for
+    ``protean observatory``). It prints a one-line message naming the extra to
+    install and raises ``typer.Abort`` so Typer exits non-zero, mirroring the
+    ``--reload``/watchfiles handling instead of surfacing a raw traceback.
+
+    ``modules`` lists the top-level packages the extra provides. If the
+    ``ImportError`` came from anything else, it is re-raised unchanged: a genuine
+    bug inside the imported module must not be masked as a missing extra.
+    """
+    top = (exc.name or "").split(".")[0]
+    if top not in modules:
+        raise exc
+    msg = f"Error: {missing_dependency_message(top, extra, feature)}"
+    # Use typer.echo, not rich's print: the message contains "protean[<extra>]",
+    # and rich would treat "[<extra>]" as a markup tag and strip it, printing a
+    # wrong (and unusable) install command.
+    typer.echo(msg)
+    logger.error(msg)
+    raise typer.Abort() from exc
 
 
 def load_domain(domain_path: str) -> "Domain":

--- a/src/protean/cli/_helpers.py
+++ b/src/protean/cli/_helpers.py
@@ -9,13 +9,18 @@ import functools
 import sys
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
+from importlib.util import find_spec
 from typing import TYPE_CHECKING, Any, NoReturn
 
 import typer
 from rich import print
 
 from protean.exceptions import NoDomainException
-from protean.utils.dependencies import missing_dependency_message
+from protean.utils.dependencies import (
+    FEATURE_EXTRA_MODULES,
+    FeatureExtra,
+    missing_dependency_message,
+)
 from protean.utils.domain_discovery import derive_domain
 from protean.utils.logging import get_logger
 
@@ -48,9 +53,8 @@ def cli_exception_handler(command: str) -> Iterator[None]:
 
 
 def abort_for_missing_dependency(
-    extra: str,
+    extra: FeatureExtra,
     feature: str,
-    modules: tuple[str, ...],
     exc: ImportError,
 ) -> NoReturn:
     """Turn an absent optional dependency into a clean install hint and abort.
@@ -58,18 +62,22 @@ def abort_for_missing_dependency(
     Call this from a subcommand's ``except ImportError`` block after a lazy
     import of a feature's optional stack (``copier`` for ``protean new``,
     ``IPython`` for ``protean shell``, the FastAPI stack for
-    ``protean observatory``). It prints a one-line message naming the extra to
-    install and raises ``typer.Abort`` so Typer exits non-zero, mirroring the
+    ``protean observatory``). If a package the ``extra`` provides is genuinely
+    not installed, it prints a one-line message naming the extra to install and
+    raises ``typer.Abort`` so Typer exits non-zero, mirroring the
     ``--reload``/watchfiles handling instead of surfacing a raw traceback.
 
-    ``modules`` lists the top-level packages the extra provides. If the
-    ``ImportError`` came from anything else, it is re-raised unchanged: a genuine
-    bug inside the imported module must not be masked as a missing extra.
+    The "is it installed?" test uses ``importlib.util.find_spec`` on the extra's
+    packages, not ``exc.name``: an ``ImportError`` from a package that IS
+    installed but broken (an incompatible version, a renamed symbol) names that
+    same package, so keying off the name would tell the user to install a package
+    they already have. When every package the extra provides is importable, the
+    ``ImportError`` is a real bug inside the feature and is re-raised unchanged.
     """
-    top = (exc.name or "").split(".")[0]
-    if top not in modules:
+    missing = [pkg for pkg in FEATURE_EXTRA_MODULES[extra] if find_spec(pkg) is None]
+    if not missing:
         raise exc
-    msg = f"Error: {missing_dependency_message(top, extra, feature)}"
+    msg = f"Error: {missing_dependency_message(missing[0], extra, feature)}"
     # Use typer.echo, not rich's print: the message contains "protean[<extra>]",
     # and rich would treat "[<extra>]" as a markup tag and strip it, printing a
     # wrong (and unusable) install command.

--- a/src/protean/cli/new.py
+++ b/src/protean/cli/new.py
@@ -149,7 +149,7 @@ def new(
     try:
         from copier import run_copy  # noqa: PLC0415
     except ImportError as exc:
-        abort_for_missing_dependency("scaffold", "'protean new'", ("copier",), exc)
+        abort_for_missing_dependency("scaffold", "'protean new'", exc)
 
     def is_valid_project_name(project_name: str) -> bool:
         """

--- a/src/protean/cli/new.py
+++ b/src/protean/cli/new.py
@@ -5,10 +5,10 @@ import subprocess
 from typing import Annotated
 
 import typer
-from copier import run_copy
 from rich.console import Console
 
 import protean
+from protean.cli._helpers import abort_for_missing_dependency
 
 console = Console()
 
@@ -142,6 +142,14 @@ def new(
 ) -> None:
     if data is None:
         data = []
+
+    # `copier` is optional (protean[scaffold]). Import it before any filesystem
+    # work so a missing extra fails with an install hint rather than after we
+    # have already cleared the target directory.
+    try:
+        from copier import run_copy  # noqa: PLC0415
+    except ImportError as exc:
+        abort_for_missing_dependency("scaffold", "'protean new'", ("copier",), exc)
 
     def is_valid_project_name(project_name: str) -> bool:
         """

--- a/src/protean/cli/observatory.py
+++ b/src/protean/cli/observatory.py
@@ -8,6 +8,7 @@ import typer
 
 from protean.cli._helpers import (
     CTX_LOG_CONFIGURED,
+    abort_for_missing_dependency,
     handle_cli_exceptions,
 )
 from protean.exceptions import NoDomainException
@@ -39,7 +40,15 @@ def observatory(
     ] = "Protean Observatory",
 ) -> None:
     """Run the Observatory observability dashboard."""
-    from protean.server.observatory import Observatory  # noqa: PLC0415
+    # The Observatory runs on the optional FastAPI/uvicorn stack
+    # (protean[server]); a missing extra fails with an install hint instead of a
+    # raw ModuleNotFoundError from deep inside the server package.
+    try:
+        from protean.server.observatory import Observatory  # noqa: PLC0415
+    except ImportError as exc:
+        abort_for_missing_dependency(
+            "server", "'protean observatory'", ("fastapi", "uvicorn", "jinja2"), exc
+        )
 
     # Check parent context for CLI-level logging configuration.
     # click.get_current_context may fail when called directly (not via CLI).

--- a/src/protean/cli/observatory.py
+++ b/src/protean/cli/observatory.py
@@ -46,9 +46,7 @@ def observatory(
     try:
         from protean.server.observatory import Observatory  # noqa: PLC0415
     except ImportError as exc:
-        abort_for_missing_dependency(
-            "server", "'protean observatory'", ("fastapi", "uvicorn", "jinja2"), exc
-        )
+        abort_for_missing_dependency("server", "'protean observatory'", exc)
 
     # Check parent context for CLI-level logging configuration.
     # click.get_current_context may fail when called directly (not via CLI).

--- a/src/protean/cli/shell.py
+++ b/src/protean/cli/shell.py
@@ -12,9 +12,8 @@ import typing
 from typing import Annotated
 
 import typer
-from IPython.terminal.embed import InteractiveShellEmbed
 
-from protean.cli._helpers import handle_cli_exceptions
+from protean.cli._helpers import abort_for_missing_dependency, handle_cli_exceptions
 from protean.exceptions import NoDomainException
 from protean.utils.domain_discovery import derive_domain
 from protean.utils.logging import get_logger
@@ -27,6 +26,15 @@ def shell(
     domain: Annotated[str, typer.Option()] = ".",
     traverse: Annotated[bool, typer.Option()] = False,
 ) -> None:
+    # `ipython` is optional (protean[shell]). Import it before loading the domain
+    # so a missing extra fails with an install hint rather than a raw traceback.
+    try:
+        from IPython.terminal.embed import (  # noqa: PLC0415
+            InteractiveShellEmbed,
+        )
+    except ImportError as exc:
+        abort_for_missing_dependency("shell", "'protean shell'", ("IPython",), exc)
+
     try:
         domain_instance = derive_domain(domain)
     except NoDomainException as exc:

--- a/src/protean/cli/shell.py
+++ b/src/protean/cli/shell.py
@@ -33,7 +33,7 @@ def shell(
             InteractiveShellEmbed,
         )
     except ImportError as exc:
-        abort_for_missing_dependency("shell", "'protean shell'", ("IPython",), exc)
+        abort_for_missing_dependency("shell", "'protean shell'", exc)
 
     try:
         domain_instance = derive_domain(domain)

--- a/src/protean/integrations/fastapi/__init__.py
+++ b/src/protean/integrations/fastapi/__init__.py
@@ -6,11 +6,15 @@ try:
     from .middleware import DomainContextMiddleware
     from .telemetry import instrument_app
 except ImportError as exc:
-    # FastAPI ships in the optional protean[server] extra. Re-raise only the
-    # fastapi-missing case with an install hint; any other ImportError points at
-    # a real bug in these modules and must surface unchanged.
-    if (exc.name or "").split(".")[0] != "fastapi":
-        raise  # pragma: no cover - a non-fastapi ImportError is a real bug, surfaced as-is
+    # These submodules import only fastapi (which pulls starlette). fastapi ships
+    # in the optional protean[server] extra, so translate a genuinely-absent
+    # fastapi into an install hint. Test importability with find_spec, not
+    # exc.name: an ImportError from a fastapi that IS installed but broken names
+    # "fastapi" too, and we must not tell the user to install what they have.
+    from importlib.util import find_spec
+
+    if find_spec("fastapi") is not None:
+        raise  # pragma: no cover - a real bug in a present fastapi, surfaced as-is
     from protean.utils.dependencies import missing_dependency_message
 
     raise ImportError(

--- a/src/protean/integrations/fastapi/__init__.py
+++ b/src/protean/integrations/fastapi/__init__.py
@@ -1,9 +1,25 @@
 """FastAPI integration utilities for Protean."""
 
-from .exception_handlers import register_exception_handlers
-from .health import create_health_router
-from .middleware import DomainContextMiddleware
-from .telemetry import instrument_app
+try:
+    from .exception_handlers import register_exception_handlers
+    from .health import create_health_router
+    from .middleware import DomainContextMiddleware
+    from .telemetry import instrument_app
+except ImportError as exc:
+    # FastAPI ships in the optional protean[server] extra. Re-raise only the
+    # fastapi-missing case with an install hint; any other ImportError points at
+    # a real bug in these modules and must surface unchanged.
+    if (exc.name or "").split(".")[0] != "fastapi":
+        raise  # pragma: no cover - a non-fastapi ImportError is a real bug, surfaced as-is
+    from protean.utils.dependencies import missing_dependency_message
+
+    raise ImportError(
+        missing_dependency_message(
+            "fastapi",
+            "server",
+            "The FastAPI integration (protean.integrations.fastapi)",
+        )
+    ) from exc
 
 __all__ = [
     "DomainContextMiddleware",

--- a/src/protean/utils/dependencies.py
+++ b/src/protean/utils/dependencies.py
@@ -12,6 +12,21 @@ single place that builds that message, so the wording stays identical across the
 CLI and the FastAPI integration.
 """
 
+from typing import Literal
+
+FeatureExtra = Literal["server", "shell", "scaffold"]
+
+# Each optional feature extra and the top-level import packages it provides. This
+# is the single source of truth for the "which extra is missing" checks: the CLI
+# abort helper and the FastAPI integration both derive their guard from it, so an
+# extra's package set is defined in exactly one place. Casing matches what
+# ``ImportError.name`` reports (e.g. ``IPython``, not ``ipython``).
+FEATURE_EXTRA_MODULES: dict[FeatureExtra, tuple[str, ...]] = {
+    "server": ("fastapi", "uvicorn", "jinja2"),
+    "shell": ("IPython",),
+    "scaffold": ("copier",),
+}
+
 
 def missing_dependency_message(package: str, extra: str, feature: str) -> str:
     """Build the standard actionable message for an absent optional dependency.

--- a/src/protean/utils/dependencies.py
+++ b/src/protean/utils/dependencies.py
@@ -1,0 +1,28 @@
+"""Helpers for Protean's optional runtime dependencies.
+
+Several runtime concerns are install-time optional and live behind extras so a
+plain ``pip install protean`` stays lean (see ADR-0029): the web/observatory
+stack (``protean[server]``), the interactive shell (``protean[shell]``), and the
+project scaffolder (``protean[scaffold]``).
+
+When a feature is used without its extra installed, the code that reaches for
+the missing package should fail with a message that names the extra to install,
+rather than letting a bare ``ModuleNotFoundError`` surface. This module holds the
+single place that builds that message, so the wording stays identical across the
+CLI and the FastAPI integration.
+"""
+
+
+def missing_dependency_message(package: str, extra: str, feature: str) -> str:
+    """Build the standard actionable message for an absent optional dependency.
+
+    ``feature`` names what the caller was trying to do (e.g. ``"'protean new'"``
+    or ``"'protean observatory'"``); ``package`` is the import that failed;
+    ``extra`` is the install extra that provides it. The phrasing matches the
+    existing ``--reload``/watchfiles hint so every "install the extra" message
+    reads the same way.
+    """
+    return (
+        f"{feature} requires the '{package}' package. "
+        f"Install it with 'pip install \"protean[{extra}]\"'."
+    )

--- a/src/protean/utils/dependencies.py
+++ b/src/protean/utils/dependencies.py
@@ -28,7 +28,7 @@ FEATURE_EXTRA_MODULES: dict[FeatureExtra, tuple[str, ...]] = {
 }
 
 
-def missing_dependency_message(package: str, extra: str, feature: str) -> str:
+def missing_dependency_message(package: str, extra: FeatureExtra, feature: str) -> str:
     """Build the standard actionable message for an absent optional dependency.
 
     ``feature`` names what the caller was trying to do (e.g. ``"'protean new'"``

--- a/tests/cli/test_helpers.py
+++ b/tests/cli/test_helpers.py
@@ -4,15 +4,17 @@ import pytest
 import typer
 
 from protean.cli._helpers import abort_for_missing_dependency
+from tests.shared import module_unavailable
 
 
-def test_abort_prints_hint_and_aborts_for_a_known_missing_package(capsys):
-    exc = ImportError("No module named 'fastapi'", name="fastapi")
-
-    with pytest.raises(typer.Abort):
-        abort_for_missing_dependency(
-            "server", "'protean observatory'", ("fastapi", "uvicorn"), exc
-        )
+def test_abort_prints_hint_and_aborts_when_a_package_is_absent(capsys):
+    with module_unavailable("fastapi"):
+        with pytest.raises(typer.Abort):
+            abort_for_missing_dependency(
+                "server",
+                "'protean observatory'",
+                ImportError("no fastapi", name="fastapi"),
+            )
 
     out = capsys.readouterr().out
     assert "'protean observatory'" in out
@@ -20,25 +22,30 @@ def test_abort_prints_hint_and_aborts_for_a_known_missing_package(capsys):
     assert 'pip install "protean[server]"' in out
 
 
-def test_abort_names_the_actually_missing_package(capsys):
-    # The stack lists several packages; the message names the one that failed.
-    exc = ImportError("No module named 'uvicorn'", name="uvicorn")
+def test_abort_catches_a_package_exc_name_never_reports(capsys):
+    # jinja2 is part of the server extra, but a missing jinja2 surfaces via
+    # starlette with exc.name=None, so an exc.name-based check would miss it.
+    # find_spec catches it regardless of how the ImportError was raised.
+    with module_unavailable("jinja2"):
+        with pytest.raises(typer.Abort):
+            abort_for_missing_dependency(
+                "server", "'protean observatory'", ImportError("boom")
+            )
 
-    with pytest.raises(typer.Abort):
-        abort_for_missing_dependency(
-            "server", "'protean observatory'", ("fastapi", "uvicorn", "jinja2"), exc
-        )
-
-    assert "uvicorn" in capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert "jinja2" in out
+    assert 'pip install "protean[server]"' in out
 
 
-def test_abort_reraises_an_unrelated_import_error(capsys):
-    # A missing module that is NOT part of the feature's stack is a real bug and
-    # must surface unchanged, not be relabelled as a missing extra.
-    exc = ImportError("No module named 'yaml'", name="yaml")
+def test_abort_reraises_when_every_package_is_importable(capsys):
+    # fastapi/uvicorn/jinja2 are all installed in the test env, so an ImportError
+    # here means a package is present but broken (an incompatible version, a
+    # renamed symbol), which names that same package. It is a real bug inside the
+    # feature and must surface unchanged, not be relabelled "install the extra".
+    exc = ImportError("cannot import name 'X' from 'fastapi'", name="fastapi")
 
     with pytest.raises(ImportError) as exc_info:
-        abort_for_missing_dependency("server", "'x'", ("fastapi",), exc)
+        abort_for_missing_dependency("server", "'protean observatory'", exc)
 
     assert exc_info.value is exc
     assert "pip install" not in capsys.readouterr().out

--- a/tests/cli/test_helpers.py
+++ b/tests/cli/test_helpers.py
@@ -1,0 +1,44 @@
+"""Unit tests for the CLI optional-dependency helpers (ADR-0029)."""
+
+import pytest
+import typer
+
+from protean.cli._helpers import abort_for_missing_dependency
+
+
+def test_abort_prints_hint_and_aborts_for_a_known_missing_package(capsys):
+    exc = ImportError("No module named 'fastapi'", name="fastapi")
+
+    with pytest.raises(typer.Abort):
+        abort_for_missing_dependency(
+            "server", "'protean observatory'", ("fastapi", "uvicorn"), exc
+        )
+
+    out = capsys.readouterr().out
+    assert "'protean observatory'" in out
+    assert "fastapi" in out
+    assert 'pip install "protean[server]"' in out
+
+
+def test_abort_names_the_actually_missing_package(capsys):
+    # The stack lists several packages; the message names the one that failed.
+    exc = ImportError("No module named 'uvicorn'", name="uvicorn")
+
+    with pytest.raises(typer.Abort):
+        abort_for_missing_dependency(
+            "server", "'protean observatory'", ("fastapi", "uvicorn", "jinja2"), exc
+        )
+
+    assert "uvicorn" in capsys.readouterr().out
+
+
+def test_abort_reraises_an_unrelated_import_error(capsys):
+    # A missing module that is NOT part of the feature's stack is a real bug and
+    # must surface unchanged, not be relabelled as a missing extra.
+    exc = ImportError("No module named 'yaml'", name="yaml")
+
+    with pytest.raises(ImportError) as exc_info:
+        abort_for_missing_dependency("server", "'x'", ("fastapi",), exc)
+
+    assert exc_info.value is exc
+    assert "pip install" not in capsys.readouterr().out

--- a/tests/cli/test_helpers.py
+++ b/tests/cli/test_helpers.py
@@ -6,6 +6,8 @@ import typer
 from protean.cli._helpers import abort_for_missing_dependency
 from tests.shared import module_unavailable
 
+pytestmark = pytest.mark.no_test_domain
+
 
 def test_abort_prints_hint_and_aborts_when_a_package_is_absent(capsys):
     with module_unavailable("fastapi"):

--- a/tests/cli/test_new.py
+++ b/tests/cli/test_new.py
@@ -22,6 +22,31 @@ def test_new_without_scaffold_extra_reports_actionable_error():
     assert 'pip install "protean[scaffold]"' in result.output
 
 
+def test_new_aborts_before_clearing_directory_when_copier_absent():
+    """The copier import guard must run before --force clears the target dir.
+
+    The guard sits above ``clear_directory_contents``; without that ordering a
+    lean install would wipe an existing project directory and only then fail.
+    This pins the ordering: with copier absent, ``--force`` must not delete the
+    existing contents.
+    """
+    with isolated_filesystem() as output_dir:
+        project_dir = os.path.join(output_dir, PROJECT_NAME)
+        os.makedirs(project_dir)
+        sentinel = Path(project_dir) / "keep.txt"
+        sentinel.write_text("precious", encoding="utf-8")
+
+        with module_unavailable("copier"):
+            result = runner.invoke(
+                app, ["new", PROJECT_NAME, "-o", output_dir, "--force"]
+            )
+
+        assert result.exit_code == 1
+        assert 'pip install "protean[scaffold]"' in result.output
+        assert sentinel.is_file(), "target directory was cleared before the guard fired"
+        assert sentinel.read_text(encoding="utf-8") == "precious"
+
+
 class TestGenerator:
     def test_successful_project_generation(self):
         with isolated_filesystem() as current_dir:

--- a/tests/cli/test_new.py
+++ b/tests/cli/test_new.py
@@ -5,11 +5,21 @@ import pytest
 from typer.testing import CliRunner
 
 from protean.cli import app
-from tests.shared import isolated_filesystem
+from tests.shared import isolated_filesystem, module_unavailable
 
 runner = CliRunner()
 
 PROJECT_NAME = "foobar"
+
+
+def test_new_without_scaffold_extra_reports_actionable_error():
+    """`protean new` without copier fails with an install hint, not a traceback."""
+    with module_unavailable("copier"):
+        result = runner.invoke(app, ["new", PROJECT_NAME])
+
+    assert result.exit_code == 1
+    assert "copier" in result.output
+    assert 'pip install "protean[scaffold]"' in result.output
 
 
 class TestGenerator:

--- a/tests/cli/test_observatory.py
+++ b/tests/cli/test_observatory.py
@@ -12,7 +12,7 @@ from typer.testing import CliRunner
 
 from protean.cli import app
 from protean.exceptions import NoDomainException
-from tests.shared import change_working_directory_to
+from tests.shared import change_working_directory_to, module_unavailable
 
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
@@ -41,6 +41,20 @@ class TestObservatoryCommand:
         assert result.exit_code != 0
         assert isinstance(result.exception, SystemExit)
         assert "Aborted" in result.output
+
+    def test_observatory_without_server_extra_reports_actionable_error(self):
+        """`protean observatory` without the FastAPI stack fails with an install hint.
+
+        The import guard runs before the domain is loaded, so no domain is
+        needed. `reload` forces the observatory package to re-execute its imports
+        so it hits the (now-missing) fastapi import.
+        """
+        with module_unavailable("fastapi", reload=("protean.server.observatory",)):
+            result = runner.invoke(app, ["observatory", "--domain", "x"])
+
+        assert result.exit_code == 1
+        assert "fastapi" in result.output
+        assert 'pip install "protean[server]"' in result.output
 
     def test_observatory_with_valid_domain(self):
         """Test that the observatory command initializes and runs with a valid domain."""

--- a/tests/cli/test_shell.py
+++ b/tests/cli/test_shell.py
@@ -6,9 +6,22 @@ import pytest
 from typer.testing import CliRunner
 
 from protean.cli import app
-from tests.shared import change_working_directory_to
+from tests.shared import change_working_directory_to, module_unavailable
 
 runner = CliRunner()
+
+
+def test_shell_without_shell_extra_reports_actionable_error():
+    """`protean shell` without IPython fails with an install hint, not a traceback.
+
+    The import guard runs before the domain is loaded, so no domain is needed.
+    """
+    with module_unavailable("IPython"):
+        result = runner.invoke(app, ["shell"])
+
+    assert result.exit_code == 1
+    assert "IPython" in result.output
+    assert 'pip install "protean[shell]"' in result.output
 
 
 class TestShellCommand:

--- a/tests/integrations/fastapi/test_missing_dependency.py
+++ b/tests/integrations/fastapi/test_missing_dependency.py
@@ -1,0 +1,30 @@
+"""The FastAPI integration reports an install hint when fastapi is absent (ADR-0029).
+
+``fastapi`` ships in the optional ``protean[server]`` extra. Importing
+``protean.integrations.fastapi`` without it must fail with a message naming the
+extra, not a bare ``ModuleNotFoundError`` from deep inside the package.
+"""
+
+import importlib
+
+import pytest
+
+from tests.shared import module_unavailable
+
+
+def test_importing_integration_without_fastapi_reports_actionable_error():
+    with module_unavailable("fastapi", reload=("protean.integrations.fastapi",)):
+        with pytest.raises(ImportError) as exc_info:
+            importlib.import_module("protean.integrations.fastapi")
+
+    message = str(exc_info.value)
+    assert "protean.integrations.fastapi" in message
+    assert 'pip install "protean[server]"' in message
+
+
+def test_integration_imports_normally_when_fastapi_is_present():
+    # Sanity check that the guard does not interfere with the happy path.
+    module = importlib.import_module("protean.integrations.fastapi")
+
+    assert hasattr(module, "DomainContextMiddleware")
+    assert hasattr(module, "create_health_router")

--- a/tests/integrations/fastapi/test_missing_dependency.py
+++ b/tests/integrations/fastapi/test_missing_dependency.py
@@ -11,6 +11,8 @@ import pytest
 
 from tests.shared import module_unavailable
 
+pytestmark = pytest.mark.no_test_domain
+
 
 def test_importing_integration_without_fastapi_reports_actionable_error():
     with module_unavailable("fastapi", reload=("protean.integrations.fastapi",)):

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -139,11 +139,14 @@ def module_unavailable(*names: str, reload: tuple[str, ...] = ()) -> Iterator[No
     """Simulate optional packages being uninstalled, then restore them.
 
     Each name in ``names`` (and its submodules) is removed from ``sys.modules``
-    and the top-level name is set to ``None`` so a subsequent ``import <name>``
-    raises ``ImportError``, exactly as it would if the package were not
-    installed. Names in ``reload`` are only evicted (not set to ``None``) so they
-    re-execute on next import; use this for a Protean package that lazily imports
-    an absent extra, so its ``__init__`` runs again and hits the missing import.
+    and the top-level name is set to ``None``. A subsequent ``import <name>`` then
+    raises ``ModuleNotFoundError`` and ``importlib.util.find_spec(name)`` returns
+    ``None``: the same type and spec result an uninstalled package produces (the
+    error message differs, reading "None in sys.modules"), which is what the
+    dependency guards key off. Names in ``reload`` are only evicted (not set to
+    ``None``) so they re-execute on next import; use this for a Protean package
+    that lazily imports an absent extra, so its ``__init__`` runs again and hits
+    the missing import.
 
     Exercises the "optional dependency is missing" paths without touching the
     real environment; the original module table is restored on exit.

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -134,6 +134,38 @@ def change_working_directory_to(path):
     sys.path.insert(0, str(test_path))
 
 
+@contextlib.contextmanager
+def module_unavailable(*names: str, reload: tuple[str, ...] = ()) -> Iterator[None]:
+    """Simulate optional packages being uninstalled, then restore them.
+
+    Each name in ``names`` (and its submodules) is removed from ``sys.modules``
+    and the top-level name is set to ``None`` so a subsequent ``import <name>``
+    raises ``ImportError`` — exactly as it would if the package were not
+    installed. Names in ``reload`` are only evicted (not set to ``None``) so they
+    re-execute on next import; use this for a Protean package that lazily imports
+    an absent extra, so its ``__init__`` runs again and hits the missing import.
+
+    Exercises the "optional dependency is missing" paths without touching the
+    real environment; the original module table is restored on exit.
+    """
+    to_clear = {
+        key
+        for key in list(sys.modules)
+        if any(key == n or key.startswith(f"{n}.") for n in (*names, *reload))
+    }
+    saved = {key: sys.modules[key] for key in to_clear}
+    for key in to_clear:
+        del sys.modules[key]
+    for name in names:
+        sys.modules[name] = None  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        for name in names:
+            sys.modules.pop(name, None)
+        sys.modules.update(saved)
+
+
 def has_key_or_attr(obj, name):
     try:
         return name in obj  # Works if obj is dict-like

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -140,7 +140,7 @@ def module_unavailable(*names: str, reload: tuple[str, ...] = ()) -> Iterator[No
 
     Each name in ``names`` (and its submodules) is removed from ``sys.modules``
     and the top-level name is set to ``None`` so a subsequent ``import <name>``
-    raises ``ImportError`` — exactly as it would if the package were not
+    raises ``ImportError``, exactly as it would if the package were not
     installed. Names in ``reload`` are only evicted (not set to ``None``) so they
     re-execute on next import; use this for a Protean package that lazily imports
     an absent extra, so its ``__init__`` runs again and hits the missing import.

--- a/tests/test_runtime_dependencies.py
+++ b/tests/test_runtime_dependencies.py
@@ -1,0 +1,98 @@
+"""Guards for the right-sized runtime dependency surface (ADR-0029).
+
+The web/observatory stack, the interactive shell, and the project scaffolder live
+behind install extras, not in the lean core. These tests pin that boundary so a
+stray eager import or a dependency creeping back into ``[project].dependencies``
+is caught. ``bleach`` and ``werkzeug`` intentionally stay in core.
+"""
+
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+import protean
+
+# Distribution name -> the extra that must provide it. None of these may be a
+# core dependency.
+OPTIONAL_DISTS = {
+    "fastapi": "server",
+    "uvicorn": "server",
+    "jinja2": "server",
+    "ipython": "shell",
+    "copier": "scaffold",
+}
+
+# Top-level import name of each optional stack. `import protean` must pull none.
+OPTIONAL_IMPORTS = ["fastapi", "uvicorn", "jinja2", "IPython", "copier"]
+
+# Dependencies that must stay in the lean core.
+CORE_MUST_KEEP = {"bleach", "werkzeug", "pydantic", "marshmallow", "typer"}
+
+
+def _pyproject() -> dict:
+    path = Path(protean.__file__).resolve().parents[2] / "pyproject.toml"
+    if not path.exists():
+        pytest.skip("pyproject.toml not available (installed, non-editable)")
+    return tomllib.loads(path.read_text(encoding="utf-8"))
+
+
+def _dist_name(spec: str) -> str:
+    """Extract the distribution name from a requirement spec (`fastapi>=1` -> `fastapi`)."""
+    match = re.match(r"[A-Za-z0-9._-]+", spec)
+    assert match is not None, spec
+    return match.group(0).lower()
+
+
+def test_optional_distributions_are_not_core_dependencies():
+    core = {_dist_name(spec) for spec in _pyproject()["project"]["dependencies"]}
+    assert core, "core dependency list is empty"
+    for dist, extra in OPTIONAL_DISTS.items():
+        assert dist not in core, (
+            f"{dist!r} must live behind protean[{extra}], not in [project].dependencies"
+        )
+
+
+def test_core_keeps_its_essential_dependencies():
+    core = {_dist_name(spec) for spec in _pyproject()["project"]["dependencies"]}
+    for dist in CORE_MUST_KEEP:
+        assert dist in core, f"{dist!r} must stay a core dependency"
+
+
+def test_each_optional_distribution_is_declared_in_its_extra():
+    extras = _pyproject()["project"]["optional-dependencies"]
+    for dist, extra in OPTIONAL_DISTS.items():
+        names = {_dist_name(spec) for spec in extras[extra]}
+        assert dist in names, f"protean[{extra}] must provide {dist!r}"
+
+
+def test_convenience_extras_compose_the_feature_extras():
+    extras = _pyproject()["project"]["optional-dependencies"]
+    assert extras["cli"] == ["protean[shell,scaffold]"]
+    assert extras["all"] == ["protean[server,cli]"]
+
+
+def test_import_protean_does_not_pull_optional_stacks():
+    """A bare ``import protean`` must not import any optional feature stack.
+
+    Runs in a subprocess so the check sees a clean module table, not one already
+    populated by the test session (which installs every extra).
+    """
+    code = (
+        "import sys, protean;"
+        f"watched=set({OPTIONAL_IMPORTS!r});"
+        "pulled=sorted(m for m in sys.modules if m.split('.')[0] in watched);"
+        "print(','.join(pulled))"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.stdout.strip() == "", (
+        f"import protean pulled optional stacks: {result.stdout.strip()}"
+    )

--- a/tests/test_runtime_dependencies.py
+++ b/tests/test_runtime_dependencies.py
@@ -75,14 +75,14 @@ def test_convenience_extras_compose_the_feature_extras():
     assert extras["all"] == ["protean[server,cli]"]
 
 
-def test_import_protean_does_not_pull_optional_stacks():
-    """A bare ``import protean`` must not import any optional feature stack.
+def _optional_stacks_pulled_by(import_stmt: str) -> str:
+    """Return the optional-stack modules `import_stmt` pulls, checked in a subprocess.
 
-    Runs in a subprocess so the check sees a clean module table, not one already
-    populated by the test session (which installs every extra).
+    A subprocess gives a clean module table, not one already populated by the
+    test session (which installs every extra).
     """
     code = (
-        "import sys, protean;"
+        f"import sys; {import_stmt};"
         f"watched=set({OPTIONAL_IMPORTS!r});"
         "pulled=sorted(m for m in sys.modules if m.split('.')[0] in watched);"
         "print(','.join(pulled))"
@@ -93,6 +93,22 @@ def test_import_protean_does_not_pull_optional_stacks():
         text=True,
         check=True,
     )
-    assert result.stdout.strip() == "", (
-        f"import protean pulled optional stacks: {result.stdout.strip()}"
-    )
+    return result.stdout.strip()
+
+
+def test_import_protean_does_not_pull_optional_stacks():
+    """A bare ``import protean`` must not import any optional feature stack."""
+    pulled = _optional_stacks_pulled_by("import protean")
+    assert pulled == "", f"import protean pulled optional stacks: {pulled}"
+
+
+def test_loading_the_cli_does_not_pull_optional_stacks():
+    """Loading the CLI must stay lean.
+
+    ``import protean`` never touches ``protean.cli``, so this is a separate
+    guarantee. The CLI package imports every subcommand module at load, so a
+    subcommand regaining a module-top ``import IPython``/``copier``/fastapi would
+    break ``protean --help`` on a lean install while the check above stayed green.
+    """
+    pulled = _optional_stacks_pulled_by("from protean.cli import app")
+    assert pulled == "", f"loading the CLI pulled optional stacks: {pulled}"

--- a/tests/test_runtime_dependencies.py
+++ b/tests/test_runtime_dependencies.py
@@ -16,6 +16,8 @@ import pytest
 
 import protean
 
+pytestmark = pytest.mark.no_test_domain
+
 # Distribution name -> the extra that must provide it. None of these may be a
 # core dependency.
 OPTIONAL_DISTS = {

--- a/tests/utils/test_dependencies.py
+++ b/tests/utils/test_dependencies.py
@@ -9,7 +9,7 @@ def test_message_names_the_package_extra_and_feature():
     assert "copier" in msg
     assert "'protean new'" in msg
     # The literal install command must survive intact, including the bracketed
-    # extra — this is what the caller pastes into a terminal.
+    # extra, which is what the caller pastes into a terminal.
     assert 'pip install "protean[scaffold]"' in msg
 
 

--- a/tests/utils/test_dependencies.py
+++ b/tests/utils/test_dependencies.py
@@ -1,6 +1,10 @@
 """Tests for the optional-dependency message builder (ADR-0029)."""
 
+import pytest
+
 from protean.utils.dependencies import missing_dependency_message
+
+pytestmark = pytest.mark.no_test_domain
 
 
 def test_message_names_the_package_extra_and_feature():

--- a/tests/utils/test_dependencies.py
+++ b/tests/utils/test_dependencies.py
@@ -1,0 +1,24 @@
+"""Tests for the optional-dependency message builder (ADR-0029)."""
+
+from protean.utils.dependencies import missing_dependency_message
+
+
+def test_message_names_the_package_extra_and_feature():
+    msg = missing_dependency_message("copier", "scaffold", "'protean new'")
+
+    assert "copier" in msg
+    assert "'protean new'" in msg
+    # The literal install command must survive intact, including the bracketed
+    # extra — this is what the caller pastes into a terminal.
+    assert 'pip install "protean[scaffold]"' in msg
+
+
+def test_message_is_a_single_actionable_line_per_extra():
+    for package, extra in [
+        ("fastapi", "server"),
+        ("IPython", "shell"),
+        ("copier", "scaffold"),
+    ]:
+        msg = missing_dependency_message(package, extra, "a feature")
+        assert msg.startswith("a feature requires the")
+        assert f"protean[{extra}]" in msg

--- a/uv.lock
+++ b/uv.lock
@@ -2267,22 +2267,28 @@ source = { editable = "." }
 dependencies = [
     { name = "bleach" },
     { name = "cffi" },
-    { name = "copier" },
-    { name = "fastapi" },
     { name = "greenlet" },
     { name = "inflection" },
-    { name = "ipython" },
-    { name = "jinja2" },
     { name = "marshmallow" },
     { name = "pydantic" },
     { name = "python-dateutil" },
     { name = "structlog" },
     { name = "typer" },
-    { name = "uvicorn" },
     { name = "werkzeug" },
 ]
 
 [package.optional-dependencies]
+all = [
+    { name = "copier" },
+    { name = "fastapi" },
+    { name = "ipython" },
+    { name = "jinja2" },
+    { name = "uvicorn" },
+]
+cli = [
+    { name = "copier" },
+    { name = "ipython" },
+]
 dev = [
     { name = "watchfiles" },
 ]
@@ -2306,8 +2312,19 @@ postgresql = [
 redis = [
     { name = "redis" },
 ]
+scaffold = [
+    { name = "copier" },
+]
 sendgrid = [
     { name = "sendgrid" },
+]
+server = [
+    { name = "fastapi" },
+    { name = "jinja2" },
+    { name = "uvicorn" },
+]
+shell = [
+    { name = "ipython" },
 ]
 sqlite = [
     { name = "sqlalchemy" },
@@ -2368,14 +2385,14 @@ types = [
 requires-dist = [
     { name = "bleach", specifier = ">=6.1.0" },
     { name = "cffi", specifier = ">=2.0.0" },
-    { name = "copier", specifier = ">=9.4.0,<10" },
+    { name = "copier", marker = "extra == 'scaffold'", specifier = ">=9.4.0,<10" },
     { name = "elasticsearch", marker = "extra == 'elasticsearch'", specifier = ">=8.18.0,<9.0.0" },
-    { name = "fastapi", specifier = ">=0.139.0" },
+    { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.139.0" },
     { name = "flask", marker = "extra == 'flask'", specifier = ">=3.0.0" },
     { name = "greenlet", specifier = ">=3.2.3,<4" },
     { name = "inflection", specifier = ">=0.5.1" },
-    { name = "ipython", specifier = ">=9.0.0,<10.0" },
-    { name = "jinja2", specifier = ">=3.1.6" },
+    { name = "ipython", marker = "extra == 'shell'", specifier = ">=9.0.0,<10.0" },
+    { name = "jinja2", marker = "extra == 'server'", specifier = ">=3.1.6" },
     { name = "marshmallow", specifier = ">=4.0.0" },
     { name = "message-db-py", marker = "extra == 'message-db'", specifier = ">=0.3.4" },
     { name = "opentelemetry-api", marker = "extra == 'telemetry'", specifier = ">=1.36.0" },
@@ -2383,22 +2400,24 @@ requires-dist = [
     { name = "opentelemetry-exporter-prometheus", marker = "extra == 'telemetry'", specifier = ">=0.57b0" },
     { name = "opentelemetry-instrumentation-fastapi", marker = "extra == 'telemetry'", specifier = ">=0.57b0" },
     { name = "opentelemetry-sdk", marker = "extra == 'telemetry'", specifier = ">=1.36.0" },
+    { name = "protean", extras = ["server", "cli"], marker = "extra == 'all'" },
+    { name = "protean", extras = ["shell", "scaffold"], marker = "extra == 'cli'" },
     { name = "psycopg2-binary", marker = "extra == 'postgresql'", specifier = ">=2.9.11" },
     { name = "pydantic", specifier = ">=2.12.0,<3.0" },
     { name = "pyodbc", marker = "extra == 'mssql'", specifier = ">=5.3.0" },
     { name = "python-dateutil", specifier = ">=2.8.2" },
-    { name = "redis", marker = "extra == 'redis'", specifier = ">=8.0.0,<8.1.0" },
+    { name = "redis", marker = "extra == 'redis'", specifier = ">=8.0.0,<8.2.0" },
     { name = "sendgrid", marker = "extra == 'sendgrid'", specifier = ">=6.11.0" },
     { name = "sqlalchemy", marker = "extra == 'mssql'", specifier = ">=2.0.36,<2.1" },
     { name = "sqlalchemy", marker = "extra == 'postgresql'", specifier = ">=2.0.36,<2.1" },
     { name = "sqlalchemy", marker = "extra == 'sqlite'", specifier = ">=2.0.36,<2.1" },
     { name = "structlog", specifier = ">=24.1.0" },
     { name = "typer", specifier = ">=0.16.0" },
-    { name = "uvicorn", specifier = ">=0.30.0" },
+    { name = "uvicorn", marker = "extra == 'server'", specifier = ">=0.30.0" },
     { name = "watchfiles", marker = "extra == 'dev'", specifier = ">=1.2.0" },
     { name = "werkzeug", specifier = ">=3.1.0" },
 ]
-provides-extras = ["elasticsearch", "redis", "postgresql", "sqlite", "mssql", "message-db", "flask", "sendgrid", "dev", "telemetry"]
+provides-extras = ["elasticsearch", "redis", "postgresql", "sqlite", "mssql", "message-db", "flask", "sendgrid", "server", "shell", "scaffold", "cli", "all", "dev", "telemetry"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Right-sizes Protean's **runtime** dependency surface so a plain `pip install protean` no longer forces a web server, an ASGI stack, an interactive REPL, and a project scaffolder onto every consumer. Five packages move out of `[project].dependencies` into feature extras:

| Extra | Packages | Gates |
|-------|----------|-------|
| `server` | fastapi, uvicorn, jinja2 | `protean observatory`, `protean.integrations.fastapi` |
| `shell` | ipython | `protean shell` |
| `scaffold` | copier | `protean new` |

Plus two bundles: `cli` = shell + scaffold, and `all` = server + cli (restores the pre-0.18 install in one word).

These imports were already lazy, so `import protean`, defining a domain, persisting through the memory adapter, and `protean server` (the async engine) never needed them — this is a footprint change, not an import-coupling one.

**bleach and werkzeug stay in core.** bleach is a genuine runtime need because `String()`/`Text()` default to `sanitize=True`, so it runs for nearly every domain; werkzeug backs `current_domain`/`current_uow`. See ADR-0029 for the full boundary and rationale.

## Behaviour when an extra is missing

Running `protean observatory`/`shell`/`new`, or importing `protean.integrations.fastapi`, without the matching extra now fails with an actionable message instead of a raw `ModuleNotFoundError`:

```
Error: 'protean observatory' requires the 'fastapi' package. Install it with 'pip install "protean[server]"'.
```

The "is it installed?" check uses `importlib.util.find_spec` over the extra's packages, not `ImportError.name`: a package that is installed but broken (an incompatible version, a renamed symbol) raises an `ImportError` naming itself, so a name-based check would tell you to install what you already have. When every package the extra provides is importable, the `ImportError` is a real bug inside the feature and is re-raised unchanged.

## Decision-first

This is a Tier-1 breaking change (ADR-0004). The extras taxonomy, keeping bleach/werkzeug in core, and the clean-break-in-0.18 strategy were signed off before implementation and are recorded in **ADR-0029**. The `docs/reference/migration/v0-18.md` guide documents the break; the changelog fragment marks it breaking and links the migration section.

## Test plan

- [x] Core tests pass (`protean test`)
- [x] Full adapter suite — Docker unavailable locally; runs on CI
- [x] 100% patch coverage (`make coverage-diff`)
- [x] Packaging boundary pinned: optional dists absent from core, core essentials present, each optional dist declared in its extra, `import protean` and `from protean.cli import app` pull none of the optional stacks
- [x] `protean new --force` aborts before clearing the target directory when copier is absent (data-loss guard)
- [x] `mkdocs build --strict` passes

Closes #1000
