### PR TITLE
Replace Werkzeug LocalProxy/LocalStack with stdlib contextvars

### DIFF
--- a/changes/1375.changed.md
+++ b/changes/1375.changed.md
@@ -1,0 +1,1 @@
+Replaced Werkzeug's `LocalProxy`/`LocalStack` with stdlib `contextvars` for `current_domain`, `current_uow`, and `g`. The push/pop nesting semantics for domain contexts and Unit-of-Work stacks are preserved, and the active context now follows asyncio tasks and `await` boundaries. `werkzeug` is no longer a core dependency.

--- a/docs/adr/0020-dependency-floor-policy.md
+++ b/docs/adr/0020-dependency-floor-policy.md
@@ -77,7 +77,7 @@ newest version available.** Concretely:
 
 - Applications gain a materially wider compatibility window for the
   pure-Python dependencies they are most likely to share and pin (`fastapi`
-  ecosystem: `typer`, `uvicorn`, `starlette`; plus `jinja2`, `werkzeug`,
+  ecosystem: `typer`, `uvicorn`, `starlette`; plus `jinja2`,
   `structlog`, `marshmallow`, `flask`, and others). They can adopt or hold a
   Protean upgrade without being forced onto the newest release of each.
 - The floors now mean something and are continuously verified. A future change

--- a/docs/adr/0029-runtime-dependency-boundary-and-extras.md
+++ b/docs/adr/0029-runtime-dependency-boundary-and-extras.md
@@ -26,13 +26,16 @@ surface every consumer inherited. FastAPI itself models the fix (it pushes
 `uvicorn` into `fastapi[standard]`); Requests keeps its core at a handful of
 dependencies.
 
-Two more packages were candidates but stay in core after review. `bleach` (HTML
-sanitization) looked optional, used only for String/Text field sanitization,
-until you notice that `String()` and `Text()` default to `sanitize=True`. Nearly
-every domain has a string field, so bleach runs for nearly every domain; moving
-it behind an extra would make that extra a de-facto requirement and would
-silently stop sanitizing for anyone who missed it. `werkzeug` is a genuine
-import-time need (it backs `current_domain`/`current_uow`). Both stay in core.
+Two more packages were candidates but stayed in core after the original review.
+`bleach` (HTML sanitization) looked optional, used only for String/Text field
+sanitization, until you notice that `String()` and `Text()` default to
+`sanitize=True`. Nearly every domain has a string field, so bleach runs for
+nearly every domain; moving it behind an extra would make that extra a de-facto
+requirement and would silently stop sanitizing for anyone who missed it.
+`werkzeug` was a genuine import-time need (it backed `current_domain`/
+`current_uow`). Both stayed in core at the time. (Each of `werkzeug`, `cffi`,
+and `greenlet` was later reviewed and moved out; see the amendments in
+Consequences.)
 
 Moving a package out of `[project].dependencies` is a Tier-1 breaking change
 under [ADR-0004](0004-release-workflow-and-breaking-change-policy.md): code that
@@ -45,10 +48,12 @@ how to land the break without stranding upgraders.
 **Draw the core at the domain-modeling and message-processing essentials, and
 move the five install-time-optional packages behind feature extras.**
 
-Core (`pip install protean`) keeps only what every consumer needs to define a
+Core (`pip install protean`) kept only what every consumer needed to define a
 domain, persist through the memory adapter, and run the async engine:
 `inflection`, `marshmallow`, `python-dateutil`, `typer` (the CLI framework
-itself), `structlog`, `werkzeug`, `bleach`, `pydantic`, `greenlet`, and `cffi`.
+itself), `structlog`, `werkzeug`, `bleach`, `pydantic`, `greenlet`, and `cffi`
+(at the time of the original decision; see the amendments in Consequences for
+the current state).
 
 The feature extras:
 

--- a/docs/adr/0029-runtime-dependency-boundary-and-extras.md
+++ b/docs/adr/0029-runtime-dependency-boundary-and-extras.md
@@ -111,23 +111,24 @@ document the change in the 0.18 migration guide. The actionable error plus the
 - Deriving the boundary per feature (rather than one big `cli` bucket) means more
   extra names to document, but each install stays minimal: a REPL user does not
   drag in the scaffolder.
-- `bleach`, `werkzeug`, `cffi`, and `greenlet` stay in core. `bleach` because
-  String/Text fields sanitize by default (see Context); `werkzeug` because it
-  backs `current_domain`/`current_uow` via `LocalProxy`/`LocalStack`. `cffi` and
-  `greenlet` are not imported directly by `src/protean` and appear to be
-  transitive-only. Whether `werkzeug` can be replaced by `contextvars`, and
-  whether `cffi`/`greenlet` can leave core, is deferred to a separate review so
-  this change stays a packaging change and does not touch the context system's
-  semantics.
+- `bleach` stays in core because String/Text fields sanitize by default (see
+  Context). `werkzeug`, `cffi`, and `greenlet` stayed in core at the time of the
+  original decision, but each was later reviewed and moved out; see the
+  amendments below.
 
-  *Amended (August 2026, #1376): the deferred review landed. Nothing in
-  `src/protean` imports `cffi` or `greenlet` on any runtime path (the SQLAlchemy
-  adapter uses the synchronous engine; werkzeug's locals are contextvars-based),
-  so both left core. Their floors moved to the extras whose trees pull them:
-  `greenlet` to `postgresql`/`sqlite`/`mssql` (SQLAlchemy requires it on common
-  platforms but pins no floor), `cffi` to `sendgrid` (its only consumer is
-  `cryptography`, also floorless). The ADR-0020 newest-Python-wheel floor still
-  holds where each package is actually installed.*
+  *Amended (August 2026, #1376): `cffi` and `greenlet` left core. Nothing in
+  `src/protean` imports either package on any runtime path (the SQLAlchemy
+  adapter uses the synchronous engine), so both left core. Their floors moved to
+  the extras whose trees pull them: `greenlet` to `postgresql`/`sqlite`/`mssql`
+  (SQLAlchemy requires it on common platforms but pins no floor), `cffi` to
+  `sendgrid` (its only consumer is `cryptography`, also floorless). The
+  ADR-0020 newest-Python-wheel floor still holds where each package is actually
+  installed.*
+
+  *Amended (August 2026, #1375): `werkzeug` left core. `current_domain`,
+  `current_uow`, and `g` are now backed by a small stdlib `contextvars`
+  implementation that preserves the push/pop nesting semantics of the old
+  `LocalStack`/`LocalProxy`. The public API of the three proxies is unchanged.*
 
 ## Alternatives Considered
 

--- a/docs/reference/migration/v0-18.md
+++ b/docs/reference/migration/v0-18.md
@@ -20,6 +20,7 @@ now needs an extra, the CLI or the import tells you exactly which one.
 - [The one-line fix](#the-one-line-fix): `protean[all]` restores the old install
 - [What each feature needs now](#what-each-feature-needs-now)
 - [cffi and greenlet left the core install](#cffi-and-greenlet-left-the-core-install)
+- [werkzeug left the core install](#werkzeug-left-the-core-install)
 
 ---
 
@@ -107,3 +108,21 @@ a version with wheels for the newest supported Python.
 
 You only need to act if your own code imports `cffi` or `greenlet` and relied
 on Protean to provide it. Declare the package in your own project instead.
+
+---
+
+## werkzeug left the core install
+
+0.17 used Werkzeug's `LocalProxy`/`LocalStack` to back `current_domain`,
+`current_uow`, and `g`. In 0.18 these context locals are backed by stdlib
+`contextvars`, and `werkzeug` is no longer a core dependency.
+
+For nearly all code this is transparent: the same push/pop nesting, the same
+proxy behavior, and the same async support (in fact, `contextvars` follows
+asyncio tasks and `await` boundaries natively). The public surface of
+`current_domain`, `current_uow`, and `g` is unchanged.
+
+You only need to act if your own code depends on Werkzeug-specific details of
+the proxy or stack, such as inspecting the underlying `LocalStack` directly.
+Internal helpers like `_domain_context_stack` and `_uow_context_stack` remain
+private and have changed their implementation type.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,8 @@ classifiers = [
 # interactive shell, the project scaffolder) live behind the extras below so a
 # plain `pip install protean` does not drag them onto every consumer. `bleach`
 # stays here: String/Text fields sanitize by default, so it is a genuine runtime
-# need for nearly every domain. See ADR-0029 for the boundary and the rationale.
+# need for nearly every domain. `werkzeug` was removed: the context locals are
+# now backed by stdlib `contextvars` (see ADR-0029 and #1375).
 dependencies = [
     "bleach>=6.1.0",
     "inflection>=0.5.1",
@@ -68,7 +69,6 @@ dependencies = [
     "python-dateutil>=2.8.2",
     "typer>=0.16.0",
     "structlog>=24.1.0",
-    "werkzeug>=3.1.0",
     "pydantic>=2.12.0,<3.0",
 ]
 
@@ -209,7 +209,6 @@ types = [
     "types-mock>=5.2.0.20260518",
     "types-python-dateutil>=2.9.0.20260716",
     "types-redis>=4.6.0.20241004",
-    "types-Werkzeug>=1.0.9",
 ]
 # Mutation testing. Installed only into the dedicated .venv-mutation environment
 # built by `make mutation` / scripts/mutation.sh — never the project .venv. That

--- a/src/protean/core/unit_of_work.py
+++ b/src/protean/core/unit_of_work.py
@@ -24,20 +24,17 @@ if TYPE_CHECKING:
 
 
 class _UoWStack(Protocol):
-    """Typed view of the ``LocalStack`` methods this module relies on.
+    """Typed view of the context stack methods this module relies on.
 
-    The installed werkzeug ships ``LocalStack`` without usable annotations
-    (its ``push``/``pop`` resolve to ``Any``), which trips mypy ``--strict``'s
-    ``no-untyped-call`` on every stack access. Casting the shared stack to this
-    Protocol restores precise types at the call sites without suppressing the
-    diagnostic. Mirrors the ``cast`` precedent at the construction site in
-    ``protean.utils.globals``.
+    ``protean.utils.globals`` now supplies a stdlib ``contextvars``-backed
+    stack, but this protocol keeps the call sites in this module precisely
+    typed without leaking the implementation type.
     """
 
     @property
     def top(self) -> "UnitOfWork | None": ...
 
-    def push(self, obj: "UnitOfWork") -> list["UnitOfWork"]: ...
+    def push(self, obj: "UnitOfWork") -> None: ...
 
     def pop(self) -> "UnitOfWork | None": ...
 

--- a/src/protean/domain/context.py
+++ b/src/protean/domain/context.py
@@ -13,21 +13,17 @@ if TYPE_CHECKING:
 
 
 class _DomainContextStack(Protocol):
-    """Typed view of the ``LocalStack`` methods this module relies on.
+    """Typed view of the context stack methods this module relies on.
 
-    The installed werkzeug ships ``LocalStack`` without usable annotations
-    (its ``push``/``pop`` resolve to ``Any``), which trips mypy ``--strict``'s
-    ``no-untyped-call`` on every stack access. Casting the shared stack to this
-    Protocol restores precise types at the call sites without suppressing the
-    diagnostic. Mirrors the ``_UoWStack`` precedent in
-    ``protean.core.unit_of_work`` and the ``cast`` at the construction site in
-    ``protean.utils.globals``.
+    ``protean.utils.globals`` now supplies a stdlib ``contextvars``-backed
+    stack, but this protocol keeps the call sites in this module precisely
+    typed without leaking the implementation type.
     """
 
     @property
     def top(self) -> "DomainContext | None": ...
 
-    def push(self, obj: "DomainContext") -> list["DomainContext"]: ...
+    def push(self, obj: "DomainContext") -> None: ...
 
     def pop(self) -> "DomainContext | None": ...
 
@@ -102,8 +98,11 @@ def has_domain_context() -> bool:
 
 
 class DomainContext:
-    """The domain context binds an domain object implicitly
-    to the current thread or greenlet.
+    """The domain context binds a domain object implicitly to the current context.
+
+    The backing stack uses stdlib ``contextvars``, so the active domain follows
+    the execution context across OS threads, asyncio tasks, and ``await``
+    boundaries.
     """
 
     def __init__(self, domain: "Domain", **kwargs: Any) -> None:

--- a/src/protean/utils/globals.py
+++ b/src/protean/utils/globals.py
@@ -61,11 +61,11 @@ class _ContextLocalProxy(Generic[_T]):
 
     Replaces Werkzeug's ``LocalProxy`` for ``current_domain``,
     ``current_uow``, and ``g``. When a lookup returns an object, attribute
-    get/set/delete, containment, iteration, representation, and comparison
-    delegate to that object. When no object is active, the proxy behaves like
-    ``None``: it is falsy, its string form is ``"None"``, it compares equal to
-    ``None``, and containment/iteration raise the same ``TypeError`` that
-    ``None`` would.
+    get/set/delete, containment, iteration, representation, truthiness, and
+    comparison delegate to that object. When no object is active, the proxy
+    behaves like ``None``: it is falsy, its representation and string form are
+    ``"None"``, it compares equal to ``None``, and containment/iteration raise
+    the same ``TypeError`` that ``None`` would.
     """
 
     _lookup: Callable[[], _T | None]
@@ -99,12 +99,13 @@ class _ContextLocalProxy(Generic[_T]):
         delattr(self._get_object_or_raise(name), name)
 
     def __bool__(self) -> bool:
-        return self._get_current_object() is not None
+        obj = self._get_current_object()
+        return bool(obj) if obj is not None else False
 
     def __repr__(self) -> str:
         obj = self._get_current_object()
         if obj is None:
-            return "<unbound proxy>"
+            return repr(None)
         return repr(obj)
 
     def __str__(self) -> str:

--- a/src/protean/utils/globals.py
+++ b/src/protean/utils/globals.py
@@ -83,7 +83,10 @@ class _ContextLocalProxy(Generic[_T]):
         return obj
 
     @property  # type: ignore[misc]
-    def __class__(self) -> type:
+    def __class__(self) -> type:  # pyright: ignore[reportIncompatibleMethodOverride]
+        # ``object.__class__`` is a read/write property; overriding it read-only
+        # is deliberate (the proxy reports the wrapped type for ``isinstance``),
+        # so silence the incompatible-override report.
         obj = self._get_current_object()
         if obj is None:
             return type(self)

--- a/src/protean/utils/globals.py
+++ b/src/protean/utils/globals.py
@@ -1,16 +1,21 @@
+import contextvars
 import logging
+import sys
 import traceback
+import types
 import warnings
+from collections.abc import Callable, Iterator
 from datetime import UTC, datetime
 from functools import partial
-from typing import TYPE_CHECKING, Any, cast
-
-from werkzeug.local import LocalProxy, LocalStack
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
 
 if TYPE_CHECKING:
     from protean import Domain, UnitOfWork
+    from protean.domain.context import DomainContext
 
 logger = logging.getLogger(__name__)
+
+_T = TypeVar("_T")
 
 _domain_ctx_err_msg = """\
 Working outside of domain context.
@@ -21,33 +26,159 @@ documentation for more information.\
 """
 
 
-def _lookup_domain_object(name: str) -> Any | None:
+class _ContextStack(Generic[_T]):
+    """A contextvars-backed stack preserving ``push``/``pop`` nesting.
+
+    Replaces Werkzeug's ``LocalStack`` for the domain and Unit-of-Work context
+    stacks. Each execution context (OS thread or asyncio task) gets its own
+    list via ``contextvars.ContextVar``. The list is replaced on every mutation,
+    which keeps the stack correct across ``await`` boundaries without
+    thread-local machinery.
+    """
+
+    def __init__(self, name: str) -> None:
+        self._var: contextvars.ContextVar[list[_T]] = contextvars.ContextVar(name)
+
+    @property
+    def top(self) -> _T | None:
+        stack = self._var.get([])
+        return stack[-1] if stack else None
+
+    def push(self, obj: _T) -> None:
+        stack = self._var.get([])
+        self._var.set([*stack, obj])
+
+    def pop(self) -> _T | None:
+        stack = self._var.get([])
+        if not stack:
+            return None
+        self._var.set(stack[:-1])
+        return stack[-1]
+
+
+class _ContextLocalProxy(Generic[_T]):
+    """A proxy that resolves the wrapped object on every access.
+
+    Replaces Werkzeug's ``LocalProxy`` for ``current_domain``,
+    ``current_uow``, and ``g``. When a lookup returns an object, attribute
+    get/set/delete, containment, iteration, representation, and comparison
+    delegate to that object. When no object is active, the proxy behaves like
+    ``None``: it is falsy, its string form is ``"None"``, it compares equal to
+    ``None``, and containment/iteration raise the same ``TypeError`` that
+    ``None`` would.
+    """
+
+    _lookup: Callable[[], _T | None]
+
+    def __init__(self, lookup: Callable[[], _T | None]) -> None:
+        object.__setattr__(self, "_lookup", lookup)
+
+    def _get_current_object(self) -> _T | None:
+        return self._lookup()
+
+    def _get_object_or_raise(self, name: str) -> _T:
+        obj = self._get_current_object()
+        if obj is None:
+            raise AttributeError(name)
+        return obj
+
+    @property  # type: ignore[misc]
+    def __class__(self) -> type:
+        obj = self._get_current_object()
+        if obj is None:
+            return type(self)
+        return type(obj)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._get_object_or_raise(name), name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        setattr(self._get_object_or_raise(name), name, value)
+
+    def __delattr__(self, name: str) -> None:
+        delattr(self._get_object_or_raise(name), name)
+
+    def __bool__(self) -> bool:
+        return self._get_current_object() is not None
+
+    def __repr__(self) -> str:
+        obj = self._get_current_object()
+        if obj is None:
+            return "<unbound proxy>"
+        return repr(obj)
+
+    def __str__(self) -> str:
+        obj = self._get_current_object()
+        if obj is None:
+            return "None"
+        return str(obj)
+
+    def __eq__(self, other: object) -> bool:
+        obj = self._get_current_object()
+        if obj is None:
+            return other is None
+        return bool(obj == other)
+
+    def __hash__(self) -> int:
+        obj = self._get_current_object()
+        if obj is None:
+            return hash(None)
+        return hash(obj)
+
+    def __dir__(self) -> list[str]:
+        obj = self._get_current_object()
+        return list(dir(obj))
+
+    def __contains__(self, item: object) -> bool:
+        obj = self._get_current_object()
+        return item in obj  # type: ignore[operator]
+
+    def __iter__(self) -> Iterator[Any]:
+        obj = self._get_current_object()
+        return iter(obj)  # type: ignore[no-any-return, call-overload]
+
+
+def _warning_stacklevel() -> int:
+    """Return a stacklevel that points at the first frame outside this module.
+
+    The warning must appear to come from user code, not from the proxy or stack
+    helpers inside this module. Walk up from the caller of
+    ``_active_domain_context`` until we leave ``protean.utils.globals``.
+    """
+    frame: types.FrameType | None = sys._getframe(2)  # caller of _active_domain_context
+    stacklevel = 2
+    while frame is not None and frame.f_globals.get("__name__") == __name__:
+        frame = frame.f_back
+        stacklevel += 1
+    return stacklevel
+
+
+def _active_domain_context(log_traceback: bool = False) -> "DomainContext | None":
     top = _domain_context_stack.top
     if top is None:
+        if log_traceback:
+            logger.debug("=======NO ACTIVE DOMAIN - STACK TRACE - START=======")
+            logger.debug("".join(traceback.format_stack()))
+            logger.debug("=======NO ACTIVE DOMAIN - STACK TRACE - END=======")
         warnings.warn(
             _domain_ctx_err_msg,
-            stacklevel=3,
+            stacklevel=_warning_stacklevel(),
         )
-        return None
-    return getattr(top, name)
+    return top
+
+
+def _lookup_domain_object(name: str) -> Any | None:
+    top = _active_domain_context()
+    return getattr(top, name) if top is not None else None
 
 
 def _find_domain() -> "Domain | None":
-    top = _domain_context_stack.top
-    if top is None:
-        logger.debug("=======NO ACTIVE DOMAIN - STACK TRACE - START=======")
-        logger.debug("".join(traceback.format_stack()))
-        logger.debug("=======NO ACTIVE DOMAIN - STACK TRACE - END=======")
-        warnings.warn(
-            _domain_ctx_err_msg,
-            stacklevel=3,
-        )
-        return None
-    return cast("Domain", top.domain)
+    top = _active_domain_context(log_traceback=True)
+    return top.domain if top is not None else None
 
 
-def _find_uow() -> "UnitOfWork":
-    return cast("UnitOfWork", _uow_context_stack.top)
+def _find_uow() -> "UnitOfWork | None":
+    return _uow_context_stack.top
 
 
 def _domain_now(now: datetime | None = None) -> datetime:
@@ -83,20 +214,13 @@ def _domain_now(now: datetime | None = None) -> datetime:
 
 
 # context locals
-# ``mypy`` resolves the obsolete ``types-Werkzeug`` stub package (obsolete since
-# werkzeug 2.0, which ships inline ``py.typed``), whose ``LocalStack.__init__`` is
-# untyped and non-generic. That produces a spurious ``no-untyped-call`` for a
-# source that is genuinely typed upstream, so we cast the class to ``Any`` at the
-# construction site. The explicit ``LocalStack`` annotations preserve the type for
-# downstream ``.top``/``.push`` access; pyright (which reads the inline types) is
-# unaffected.
-_domain_context_stack: LocalStack = cast("Any", LocalStack)()
-_uow_context_stack: LocalStack = cast("Any", LocalStack)()
-current_domain: "Domain" = LocalProxy(_find_domain)  # type: ignore
-current_uow: "UnitOfWork" = LocalProxy(_find_uow)  # type: ignore
-# ``g`` is a request-scoped scratch namespace (Werkzeug-style) that intentionally
-# holds arbitrary attributes; typing it ``Any`` reflects that dynamic contract.
-g: Any = LocalProxy(partial(_lookup_domain_object, "g"))
+_domain_context_stack: _ContextStack[Any] = _ContextStack("protean.domain_context")
+_uow_context_stack: _ContextStack[Any] = _ContextStack("protean.uow_context")
+current_domain: "Domain" = _ContextLocalProxy(_find_domain)  # type: ignore[assignment]
+current_uow: "UnitOfWork" = _ContextLocalProxy(_find_uow)  # type: ignore[assignment]
+# ``g`` is a request-scoped scratch namespace that intentionally holds arbitrary
+# attributes; typing it ``Any`` reflects that dynamic contract.
+g: Any = _ContextLocalProxy(partial(_lookup_domain_object, "g"))
 
 # Only the three request-scoped proxies are public; the lookup helpers and the
 # context stacks above stay internal and are excluded from ``import *``.

--- a/src/protean/utils/logging.py
+++ b/src/protean/utils/logging.py
@@ -343,8 +343,8 @@ def _http_wide_event_extras() -> dict[str, Any] | None:
     """Return the HTTP wide-event extras dict, or ``None`` when absent.
 
     Only present when ``DomainContextMiddleware`` has initialised it for
-    the current request. Any failure to reach ``g`` (no domain context,
-    LocalProxy errors) yields ``None`` so callers can treat absence the
+    the current request. Any failure to reach ``g`` (no domain context, or a
+    proxy lookup that raises) yields ``None`` so callers can treat absence the
     same as "no middleware in play".
     """
     try:
@@ -441,9 +441,9 @@ def get_logging_config_value(key: str, default: _T) -> _T:
 
     Returns ``default`` when no domain is bound to the current context or when
     the key is absent. Uses ``has_domain_context()`` to avoid triggering the
-    ``LocalProxy`` warning that ``current_domain`` would emit outside a domain
-    context. Any unexpected failure also yields ``default`` so callers on a hot
-    path (e.g. per-query instrumentation) can safely swallow it.
+    outside-domain-context warning that ``current_domain`` would emit outside a
+    domain context. Any unexpected failure also yields ``default`` so callers on
+    a hot path (e.g. per-query instrumentation) can safely swallow it.
     """
     try:
         if has_domain_context():

--- a/tests/test_runtime_dependencies.py
+++ b/tests/test_runtime_dependencies.py
@@ -3,7 +3,8 @@
 The web/observatory stack, the interactive shell, and the project scaffolder live
 behind install extras, not in the lean core. These tests pin that boundary so a
 stray eager import or a dependency creeping back into ``[project].dependencies``
-is caught. ``bleach`` and ``werkzeug`` intentionally stay in core.
+is caught. ``bleach`` intentionally stays in core; ``werkzeug`` was removed in
+favor of stdlib ``contextvars`` (#1375).
 """
 
 import re
@@ -32,7 +33,7 @@ OPTIONAL_DISTS = {
 OPTIONAL_IMPORTS = ["fastapi", "uvicorn", "jinja2", "IPython", "copier"]
 
 # Dependencies that must stay in the lean core.
-CORE_MUST_KEEP = {"bleach", "werkzeug", "pydantic", "marshmallow", "typer"}
+CORE_MUST_KEEP = {"bleach", "pydantic", "marshmallow", "typer"}
 
 
 def _pyproject() -> dict:

--- a/tests/utils/test_globals.py
+++ b/tests/utils/test_globals.py
@@ -13,6 +13,7 @@ import pytest
 
 from protean import Domain, UnitOfWork
 from protean.utils.globals import (
+    _ContextLocalProxy,
     _domain_context_stack,
     _uow_context_stack,
     current_domain,
@@ -231,16 +232,29 @@ class TestProxyBehavior:
         assert bool(current_domain) is False
 
     @pytest.mark.no_test_domain
+    def test_proxy_bool_delegates_to_wrapped_object(self):
+        class Falsy:
+            def __bool__(self):
+                return False
+
+        proxy = _ContextLocalProxy(lambda: Falsy())
+        assert bool(proxy) is False
+
+    @pytest.mark.no_test_domain
     def test_current_domain_warns_on_access_outside_context(self):
         # Resolving the proxy (truthiness, repr, or attribute access) triggers
         # the lookup and therefore the warning. The warning must appear to come
-        # from user code, not from inside protean.utils.globals.
+        # from this test file, not from inside protean.utils.globals.
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             bool(current_domain)
         assert len(caught) == 1
         assert "Working outside of domain context" in str(caught[0].message)
-        assert "protean/utils/globals.py" not in caught[0].filename
+        assert (
+            caught[0]
+            .filename.replace("\\", "/")
+            .endswith("tests/utils/test_globals.py")
+        )
 
     @pytest.mark.no_test_domain
     def test_current_domain_attribute_access_outside_context_raises(self):
@@ -281,7 +295,8 @@ class TestProxyBehavior:
             assert "GlobalsTest" in repr(g)
 
     @pytest.mark.no_test_domain
-    def test_proxy_str_and_dir_outside_context(self):
+    def test_proxy_repr_str_and_dir_outside_context(self):
+        assert repr(current_domain) == "None"
         assert str(current_domain) == "None"
         assert "__class__" in dir(current_domain)
 

--- a/tests/utils/test_globals.py
+++ b/tests/utils/test_globals.py
@@ -1,0 +1,338 @@
+"""Tests for the stdlib ``contextvars``-backed context locals.
+
+These tests pin the push/pop nesting semantics of ``current_domain``,
+``current_uow``, and ``g``, and verify that the active context follows the
+execution context across async boundaries.
+"""
+
+import asyncio
+import warnings
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from protean import Domain, UnitOfWork
+from protean.utils.globals import (
+    _domain_context_stack,
+    _uow_context_stack,
+    current_domain,
+    current_uow,
+    g,
+)
+
+
+@pytest.fixture
+def fresh_domain():
+    """A separate, initialized domain for context-local tests."""
+    domain = Domain(name="GlobalsTest")
+    domain._initialize()
+    return domain
+
+
+def _drain_stack(stack) -> None:
+    while stack.pop() is not None:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _clean_context_stacks():
+    """Ensure no-test-domain tests do not leak context state to each other."""
+    yield
+    _drain_stack(_domain_context_stack)
+    _drain_stack(_uow_context_stack)
+
+
+class TestContextStack:
+    """Direct tests for the internal ``_ContextStack``."""
+
+    @pytest.mark.no_test_domain
+    def test_push_pop_nesting(self):
+        stack = _domain_context_stack
+        sentinel_a = object()
+        sentinel_b = object()
+
+        assert stack.top is None
+        stack.push(sentinel_a)
+        assert stack.top is sentinel_a
+        stack.push(sentinel_b)
+        assert stack.top is sentinel_b
+        assert stack.pop() is sentinel_b
+        assert stack.top is sentinel_a
+        assert stack.pop() is sentinel_a
+        assert stack.top is None
+        assert stack.pop() is None
+
+    @pytest.mark.no_test_domain
+    def test_pop_on_empty_stack_returns_none(self):
+        _drain_stack(_domain_context_stack)
+        assert _domain_context_stack.pop() is None
+
+    @pytest.mark.no_test_domain
+    def test_stack_is_isolated_across_threads(self):
+        """A push in one OS thread must not leak to another."""
+        stack = _domain_context_stack
+        sentinel = object()
+        stack.push(sentinel)
+
+        def _check():
+            return stack.top
+
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            result = pool.submit(_check).result()
+
+        assert result is None
+        assert stack.top is sentinel
+        stack.pop()
+
+
+class TestDomainContextNesting:
+    """Nested ``DomainContext`` push/pop behavior."""
+
+    @pytest.mark.no_test_domain
+    def test_nested_domain_contexts_resolve_to_innermost(self, fresh_domain):
+        domain_a = fresh_domain
+        domain_b = Domain(name="InnerDomain")
+        domain_b._initialize()
+
+        with domain_a.domain_context():
+            assert current_domain == domain_a
+            assert isinstance(current_domain, Domain)
+            with domain_b.domain_context():
+                assert current_domain == domain_b
+                assert isinstance(current_domain, Domain)
+            assert current_domain == domain_a
+
+    @pytest.mark.no_test_domain
+    def test_domain_context_stack_is_independent_of_uow_stack(self, fresh_domain):
+        with fresh_domain.domain_context():
+            assert _domain_context_stack.top is not None
+            assert _uow_context_stack.top is None
+
+
+class TestUoWContextNesting:
+    """Unit-of-Work context stack behavior."""
+
+    @pytest.mark.no_test_domain
+    def test_uow_stack_nesting(self, fresh_domain):
+        with fresh_domain.domain_context():
+            outer = UnitOfWork()
+            outer.start()
+            assert current_uow == outer
+            assert _uow_context_stack.top is outer
+
+            inner = UnitOfWork()
+            inner.start()  # joins outer, does not push
+            assert current_uow == outer
+            assert _uow_context_stack.top is outer
+
+            inner.commit()  # no-op for nested participant
+            assert current_uow == outer
+
+            outer.commit()
+            assert _uow_context_stack.top is None
+
+    @pytest.mark.no_test_domain
+    def test_uow_pops_itself_on_commit(self, fresh_domain):
+        with fresh_domain.domain_context():
+            uow = UnitOfWork()
+            uow.start()
+            assert _uow_context_stack.top is uow
+            uow.commit()
+            assert _uow_context_stack.top is None
+
+    @pytest.mark.no_test_domain
+    def test_uow_stack_is_isolated_across_threads(self, fresh_domain):
+        """A UoW started in one OS thread must not leak to another."""
+        with fresh_domain.domain_context():
+            uow = UnitOfWork()
+            uow.start()
+
+            def _check():
+                return _uow_context_stack.top
+
+            with ThreadPoolExecutor(max_workers=1) as pool:
+                result = pool.submit(_check).result()
+
+            assert result is None
+            assert current_uow == uow
+            uow.commit()
+
+
+class TestAsyncPropagation:
+    """The active context follows the execution context across ``await``."""
+
+    @pytest.mark.no_test_domain
+    def test_current_domain_propagates_across_await(self, fresh_domain):
+        async def _inside():
+            await asyncio.sleep(0)
+            assert current_domain == fresh_domain
+
+        async def _main():
+            with fresh_domain.domain_context():
+                await _inside()
+
+        asyncio.run(_main())
+
+    @pytest.mark.no_test_domain
+    def test_current_domain_propagates_to_task(self, fresh_domain):
+        async def _task():
+            await asyncio.sleep(0)
+            assert current_domain == fresh_domain
+
+        async def _main():
+            with fresh_domain.domain_context():
+                await asyncio.create_task(_task())
+
+        asyncio.run(_main())
+
+    @pytest.mark.no_test_domain
+    def test_current_uow_propagates_across_await(self, fresh_domain):
+        async def _inside():
+            await asyncio.sleep(0)
+            assert current_uow is not None
+
+        async def _main():
+            with fresh_domain.domain_context():
+                uow = UnitOfWork()
+                uow.start()
+                await _inside()
+                uow.commit()
+
+        asyncio.run(_main())
+
+    @pytest.mark.no_test_domain
+    def test_concurrent_async_tasks_keep_domains_isolated(self, fresh_domain):
+        # Two tasks running concurrently on the same OS thread must see their
+        # own current_domain, not whichever context was pushed last. The stdlib
+        # contextvars backing guarantees this without thread-local machinery.
+        other_domain = Domain(name="Other")
+
+        async def _in_domain(domain, expected_name):
+            with domain.domain_context():
+                await asyncio.sleep(0)
+                assert current_domain.name == expected_name
+                await asyncio.sleep(0)
+                assert current_domain.name == expected_name
+
+        async def _main():
+            await asyncio.gather(
+                _in_domain(fresh_domain, "GlobalsTest"),
+                _in_domain(other_domain, "Other"),
+            )
+
+        asyncio.run(_main())
+
+
+class TestProxyBehavior:
+    """Behavioral contract of the request-scoped proxies."""
+
+    @pytest.mark.no_test_domain
+    def test_current_domain_is_falsy_outside_context(self):
+        assert bool(current_domain) is False
+
+    @pytest.mark.no_test_domain
+    def test_current_domain_warns_on_access_outside_context(self):
+        # Resolving the proxy (truthiness, repr, or attribute access) triggers
+        # the lookup and therefore the warning.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            bool(current_domain)
+        assert len(caught) == 1
+        assert "Working outside of domain context" in str(caught[0].message)
+
+    @pytest.mark.no_test_domain
+    def test_current_domain_attribute_access_outside_context_raises(self):
+        with pytest.raises(AttributeError):
+            _ = current_domain.config
+
+    @pytest.mark.no_test_domain
+    def test_current_uow_is_falsy_outside_context(self):
+        assert bool(current_uow) is False
+
+    @pytest.mark.no_test_domain
+    def test_g_set_get_delete_attribute(self, fresh_domain):
+        with fresh_domain.domain_context():
+            g.trace_id = "abc"
+            assert g.trace_id == "abc"
+            assert getattr(g, "trace_id") == "abc"
+            del g.trace_id
+            with pytest.raises(AttributeError):
+                _ = g.trace_id
+
+    @pytest.mark.no_test_domain
+    def test_g_contains_and_iterates(self, fresh_domain):
+        with fresh_domain.domain_context():
+            g.a = 1
+            g.b = 2
+            assert "a" in g
+            assert "z" not in g
+            assert set(g) == {"a", "b"}
+
+    @pytest.mark.no_test_domain
+    def test_g_attribute_access_outside_context_raises(self):
+        with pytest.raises(AttributeError):
+            _ = g.missing
+
+    @pytest.mark.no_test_domain
+    def test_g_repr_inside_context(self, fresh_domain):
+        with fresh_domain.domain_context():
+            assert "GlobalsTest" in repr(g)
+
+    @pytest.mark.no_test_domain
+    def test_proxy_str_and_dir_outside_context(self):
+        assert str(current_domain) == "None"
+        assert "__class__" in dir(current_domain)
+
+    @pytest.mark.no_test_domain
+    def test_proxy_str_delegates_inside_context(self, fresh_domain):
+        with fresh_domain.domain_context():
+            assert "GlobalsTest" in str(current_domain)
+
+    @pytest.mark.no_test_domain
+    def test_proxy_hash_outside_context(self):
+        assert hash(current_domain) == hash(None)
+
+    @pytest.mark.no_test_domain
+    def test_proxy_dir_delegates(self, fresh_domain):
+        with fresh_domain.domain_context():
+            names = dir(current_domain)
+            assert "config" in names
+            assert "repository_for" in names
+
+    @pytest.mark.no_test_domain
+    def test_proxy_eq_and_hash_delegates(self, fresh_domain):
+        with fresh_domain.domain_context():
+            assert current_domain == fresh_domain
+            assert hash(current_domain) == hash(fresh_domain)
+            assert current_domain is not fresh_domain
+            assert current_domain != None  # noqa: E711
+
+    @pytest.mark.no_test_domain
+    def test_proxy_eq_when_unbound(self):
+        # The proxy object itself is always present; only its resolved value is None.
+        assert current_domain is not None
+        assert current_domain is current_domain
+        assert current_domain == None  # noqa: E711
+        assert current_domain != object()
+
+    @pytest.mark.no_test_domain
+    def test_proxy_contains_and_iter_raise_when_unbound(self):
+        with pytest.raises(TypeError):
+            "x" in current_domain  # noqa: B015
+        with pytest.raises(TypeError):
+            list(current_domain)
+
+
+class TestDomainContextWarning:
+    """Warning behavior outside an active domain context."""
+
+    @pytest.mark.no_test_domain
+    def test_each_access_outside_context_warns(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            bool(current_domain)
+            repr(current_domain)
+        assert len(caught) == 2
+        assert all(
+            "Working outside of domain context" in str(w.message) for w in caught
+        )

--- a/tests/utils/test_globals.py
+++ b/tests/utils/test_globals.py
@@ -233,12 +233,14 @@ class TestProxyBehavior:
     @pytest.mark.no_test_domain
     def test_current_domain_warns_on_access_outside_context(self):
         # Resolving the proxy (truthiness, repr, or attribute access) triggers
-        # the lookup and therefore the warning.
+        # the lookup and therefore the warning. The warning must appear to come
+        # from user code, not from inside protean.utils.globals.
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             bool(current_domain)
         assert len(caught) == 1
         assert "Working outside of domain context" in str(caught[0].message)
+        assert "protean/utils/globals.py" not in caught[0].filename
 
     @pytest.mark.no_test_domain
     def test_current_domain_attribute_access_outside_context_raises(self):

--- a/uv.lock
+++ b/uv.lock
@@ -2258,7 +2258,6 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "structlog" },
     { name = "typer" },
-    { name = "werkzeug" },
 ]
 
 [package.optional-dependencies]
@@ -2366,7 +2365,6 @@ types = [
     { name = "types-mock" },
     { name = "types-python-dateutil" },
     { name = "types-redis" },
-    { name = "types-werkzeug" },
 ]
 
 [package.metadata]
@@ -2405,7 +2403,6 @@ requires-dist = [
     { name = "typer", specifier = ">=0.16.0" },
     { name = "uvicorn", marker = "extra == 'server'", specifier = ">=0.30.0" },
     { name = "watchfiles", marker = "extra == 'dev'", specifier = ">=1.2.0" },
-    { name = "werkzeug", specifier = ">=3.1.0" },
 ]
 provides-extras = ["elasticsearch", "redis", "postgresql", "sqlite", "mssql", "message-db", "flask", "sendgrid", "server", "shell", "scaffold", "cli", "all", "dev", "telemetry"]
 
@@ -2448,7 +2445,6 @@ types = [
     { name = "types-mock", specifier = ">=5.2.0.20260518" },
     { name = "types-python-dateutil", specifier = ">=2.9.0.20260716" },
     { name = "types-redis", specifier = ">=4.6.0.20241004" },
-    { name = "types-werkzeug", specifier = ">=1.0.9" },
 ]
 
 [[package]]
@@ -3629,15 +3625,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fe/fa/deb7066a472bb23d28205a9dde66caef317db4b0f2ce612068c5d45a9f87/types_setuptools-83.0.0.20260716.tar.gz", hash = "sha256:a36ad71a57919b80db314e6104478ee75376a34abea88ba0f3d28db4d10006d7", size = 45672, upload-time = "2026-07-16T04:47:56.484Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e3/f9/b89c50c1f482b2b4e038a845c23a3b3fdfd735199634d2452b8951a8629b/types_setuptools-83.0.0.20260716-py3-none-any.whl", hash = "sha256:77315e9a921ced0c7cbef803d7cf06db8e60e9df5661955ee4ce3d1a1675e0dc", size = 68767, upload-time = "2026-07-16T04:47:55.484Z" },
-]
-
-[[package]]
-name = "types-werkzeug"
-version = "1.0.9"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/eb/43/161261d2ac1fc20e944aa108e48a98ff0d994e19b498d6fb19d6637caf05/types-Werkzeug-1.0.9.tar.gz", hash = "sha256:5cc269604c400133d452a40cee6397655f878fc460e03fde291b9e3a5eaa518c", size = 23909, upload-time = "2021-11-26T06:21:28.33Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/c1/eaf8426126eafa46d649afb2fddede327043fbc2e84021b8b09a7fa15115/types_Werkzeug-1.0.9-py3-none-any.whl", hash = "sha256:194bd5715a13c598f05c63e8a739328657590943bce941e8a3619a6b5d4a54ec", size = 36186, upload-time = "2021-11-26T06:21:27.37Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #1375

Replace Werkzeug's \+LocalProxy\+/\+LocalStack\+ for `current_domain`, `current_uow`, and `g` with a small stdlib `contextvars` implementation. The public API of the three proxies is unchanged, and push/pop nesting semantics are preserved.

## Changes

- Add `_ContextStack` and `_ContextLocalProxy` in `src/protean/utils/globals.py`.
- Remove `werkzeug` and `types-Werkzeug` from core dependencies.
- Update `DomainContext` and `UnitOfWork` protocols to match the new stack shape.
- Add `tests/utils/test_globals.py` covering nesting, async propagation, and proxy behavior.
- Update runtime-dependency tests, migration guide, and ADR-0029/ADR-0020.

## Breaking change

This is a Tier-1 breaking change: `werkzeug` is no longer a core dependency. Code that only uses `current_domain`, `current_uow`, and `g` is unaffected. Code that imports Werkzeug-specific internals (e.g. the underlying `LocalStack`) must declare `werkzeug` itself. The migration guide covers this.