### PR TITLE
Add ADR-0030 recording the canonical generated project layout

### DIFF
--- a/docs/adr/0030-canonical-project-layout.md
+++ b/docs/adr/0030-canonical-project-layout.md
@@ -32,7 +32,7 @@ Config resolution follows the same root. `Config2.load_from_path(root_path)` loo
 `.domain.toml` / `domain.toml` / `pyproject.toml` in the root and up to two parent
 directories.
 
-Two failure modes in the 0.17 line traced directly to layout that the discovery path did
+Two failure modes in the 0.17 line traced directly to a layout that the discovery path did
 not expect. A generated `example/__init__.py` that re-exported from its own submodules created
 partially initialized module cycles during traversal, so a real `init(traverse=True)`
 crashed (#1316). And a `logging.toml` sat in the scaffold that no adapter read (#1315).

--- a/docs/adr/0030-canonical-project-layout.md
+++ b/docs/adr/0030-canonical-project-layout.md
@@ -32,8 +32,8 @@ Config resolution follows the same root. `Config2.load_from_path(root_path)` loo
 `.domain.toml` / `domain.toml` / `pyproject.toml` in the root and up to two parent
 directories.
 
-Two failure modes in the 0.17 line traced directly to layout the discovery path did not
-expect. A generated `example/__init__.py` that re-exported from its own submodules created
+Two failure modes in the 0.17 line traced directly to layout that the discovery path did
+not expect. A generated `example/__init__.py` that re-exported from its own submodules created
 partially initialized module cycles during traversal, so a real `init(traverse=True)`
 crashed (#1316). And a `logging.toml` sat in the scaffold that no adapter read (#1315).
 Both are fixed, but they are the reason to fix the layout in writing rather than leave it
@@ -120,8 +120,9 @@ structural IR is computed from the domain model, not from files, so a file can o
 "IR-derivable" if it hard-codes something the IR already computes from the registered
 elements. No such file exists in the template: the Python element modules *are* the domain
 model the IR is built from, and the rest (packaging, Docker, CI, Makefile, scripts) is
-deployment scaffolding the IR never represents. The one stranded file, `logging.toml`, was an orphan no adapter
-read, not an IR duplicate, and has already been removed separately (#1315). If a genuinely
+deployment scaffolding the IR never represents. The one stranded file, `logging.toml`, was
+an orphan that no adapter read, not an IR duplicate, and has already been removed separately
+(#1315). If a genuinely
 IR-derivable artifact ever ships in the scaffold, prune it then; today there is none.
 
 ## Consequences

--- a/docs/adr/0030-canonical-project-layout.md
+++ b/docs/adr/0030-canonical-project-layout.md
@@ -1,0 +1,175 @@
+# ADR-0030: Canonical Generated Project Layout
+
+**Status:** Accepted
+
+**Date:** August 2026
+
+## Context
+
+`protean new` stamps a project from `src/protean/template/`. That project's shape is
+not arbitrary: element discovery and, downstream of it, the IR both assume a specific
+directory layout. Until now that assumption lived only in the template files and in the
+discovery code, never written down. Every later piece of this work (the additive `add`
+engine, the renderer, a project manifest) would otherwise re-guess where the domain root
+is, where element modules live, where tests go, and which subtrees discovery must skip.
+
+The layout is a contract because of how discovery works. `Domain.init(traverse=True)`
+calls `_traverse()` (`src/protean/domain/__init__.py`), which:
+
+- Treats the directory that holds the domain file (the module that constructs
+  `Domain(...)`) as the **root**. When `root_path` is not passed explicitly and
+  `DOMAIN_ROOT_PATH` is unset, `_guess_caller_path()` resolves it to the directory of
+  the file that called the `Domain` constructor.
+- Scans one level deep, not recursively: it imports every `.py` file directly in the root
+  and every `.py` file directly in each immediate subdirectory (except the domain file
+  itself), so each module executes and its decorators register elements. A module nested
+  two levels below the root (for example `example/handlers/foo.py`) is never imported.
+- **Skips any immediate subdirectory that carries its own config file** (`domain.toml`,
+  `.domain.toml`, or `pyproject.toml`). That file marks a separate boundary, which lines up
+  with ADR-0003: one `Domain` is one bounded context is one IR document.
+
+Config resolution follows the same root. `Config2.load_from_path(root_path)` looks for
+`.domain.toml` / `domain.toml` / `pyproject.toml` in the root and up to two parent
+directories.
+
+Two failure modes in the 0.17 line traced directly to layout the discovery path did not
+expect. A generated `example/__init__.py` that re-exported from its own submodules created
+partially initialized module cycles during traversal, so a real `init(traverse=True)`
+crashed (#1316). And a `logging.toml` sat in the scaffold that no adapter read (#1315).
+Both are fixed, but they are the reason to fix the layout in writing rather than leave it
+implied.
+
+The IR is the other half of the contract. `Domain.to_ir()` builds the IR's structural view
+(clusters, contracts, flows, projections, the elements index, and config-derived domain
+metadata) from the initialized in-memory domain, not from files on disk. It then runs an
+advisory `diagnostics` pass that does re-parse source files, but that layer only annotates;
+it derives no structure. So the layout's whole job is to make traversal deterministic: init
+the canonical layout and the domain holds exactly the elements the developer wrote, and
+nothing spurious (no test doubles, no re-export duplicates). The structural IR is a
+projection of that domain.
+
+## Decision
+
+We record the following as the canonical layout that `protean new` generates and that
+discovery and the IR expect. A default project (package `myproj`, example included) is:
+
+```
+myproj/                     # project root
+├── pyproject.toml          # packaging; domain config lives in domain.toml, not here
+├── Makefile, Dockerfile*, docker-compose*.yml, nginx.conf, scripts/, .github/  # deploy scaffolding
+├── src/
+│   └── myproj/             # importable package == domain root
+│       ├── __init__.py     # empty
+│       ├── domain.py       # composition root: constructs Domain(name="myproj")
+│       ├── domain.toml     # domain config, co-located with domain.py
+│       ├── example/        # one feature slice, discovered by traversal
+│       │   ├── __init__.py # side-effect free (docstring only)
+│       │   ├── aggregate.py
+│       │   ├── commands.py
+│       │   ├── events.py
+│       │   ├── command_handlers.py
+│       │   ├── projection.py
+│       │   └── projectors.py
+│       └── shared/         # cross-slice value objects, exceptions, logging helpers
+│           ├── __init__.py # empty
+│           ├── exceptions.py
+│           ├── value_objects.py
+│           └── logging.py
+└── tests/
+    └── myproj/             # test tree, a sibling of src/, never traversed as domain code
+        ├── conftest.py     # session fixture boots the domain
+        ├── test_smoke.py
+        ├── domain/
+        ├── application/
+        └── integration/
+```
+
+The rules that make this a contract, not a suggestion:
+
+1. **One composition root per domain.** `src/<package>/domain.py` constructs the single
+   `Domain` instance. Its directory is the discovery root. One `Domain` is one bounded
+   context is one IR document (ADR-0003).
+
+2. **Config sits at the domain root.** `domain.toml` lives next to `domain.py` in
+   `src/<package>/`, where `load_from_path` finds it first.
+
+3. **Element modules live at most one directory below the domain root, one concept per
+   module.** A module directly in `src/<package>/`, or directly in an immediate subpackage
+   of it (here `example/` and `shared/`), is imported during traversal and registers via
+   decorators. Discovery scans one level deep only, so a module nested deeper (for example
+   `example/handlers/foo.py`) is silently not discovered. Modules import the domain with
+   `from <package>.domain import <domain>` and siblings with relative imports.
+
+4. **Package `__init__.py` files are side-effect free.** They carry a docstring at most.
+   They do not re-export from submodules. Re-exports run during traversal and create
+   partially initialized module cycles, which is exactly what broke `init(traverse=True)`
+   in #1316. Discovery finds elements by importing each module directly, so the re-exports
+   buy nothing and cost correctness.
+
+5. **Tests live outside the domain root.** `tests/` is a sibling of `src/`, so no test
+   module is ever imported as domain code during traversal. Tests boot the domain
+   themselves through a session-scoped fixture in `conftest.py`.
+
+6. **A nested config file marks a boundary discovery skips.** A subdirectory of the domain
+   root that carries its own `domain.toml` / `.domain.toml` / `pyproject.toml` is treated
+   as a separate boundary and is not traversed into. This is the escape hatch for a
+   subtree that should not register into this domain.
+
+**The template ships nothing the IR can derive, so there is nothing to prune.** The
+structural IR is computed from the domain model, not from files, so a file can only be
+"IR-derivable" if it hard-codes something the IR already computes from the registered
+elements. No such file exists in the template: the Python element modules *are* the domain
+model the IR is built from, and the rest (packaging, Docker, CI, Makefile, scripts) is
+deployment scaffolding the IR never represents. The one stranded file, `logging.toml`, was an orphan no adapter
+read, not an IR duplicate, and has already been removed separately (#1315). If a genuinely
+IR-derivable artifact ever ships in the scaffold, prune it then; today there is none.
+
+## Consequences
+
+Later work builds against a written layout instead of re-reading the template. The `add`
+engine knows to drop a new element module directly in `src/<package>/` or in an immediate
+slice subpackage (one level deep, so discovery finds it) and to leave `__init__.py` alone. A manifest knows the domain root is the directory of the
+domain file and that `tests/` is out of scope for discovery. The IR-derivation boundary is
+explicit: the IR reflects the registered domain, so scaffold correctness is a discovery
+question, not an IR question.
+
+The generated project is opinionated about structure. A `src/`-layout package, a single
+composition root, config beside the domain file, and tests as a sibling tree are all
+fixed. A user who wants a flat layout or tests interleaved with source has to move away
+from the scaffold and take responsibility for keeping discovery working (for example by
+passing `root_path` explicitly or dropping a config file to fence off a subtree). That is
+the intended trade: the default is correct by construction, and deviation is possible but
+manual.
+
+The `__init__.py`-must-stay-empty rule is easy to violate by habit, since re-exporting
+from a package initializer is idiomatic Python elsewhere. Anyone hand-editing a generated
+project, or writing a code generator that touches these files, has to know the rule. This
+ADR is where it is written down, and the scaffold's `example/__init__.py` docstring states
+it inline.
+
+## Alternatives Considered
+
+**Prune "redundant" template files as originally scoped.** The issue first paired this ADR
+with deleting template files the IR can derive. On inspection there are none, for the
+reason given above, so the pruning half was dropped and this ADR records why. Keeping the
+scope honest avoids deleting a load-bearing file to satisfy a rule that does not apply.
+
+**A flat layout (no `src/`, modules beside `domain.py` at the project root).** This works
+for discovery but blurs the packaging boundary and makes it easy for `tests/` or tooling
+files to land inside the discovery root and be imported as domain code. The `src/`-layout
+keeps the importable package, and therefore the discovery root, cleanly separated from
+project-level files.
+
+**Tests under the domain root (`src/<package>/tests/`).** Traversal would then import test
+modules during discovery, executing test-time code and registering test doubles into the
+real domain. Keeping tests a sibling of `src/` removes that hazard entirely.
+
+**Re-exporting from package `__init__.py` for ergonomic imports.** Convenient for callers,
+but it is the direct cause of #1316: re-exports execute during traversal and create
+partially initialized module cycles. Discovery does not need them, so the cost has no
+matching benefit.
+
+**Config only in `pyproject.toml`.** `load_from_path` supports it, but a dedicated
+`domain.toml` beside `domain.py` keeps domain config next to the composition root and out
+of the packaging file, and reads first in the lookup order. A generated project uses the
+dedicated file; `pyproject.toml` config stays available for users who prefer it.

--- a/docs/adr/0030-canonical-project-layout.md
+++ b/docs/adr/0030-canonical-project-layout.md
@@ -51,7 +51,9 @@ projection of that domain.
 ## Decision
 
 We record the following as the canonical layout that `protean new` generates and that
-discovery and the IR expect. A default project (package `myproj`, example included) is:
+discovery and the IR expect. A default project (package `myproj`) is shown below. The
+`example` slice and its test are gated on the `include_example` copier flag (default on);
+everything else is generated either way.
 
 ```
 myproj/                     # project root
@@ -62,7 +64,7 @@ myproj/                     # project root
 │       ├── __init__.py     # empty
 │       ├── domain.py       # composition root: constructs Domain(name="myproj")
 │       ├── domain.toml     # domain config, co-located with domain.py
-│       ├── example/        # one feature slice, discovered by traversal
+│       ├── example/        # one feature slice; generated only when include_example is on
 │       │   ├── __init__.py # side-effect free (docstring only)
 │       │   ├── aggregate.py
 │       │   ├── commands.py
@@ -78,10 +80,14 @@ myproj/                     # project root
 └── tests/
     └── myproj/             # test tree, a sibling of src/, never traversed as domain code
         ├── conftest.py     # session fixture boots the domain
-        ├── test_smoke.py
+        ├── test_smoke.py   # always generated, so a fresh project never collects zero tests
         ├── domain/
+        │   └── __init__.py         # placeholder package; the __init__ keeps the empty dir in git
         ├── application/
+        │   ├── __init__.py
+        │   └── test_example.py     # generated only when include_example is on
         └── integration/
+            └── __init__.py         # placeholder package; the __init__ keeps the empty dir in git
 ```
 
 The rules that make this a contract, not a suggestion:
@@ -115,16 +121,6 @@ The rules that make this a contract, not a suggestion:
    as a separate boundary and is not traversed into. This is the escape hatch for a
    subtree that should not register into this domain.
 
-**The template ships nothing the IR can derive, so there is nothing to prune.** The
-structural IR is computed from the domain model, not from files, so a file can only be
-"IR-derivable" if it hard-codes something the IR already computes from the registered
-elements. No such file exists in the template: the Python element modules *are* the domain
-model the IR is built from, and the rest (packaging, Docker, CI, Makefile, scripts) is
-deployment scaffolding the IR never represents. The one stranded file, `logging.toml`, was
-an orphan that no adapter read, not an IR duplicate, and has already been removed separately
-(#1315). If a genuinely
-IR-derivable artifact ever ships in the scaffold, prune it then; today there is none.
-
 ## Consequences
 
 Later work builds against a written layout instead of re-reading the template. The `add`
@@ -151,9 +147,13 @@ it inline.
 ## Alternatives Considered
 
 **Prune "redundant" template files as originally scoped.** The issue first paired this ADR
-with deleting template files the IR can derive. On inspection there are none, for the
-reason given above, so the pruning half was dropped and this ADR records why. Keeping the
-scope honest avoids deleting a load-bearing file to satisfy a rule that does not apply.
+with deleting template files the IR can derive. On inspection there are none: the structural
+IR is computed from the registered domain model, not from files, so no shipped file
+duplicates it. The Python element modules are the domain model the IR is built from, and the
+rest is deployment scaffolding the IR never represents. (The one stranded file,
+`logging.toml`, was an orphan that no adapter read, not an IR duplicate, and was removed
+under #1315.) So the pruning half was dropped. Keeping the scope honest avoids deleting a
+load-bearing file to satisfy a rule that does not apply.
 
 **A flat layout (no `src/`, modules beside `domain.py` at the project root).** This works
 for discovery but blurs the packaging boundary and makes it easy for `tests/` or tooling

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -100,3 +100,4 @@ See `TEMPLATE.md` in the `adr/` directory for the ADR template.
 | [0027](0027-unit-of-work-is-a-real-transaction.md) | The Unit of Work is a Real Database Transaction |
 | [0028](0028-partition-per-key-sequential-processing.md) | Partition-Per-Key Sequential Processing (`sequential_by`) |
 | [0029](0029-runtime-dependency-boundary-and-extras.md) | Runtime Dependency Boundary and Feature Extras |
+| [0030](0030-canonical-project-layout.md) | Canonical Generated Project Layout |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -421,6 +421,7 @@ nav:
       - adr/0027-unit-of-work-is-a-real-transaction.md
       - adr/0028-partition-per-key-sequential-processing.md
       - adr/0029-runtime-dependency-boundary-and-extras.md
+      - adr/0030-canonical-project-layout.md
     - Troubleshooting:
       - reference/troubleshooting.md
 


### PR DESCRIPTION
## Summary

Records the canonical layout that `protean new` generates and that element discovery and the IR assume, as a new ADR. Until now that shape lived only in the template files and the traversal code and was never written down, so later scaffold work (the additive `add` engine, the renderer, a project manifest) would each re-guess it.

ADR-0030 states:
- The composition root (`src/<package>/domain.py`) and config (`domain.toml` beside it) locations.
- That discovery scans the domain root and its immediate subdirectories **one level deep, not recursively**, so element modules live at most one directory below the root.
- Why package `__init__.py` files must stay side-effect free (re-exports create partially initialized module cycles during traversal, the #1316 failure).
- Why tests live outside the domain root (a sibling `tests/` tree is never imported as domain code).
- How a nested config file fences off a subtree, lining up with ADR-0003 (one Domain = one BC = one IR).
- Why the "prune IR-derivable template files" half of the issue was dropped: the structural IR is derived from the domain model, not from files, so no shipped template file is IR-derivable. The one stranded file (`logging.toml`) was an orphan, not an IR duplicate, and was already removed under #1315.

Wires the ADR into the README table and the mkdocs nav.

## Scope note

Per the 2026-08-07 decision on the issue, this is scoped to the ADR only; there are no template files to prune.

## Test plan

- [x] `mkdocs build --strict` passes with the new ADR page in the nav
- [x] Every technical claim fact-checked against `_traverse`, `Config2.load_from_path`, and `Domain.to_ir` / `IRBuilder`
- N/A: no code change, so no unit/adapter suite, coverage, or changelog fragment (ADR-only, matching repo convention)

Closes #1322