### PR TITLE
Add a TLA+ model-checked spec of the subscription failure-recovery protocol

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,9 +55,9 @@ TARGET ?= outbox
 mutation:
 	./scripts/mutation.sh $(TARGET)
 
-# Model-check the TLA+ specs of the checkpoint and outbox two-phase protocols
-# with TLC. Design-time verification, not a CI gate: run it deliberately when a
-# modeled protocol changes. Needs a JDK and tla2tools.jar; see specs/README.md.
+# Model-check the TLA+ specs of the checkpoint, outbox, OCC, and recovery
+# protocols with TLC. Design-time verification, not a CI gate: run it deliberately
+# when a modeled protocol changes. Needs a JDK and tla2tools.jar; see specs/README.md.
 verify-specs:
 	./specs/check.sh
 

--- a/changes/1372.added.md
+++ b/changes/1372.added.md
@@ -1,0 +1,1 @@
+Added a machine-checked TLA+ specification of the event-store subscription's failure-recovery record-before-advance protocol, joining the existing checkpoint, outbox, and OCC specs under `specs/`. Design-time verification, not a CI gate.

--- a/docs/reference/guarantees.md
+++ b/docs/reference/guarantees.md
@@ -231,6 +231,9 @@ event-store subscriptions**; a DLQ applies only to broker/stream subscriptions.
     tracking, no retry). This is separate from the batched-checkpoint at-least-once
     property for the happy path, where a crash re-delivers the last unflushed batch.
 
+    This record-before-advance protocol has a machine-checked TLA+ specification
+    (`Recovery.tla`); see the formal-verification section below.
+
 **Exactly-once-effect is opt-in**, in two places:
 
 - A projector marked `@domain.projector(idempotent=True)` on a relational provider
@@ -362,16 +365,18 @@ deployment is configured to persist.
 ## Formal verification of the core correctness protocols
 
 The protocols where these guarantees are hardest to reason about, the `$all`
-subscription checkpoint advance, the outbox publish, and the aggregate
-optimistic-concurrency commit, have machine-checked
+subscription checkpoint advance, the outbox publish, the aggregate
+optimistic-concurrency commit, and the subscription failure-recovery
+record-before-advance, have machine-checked
 TLA+ specifications under [`specs/`](https://github.com/proteanhq/protean/tree/main/specs)
 in the repository. TLC explores every interleaving of out-of-order commits, lock
-expiry, redelivery, crash points, and concurrent writers up to a bound, and asserts
-the invariants that state these guarantees. Each invariant maps to a specific row
-above; the mapping is in `specs/README.md`. Each spec also carries a revert test
-that reintroduces the corresponding bug (#1088 for the checkpoint, mark-before-publish
-for the outbox, the split compare-then-write lost update for OCC / #1087 / #1258) so
-the model demonstrably has teeth.
+expiry, redelivery, crash points, concurrent writers, and handler failures up to a
+bound, and asserts the invariants that state these guarantees. Each invariant maps
+to a specific row above; the mapping is in `specs/README.md`. Each spec also carries
+a revert test that reintroduces the corresponding bug (#1088 for the checkpoint,
+mark-before-publish for the outbox, the split compare-then-write lost update for
+OCC / #1087 / #1258, advance-before-record for the recovery drop) so the model
+demonstrably has teeth.
 
 This is design-time verification, not a CI gate: it verifies the design, and is
 re-run deliberately when a protocol changes, not on every commit.

--- a/specs/README.md
+++ b/specs/README.md
@@ -12,6 +12,10 @@ Protean's correctness guarantees, model-checked with TLC:
   the version check made atomic with the write (compare-and-set) shipped for
   #1087 (SQL) and #1258 (Memory)
   ([ADR-0013](../docs/adr/0013-optimistic-concurrency-and-claim-contract.md)).
+- **`Recovery.tla`**: the event-store subscription's failure-recovery
+  record-before-advance protocol, where a handler failure is written durably to
+  the recovery stream *before* the read cursor advances past it, so a failed
+  message is never silently dropped.
 
 They exist because these are where Protean's hardest correctness claims live, and
 where two silent-corruption bugs surfaced this cycle: #1087 (OCC lost update, now
@@ -90,16 +94,20 @@ The runs are small (a few thousand states each) and finish in about a second.
 | `OCC.cfg` | Shipped protocol (atomic compare-and-set); all invariants + liveness hold. |
 | `OCC_bug.cfg` | Revert test: split the commit into compare then unconditional write; TLC must fail on `NoLostUpdate`. |
 | `OCC_conflict.cfg` | Reachability probe: TLC must fail on `NoConflict`, witnessing that two writers genuinely contend from the same base. |
+| `Recovery.tla` | The subscription failure-recovery record-before-advance protocol. |
+| `Recovery.cfg` | Shipped protocol (record before advance); all invariants + liveness hold. |
+| `Recovery_bug.cfg` | Revert test: advance the cursor past a failed message without its record; TLC must fail on `NoDrop`. |
+| `Recovery_dup.cfg` | Reachability probe: TLC must fail on `NoRedeliver`, witnessing a crash-resume re-reading an already-recorded failed message. |
 | `check.sh` | Runs every config and asserts the expected pass/violation. |
 
 ## What is modeled
 
-Both specs are written as action-based TLA+ (a disjunction of next-state actions)
-rather than PlusCal. For fault-tolerant protocols the interesting behavior is a
-*crash between phases*, which is expressed directly by separating durable state
-from volatile state and having a `Crash` action clear only the volatile part.
-That is the idiomatic and auditable shape for this kind of spec; PlusCal would
-compile down to the same TLA+.
+All four specs are written as action-based TLA+ (a disjunction of next-state
+actions) rather than PlusCal. For fault-tolerant protocols the interesting
+behavior is a *crash between phases*, which is expressed directly by separating
+durable state from volatile state and having a `Crash` action clear only the
+volatile part. That is the idiomatic and auditable shape for this kind of spec;
+PlusCal would compile down to the same TLA+.
 
 **Checkpoint.** `global_position` is a store-wide sequence assigned at insert (in
 order) but made visible at commit, and across categories a lower value can commit
@@ -140,6 +148,20 @@ splits into a `Compare` step (decide "ok" without writing) and a later unconditi
 `Write` (set the version to the stale base + 1), so two writers that both read base
 `b` both write `b + 1` and one committed update is silently overwritten. That split
 is the read-compare-write race of #1087 / #1258.
+
+**Recovery.** When the handler fails on the message at the cursor, the failure is
+written durably to the failed-positions stream (`Record`) *before* the read cursor
+advances past it (`Advance`). The cursor's durable checkpoint is batched, so
+`Flush` copies the in-memory cursor to the durable one at any time, and a `Crash`
+resets the in-memory cursor to the durable one and drops the volatile pending
+state (the durable Failed records, the resolved set, and delivered side effects
+all survive, matching `_rebuild_retry_counts` rebuilding from the stream on
+restart). A periodic `Recover` pass takes each recorded, unresolved position
+terminal — resolved on a retry success, or exhausted after `max_retries`. The
+`RecordFirst` constant toggles the shipped ordering (record before advance)
+against the bug: when `FALSE` the cursor can advance past a failed message without
+its record, so a `Flush` and `Crash` there leave the durable cursor past a failed
+position with no durable record and no delivery — a silent drop.
 
 ## Invariant-to-guarantee mapping
 
@@ -187,12 +209,25 @@ negations whose counterexample witnesses that a behavior is reachable).
 | `NoConflict` (probe, `OCC_conflict.cfg`) | reachability | The witness that two writers genuinely race from the same base and one is forced to conflict, so the model is not vacuously safe and the revert test is meaningful. |
 | `EventuallyResolved` (liveness) | guarantee | No permanent stall: every writer eventually reaches a terminal state (committed or conflicted). |
 
+### Recovery (`Recovery.tla`) → guarantees.md, "Recovery of a failed message is crash-safe"
+
+| Invariant / property | Kind | Guarantee it checks |
+|---|---|---|
+| `NoDrop` | guarantee | "The failure is recorded to the recovery stream *before* the read cursor advances past it ... never dropped." A failed position the durable cursor has passed is either present as a durable Failed record (the recovery pass picks it up) or already delivered. `Recovery_bug.cfg` advances past a failed message without its record to demonstrate TLC catches the drop. |
+| `DurableBehindCursor` | guarantee | The durable checkpoint never leads the in-memory cursor, so a crash-resume re-reads from a safe position rather than skipping past a failed message. |
+| `RecordedAreFailed` | model-trust | Only genuinely failed positions ever get a durable record; guards against a successful position leaking into the record set and making `NoDrop` pass for the wrong reason. |
+| `ResolvedImpliesRecorded` | model-trust | The recovery pass only ever resolves a position that has a durable record; a resolve out of nowhere would be a modeling bug. |
+| `DeliveredImpliesHandled` | model-trust | Every delivered position was actually handled — a success on the first pass, or a recorded failed position recovered by the pass — so `NoDrop` cannot pass vacuously through its `delivered` disjunct. |
+| `NoRedeliver` (probe, `Recovery_dup.cfg`) | reachability | "Asynchronous delivery is at-least-once ... Handlers must tolerate duplicates." The witness is a crash after the record but before the flush that rewinds the cursor and re-reads the failed message. |
+| `AllFailedResolved` (liveness) | guarantee | No permanent stall: every failed message is eventually retried until it resolves (recovered) or is exhausted. |
+
 ## Revert tests and reachability probes
 
 A spec that passes proves nothing unless its invariants can fail. Each protocol
 carries a constant that reintroduces the real bug (`GapSafe`, `AckBeforePublish`,
-`ClaimSafe`, `Atomic`), and a probe that asserts the negation of a reachable
-behavior (`NoRedelivery`, `NoDuplicateDelivery`, `NoConflict`). `check.sh` asserts
+`ClaimSafe`, `Atomic`, `RecordFirst`), and a probe that asserts the negation of a
+reachable behavior (`NoRedelivery`, `NoDuplicateDelivery`, `NoConflict`,
+`NoRedeliver`). `check.sh` asserts
 TLC fails on the *named* invariant for each, so a check that stops demonstrating
 its bug (say a different invariant fails first) is caught, not silently accepted.
 The headline revert traces:
@@ -234,6 +269,20 @@ State 7: Write(w2)     version = 1  base = <<0,0>>  phase = <<committed, committ
          -> NoLostUpdate violated: two writers committed but version = 1
 ```
 
+**Recovery, `RecordFirst = FALSE` (advance before record).** The handler fails on
+position 1, the buggy cursor advances past it without writing the durable record,
+and a flush moves the durable cursor past it too, so a crash there would lose the
+message with no record to recover it:
+
+```
+State 1: fate = <<"F","S","S">>  cursorMem = 0  cursorDur = 0  recordDur = {}
+State 2: Fail(1)                 cursorMem = 0  cursorDur = 0  recordDur = {}  pending = {1}
+State 3: Advance(1)              cursorMem = 1  cursorDur = 0  recordDur = {}  pending = {}
+State 4: Flush                   cursorMem = 1  cursorDur = 1  recordDur = {}
+         -> NoDrop violated: position 1 is failed and <= cursorDur, with no
+            durable record and not delivered
+```
+
 ## Constants and bounds
 
 The configs use small bounds (3 to 4 positions, 1 to 2 workers and messages, 2
@@ -246,13 +295,9 @@ for each run.
 
 ## Out of scope
 
-The issue that produced these specs scoped them to the checkpoint and outbox
-two-phase protocols only. The following are related but deliberately not modeled
-here, and a reader arriving from `guarantees.md` should not expect them:
+The following are related but deliberately not modeled here, and a reader arriving
+from `guarantees.md` should not expect them:
 
-- **The subscription recovery-stream ordering** ("Recovery of a failed message is
-  crash-safe" in guarantees.md). It has the same record-before-flush shape as the
-  checkpoint, but it is a separate protocol (handler failure, not gap safety).
 - **Outbox write-side dedup on `(message_id, target_broker)`**. The model uses a
   single broker; the dual-write-per-broker uniqueness is a row-creation concern,
   not part of the publish protocol.

--- a/specs/README.md
+++ b/specs/README.md
@@ -157,7 +157,9 @@ resets the in-memory cursor to the durable one and drops the volatile pending
 state (the durable Failed records, the resolved set, and delivered side effects
 all survive, matching `_rebuild_retry_counts` rebuilding from the stream on
 restart). A periodic `Recover` pass takes each recorded, unresolved position
-terminal — resolved on a retry success, or exhausted after `max_retries`. The
+terminal — resolved on a retry success, or given up (an abstraction of exhausting
+`max_retries`; the retry count and the stream reconstruction are not modeled, see
+"Out of scope"). The
 `RecordFirst` constant toggles the shipped ordering (record before advance)
 against the bug: when `FALSE` the cursor can advance past a failed message without
 its record, so a `Flush` and `Crash` there leave the durable cursor past a failed
@@ -302,6 +304,14 @@ from `guarantees.md` should not expect them:
   single broker; the dual-write-per-broker uniqueness is a row-creation concern,
   not part of the publish protocol.
 - **The startup reconciliation sweep** (ADR-0015), which is marked interim.
+- **The recovery pass's retry machinery.** `Recovery.tla` proves the durable
+  Failed record *survives a crash* (the record-before-advance ordering), not that
+  the recovery pass then re-reads and retries it. `Recover` is an atomic,
+  always-terminal step off the durable `recordDur`: the `retry_count` /
+  `max_retries` threshold and the `_rebuild_retry_counts` watermark-and-snapshot
+  reconstruction of `_failed_positions` from the stream are abstracted away. A bug
+  in that reconstruction that dropped a still-unresolved position would leave
+  `NoDrop` green, so it is outside this model.
 - One nuance the model surfaces but does not assert: `ABANDONED` means the
   framework stops attempting delivery. Because delivery is at-least-once, a
   message published on an earlier attempt but not confirmed (a crash before the

--- a/specs/Recovery.cfg
+++ b/specs/Recovery.cfg
@@ -1,0 +1,20 @@
+\* Shipped protocol: the durable Failed record is written before the cursor
+\* advances past a failed message. Every safety invariant holds across every
+\* success/failure pattern, flush point, and bounded crash, and every failed
+\* message is eventually resolved.
+SPECIFICATION FairSpec
+\* The protocol legitimately quiesces once every position is handled and every
+\* failed one resolved; that is a terminal state, not a stall. AllFailedResolved
+\* is what catches a genuine permanent stall.
+CHECK_DEADLOCK FALSE
+CONSTANTS
+    N = 3
+    RecordFirst = TRUE
+    MaxCrashes = 1
+INVARIANT TypeOK
+INVARIANT NoDrop
+INVARIANT DurableBehindCursor
+INVARIANT RecordedAreFailed
+INVARIANT ResolvedImpliesRecorded
+INVARIANT DeliveredImpliesHandled
+PROPERTY AllFailedResolved

--- a/specs/Recovery.tla
+++ b/specs/Recovery.tla
@@ -35,6 +35,13 @@
 (* advance (shipped). FALSE = the cursor may advance past a failed message      *)
 (* before (or without) its record, which is exactly the silent drop            *)
 (* `enable_recovery`'s crash-safety guard prevents.                           *)
+(*                                                                          *)
+(* Scope: this spec proves the durable Failed record survives a crash (the      *)
+(* record-before-advance ordering), not that the recovery pass then re-reads     *)
+(* and retries it. `Recover` is an atomic, always-terminal step; the retry-count *)
+(* / `max_retries` machinery and the `_rebuild_retry_counts` watermark-and-      *)
+(* snapshot reconstruction from the stream are abstracted away. See the "Out of  *)
+(* scope" section of specs/README.md.                                         *)
 (***************************************************************************)
 EXTENDS Naturals, FiniteSets
 
@@ -156,9 +163,13 @@ Flush ==
 
 (***************************************************************************)
 (* The periodic recovery pass takes a recorded, unresolved position terminal.  *)
-(* Model the retry as eventually terminal: either it succeeds (delivered) or    *)
-(* it exhausts max_retries (terminal but not delivered). Either way the durable *)
-(* Failed record stays, so the message was never dropped, and the position is   *)
+(* This is an abstraction: the retry is modeled as one atomic, eventually-       *)
+(* terminal step -- either it succeeds (delivered) or it gives up (terminal but  *)
+(* not delivered). The retry count and `max_retries` threshold are NOT modeled   *)
+(* (the count where it gives up does not change what the record guarantees), nor *)
+(* is the `_rebuild_retry_counts` reconstruction that re-reads the stream: this  *)
+(* step fires directly off the durable `recordDur`. Either way the durable       *)
+(* Failed record stays, so the message was never dropped, and the position is    *)
 (* resolved so liveness is checkable.                                          *)
 (***************************************************************************)
 Recover(p) ==

--- a/specs/Recovery.tla
+++ b/specs/Recovery.tla
@@ -1,0 +1,268 @@
+---------------------------- MODULE Recovery ----------------------------
+(***************************************************************************)
+(* The event-store subscription's failure-recovery record-before-advance     *)
+(* protocol: how a handler failure is made crash-safe so a failed message is  *)
+(* never silently dropped.                                                   *)
+(*                                                                          *)
+(* When the handler fails on the message at the read cursor, the failure is   *)
+(* written durably to the failed-positions stream (`_record_failed_position`, *)
+(* a per-message synchronous write) BEFORE the read cursor advances past it.   *)
+(* The cursor's durable checkpoint is batched (flushed every                  *)
+(* `position_update_interval` messages), so the durable Failed record always   *)
+(* lands before the cursor is durably flushed past the position. A periodic    *)
+(* recovery pass (`run_recovery_pass`) re-reads each unresolved position and    *)
+(* retries until it resolves or exhausts. On restart `_rebuild_retry_counts`   *)
+(* rebuilds the in-memory tracking from the durable failed-positions stream,    *)
+(* so the record survives a crash.                                            *)
+(*                                                                          *)
+(* This is the one two-phase window in the subscription path that the          *)
+(* Checkpoint and Outbox specs deliberately left out. It has the same          *)
+(* record-before-flush shape as the checkpoint, so this spec mirrors           *)
+(* `Checkpoint.tla`: a durable-vs-volatile state split and a `Crash` action    *)
+(* that clears only the volatile part.                                        *)
+(*                                                                          *)
+(* Guarantee modeled (docs/reference/guarantees.md, "Recovery of a failed      *)
+(* message is crash-safe"):                                                   *)
+(*                                                                          *)
+(*   "the failure is recorded to the recovery stream *before* the read cursor  *)
+(*    advances past it ... If the record is written and the process then        *)
+(*    crashes, the durable cursor is either still behind the position (the      *)
+(*    message is re-read) or already past it (the durable record is picked up   *)
+(*    by the recovery pass) -- never dropped."                                 *)
+(*                                                                          *)
+(* The `RecordFirst` constant toggles the fix against the bug, so TLC's         *)
+(* counterexample IS the bug: a built-in revert test. TRUE = record before      *)
+(* advance (shipped). FALSE = the cursor may advance past a failed message      *)
+(* before (or without) its record, which is exactly the silent drop            *)
+(* `enable_recovery`'s crash-safety guard prevents.                           *)
+(***************************************************************************)
+EXTENDS Naturals, FiniteSets
+
+CONSTANTS
+    N,            \* highest position modeled; positions are 1..N
+    RecordFirst,  \* TRUE  = write the durable Failed record before advancing the
+                  \*         cursor past a failed message (the shipped protocol)
+                  \* FALSE = the cursor may advance without the record (the drop bug)
+    MaxCrashes    \* bound on crash/resume events (keeps liveness checkable)
+
+ASSUME N \in Nat /\ N >= 1
+ASSUME RecordFirst \in BOOLEAN
+ASSUME MaxCrashes \in Nat
+
+Positions == 1..N
+
+VARIABLES
+    fate,        \* [Positions -> {"S","F"}]: the handler succeeds or fails on each
+    cursorMem,   \* in-memory read cursor (current_position); 0 = nothing read (volatile)
+    cursorDur,   \* last durably-flushed cursor checkpoint; a crash resumes here (durable)
+    pending,     \* failed positions awaiting a durable record / advance (volatile)
+    recordDur,   \* positions with a durable Failed record; monotonic (durable)
+    resolved,    \* positions the recovery pass has taken terminal, Resolved or Exhausted (durable)
+    delivered,   \* positions whose handler side effect has happened
+    redelivered, \* failed positions re-read after a crash rewound the cursor (aux, for the probe)
+    crashes      \* number of crash/resume events so far
+
+vars == <<fate, cursorMem, cursorDur, pending, recordDur,
+          resolved, delivered, redelivered, crashes>>
+
+TypeOK ==
+    /\ fate \in [Positions -> {"S", "F"}]
+    /\ cursorMem \in 0..N
+    /\ cursorDur \in 0..N
+    /\ pending \subseteq Positions
+    /\ recordDur \subseteq Positions
+    /\ resolved \subseteq Positions
+    /\ delivered \subseteq Positions
+    /\ redelivered \subseteq Positions
+    /\ crashes \in 0..MaxCrashes
+
+Init ==
+    /\ fate \in [Positions -> {"S", "F"}]  \* explore every success/failure pattern
+    /\ cursorMem = 0
+    /\ cursorDur = 0
+    /\ pending = {}
+    /\ recordDur = {}
+    /\ resolved = {}
+    /\ delivered = {}
+    /\ redelivered = {}
+    /\ crashes = 0
+
+(***************************************************************************)
+(* The handler succeeds on the message at the cursor: the side effect happens *)
+(* and the cursor advances. No recovery record (nothing failed).             *)
+(***************************************************************************)
+HandleOk(p) ==
+    /\ p = cursorMem + 1
+    /\ p <= N
+    /\ fate[p] = "S"
+    /\ delivered' = delivered \cup {p}
+    /\ cursorMem' = p
+    /\ UNCHANGED <<fate, cursorDur, pending, recordDur,
+                   resolved, redelivered, crashes>>
+
+(***************************************************************************)
+(* The handler fails on the message at the cursor: mark the position as        *)
+(* needing a durable record. The cursor does NOT move yet. Re-reading a         *)
+(* message that already has a durable record (a crash rewound the cursor        *)
+(* below it) is the at-least-once redelivery the probe witnesses.              *)
+(***************************************************************************)
+Fail(p) ==
+    /\ p = cursorMem + 1
+    /\ p <= N
+    /\ fate[p] = "F"
+    /\ p \notin pending
+    /\ pending' = pending \cup {p}
+    /\ redelivered' = IF p \in recordDur THEN redelivered \cup {p} ELSE redelivered
+    /\ UNCHANGED <<fate, cursorMem, cursorDur, recordDur,
+                   resolved, delivered, crashes>>
+
+(***************************************************************************)
+(* Write the durable Failed record (the per-message synchronous write). The   *)
+(* failed-positions stream is append-only, so the record is durable and         *)
+(* monotonic: once written it survives every later crash.                     *)
+(***************************************************************************)
+Record(p) ==
+    /\ p \in pending
+    /\ p \notin recordDur
+    /\ recordDur' = recordDur \cup {p}
+    /\ UNCHANGED <<fate, cursorMem, cursorDur, pending,
+                   resolved, delivered, redelivered, crashes>>
+
+(***************************************************************************)
+(* Advance the volatile cursor past a failed message. Under the shipped        *)
+(* protocol (RecordFirst = TRUE) this is gated on the record being durable      *)
+(* first, so the cursor can never move past a failed message that was not       *)
+(* recorded (a failed record write raises before the advance; a crash in the    *)
+(* gap leaves the cursor behind). Under the bug (RecordFirst = FALSE) it fires  *)
+(* without the record: the advance-before-record drop.                         *)
+(***************************************************************************)
+Advance(p) ==
+    /\ p \in pending
+    /\ (RecordFirst => p \in recordDur)
+    /\ cursorMem' = p
+    /\ pending' = pending \ {p}
+    /\ UNCHANGED <<fate, cursorDur, recordDur,
+                   resolved, delivered, redelivered, crashes>>
+
+(***************************************************************************)
+(* Flush the in-memory cursor to the durable checkpoint. Batched in reality    *)
+(* (every position_update_interval messages); modeled as firing at any time.   *)
+(***************************************************************************)
+Flush ==
+    /\ cursorDur < cursorMem
+    /\ cursorDur' = cursorMem
+    /\ UNCHANGED <<fate, cursorMem, pending, recordDur,
+                   resolved, delivered, redelivered, crashes>>
+
+(***************************************************************************)
+(* The periodic recovery pass takes a recorded, unresolved position terminal.  *)
+(* Model the retry as eventually terminal: either it succeeds (delivered) or    *)
+(* it exhausts max_retries (terminal but not delivered). Either way the durable *)
+(* Failed record stays, so the message was never dropped, and the position is   *)
+(* resolved so liveness is checkable.                                          *)
+(***************************************************************************)
+Recover(p) ==
+    /\ p \in recordDur
+    /\ p \notin resolved
+    /\ resolved' = resolved \cup {p}
+    /\ \/ delivered' = delivered \cup {p}   \* retry succeeded
+       \/ delivered' = delivered            \* exhausted after max_retries
+    /\ UNCHANGED <<fate, cursorMem, cursorDur, pending, recordDur,
+                   redelivered, crashes>>
+
+(***************************************************************************)
+(* A crash between the phases: the in-memory cursor and the volatile pending    *)
+(* state are lost; the subscription resumes from the durable checkpoint. The    *)
+(* durable Failed records, the resolved set, and delivered side effects all     *)
+(* persist -- on restart _rebuild_retry_counts rebuilds the in-memory tracking  *)
+(* from recordDur \ resolved. Bounded by MaxCrashes so it cannot starve         *)
+(* progress.                                                                   *)
+(***************************************************************************)
+Crash ==
+    /\ crashes < MaxCrashes
+    /\ cursorMem' = cursorDur
+    /\ pending' = {}
+    /\ crashes' = crashes + 1
+    /\ UNCHANGED <<fate, cursorDur, recordDur, resolved, delivered, redelivered>>
+
+Next ==
+    \/ \E p \in Positions : HandleOk(p)
+    \/ \E p \in Positions : Fail(p)
+    \/ \E p \in Positions : Record(p)
+    \/ \E p \in Positions : Advance(p)
+    \/ \E p \in Positions : Recover(p)
+    \/ Flush
+    \/ Crash
+
+Spec == Init /\ [][Next]_vars
+
+\* Fairness for the liveness check: every progress action must eventually fire;
+\* Crash is bounded by MaxCrashes so it cannot starve progress forever.
+FairSpec ==
+    /\ Spec
+    /\ \A p \in Positions : WF_vars(HandleOk(p))
+    /\ \A p \in Positions : WF_vars(Fail(p))
+    /\ \A p \in Positions : WF_vars(Record(p))
+    /\ \A p \in Positions : WF_vars(Advance(p))
+    /\ \A p \in Positions : WF_vars(Recover(p))
+    /\ WF_vars(Flush)
+
+(***************************************************************************)
+(* Safety invariants                                                        *)
+(***************************************************************************)
+
+\* The guarantee: a failed message is never silently dropped. A failed position
+\* the durable cursor has moved past is either present as a durable Failed record
+\* (the recovery pass will pick it up) or already delivered. A failed position
+\* with the durable cursor past it, no durable record, and not delivered, is a
+\* silent drop. Holds under the shipped protocol; the advance-before-record revert
+\* (RecordFirst = FALSE) violates it, and TLC's counterexample is the dropped
+\* message. This is the invariant Recovery_bug.cfg must fail on.
+NoDrop ==
+    \A p \in Positions :
+        fate[p] = "F" => (p > cursorDur \/ p \in recordDur \/ p \in delivered)
+
+\* The durable checkpoint never leads the in-memory cursor, so a crash-resume
+\* re-reads from a safe position rather than skipping past one.
+DurableBehindCursor == cursorDur <= cursorMem
+
+\* Model-trust (should hold by construction): only genuinely failed positions ever
+\* get a durable record. If a successful position leaked into `recordDur` it could
+\* make NoDrop pass for the wrong reason. A failure here signals a modeling bug,
+\* not a protocol bug.
+RecordedAreFailed == \A p \in recordDur : fate[p] = "F"
+
+\* Model-trust: the recovery pass only ever resolves a position that has a durable
+\* record; a resolved position with no record would be a resolve out of nowhere.
+ResolvedImpliesRecorded == resolved \subseteq recordDur
+
+\* Model-trust: every delivered position was actually handled -- a success on the
+\* first pass, or a failed position that was recorded and then recovered. Guards
+\* against a modeling bug that delivers a failed position without recording it,
+\* which would make NoDrop pass vacuously through the `delivered` disjunct.
+DeliveredImpliesHandled ==
+    \A p \in delivered : fate[p] = "S" \/ p \in recordDur
+
+(***************************************************************************)
+(* Reachability probe (NOT a safety property)                                *)
+(***************************************************************************)
+
+\* At-least-once means a crash-resume can re-read a failed message that was
+\* already recorded (the crash rewound the cursor below it before the batched
+\* checkpoint flushed). Asserting "no failed message is ever re-read after a crash"
+\* and letting TLC refute it yields a concrete witness that the redelivery window
+\* is real and the model is not vacuously safe. Recovery_dup.cfg runs this as an
+\* expected violation; every other config leaves it unchecked.
+NoRedeliver == redelivered = {}
+
+(***************************************************************************)
+(* Liveness                                                                 *)
+(***************************************************************************)
+
+\* No permanent stall: every failed message is eventually retried until it
+\* resolves (recovered) or is exhausted. (Once resolved it stays resolved, so `<>`
+\* suffices.)
+AllFailedResolved ==
+    <>(\A p \in Positions : fate[p] = "F" => p \in resolved)
+
+=============================================================================

--- a/specs/Recovery_bug.cfg
+++ b/specs/Recovery_bug.cfg
@@ -1,0 +1,20 @@
+\* Revert test. RecordFirst = FALSE lets the cursor advance past a failed message
+\* before (or without) its durable record. TLC MUST report a counterexample for
+\* NoDrop: Fail(p) then Advance(p) then Flush moves the durable cursor past p with
+\* no durable Failed record and no delivery, so a crash there drops the message
+\* silently. NoDrop is listed first so it is the reported violation; the
+\* model-trust invariants still hold under the bug (the record simply never gets
+\* written), so NoDrop is the only one that fails. If this run ever passes, the
+\* model has lost its teeth.
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+CONSTANTS
+    N = 3
+    RecordFirst = FALSE
+    MaxCrashes = 1
+INVARIANT NoDrop
+INVARIANT TypeOK
+INVARIANT DurableBehindCursor
+INVARIANT RecordedAreFailed
+INVARIANT ResolvedImpliesRecorded
+INVARIANT DeliveredImpliesHandled

--- a/specs/Recovery_dup.cfg
+++ b/specs/Recovery_dup.cfg
@@ -3,7 +3,7 @@
 \* crash-resume re-reads an already-recorded failed message: the at-least-once
 \* redelivery window. The trace is a crash after Record but before Flush that
 \* rewinds the cursor below the position and re-reads it, proving the model is not
-\* vacuously safe. Like the _bug config, a passing run here would mean the model
+\* vacuously safe. Like Recovery_bug.cfg, a passing run here would mean the model
 \* failed to exhibit the behavior it should.
 SPECIFICATION Spec
 CHECK_DEADLOCK FALSE

--- a/specs/Recovery_dup.cfg
+++ b/specs/Recovery_dup.cfg
@@ -1,0 +1,14 @@
+\* Reachability probe (shipped protocol). Asserts "no failed message is ever
+\* re-read after a crash" so TLC's counterexample is a concrete witness that a
+\* crash-resume re-reads an already-recorded failed message: the at-least-once
+\* redelivery window. The trace is a crash after Record but before Flush that
+\* rewinds the cursor below the position and re-reads it, proving the model is not
+\* vacuously safe. Like the _bug config, a passing run here would mean the model
+\* failed to exhibit the behavior it should.
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+CONSTANTS
+    N = 3
+    RecordFirst = TRUE
+    MaxCrashes = 1
+INVARIANT NoRedeliver

--- a/specs/check.sh
+++ b/specs/check.sh
@@ -113,6 +113,12 @@ run OCC.tla        OCC_bug.cfg             violation  NoLostUpdate
 run OCC.tla        OCC_conflict.cfg        violation  NoConflict
 
 echo ""
+echo "Recovery protocol (subscription failure-recovery record-before-advance):"
+run Recovery.tla   Recovery.cfg            pass
+run Recovery.tla   Recovery_bug.cfg        violation  NoDrop
+run Recovery.tla   Recovery_dup.cfg        violation  NoRedeliver
+
+echo ""
 if [[ "$fail" -eq 0 ]]; then
     echo "All checks met their expected outcome."
 else


### PR DESCRIPTION
## Summary
- Add `specs/Recovery.tla`, model-checking the event-store subscription's failure-recovery record-before-advance protocol: a handler failure is written durably to the recovery stream before the read cursor advances past it, so a failed message is never silently dropped.
- Add revert test `Recovery_bug.cfg` (advance before record, must fail `NoDrop`) and reachability probe `Recovery_dup.cfg` (crash-resume redelivery, must fail `NoRedeliver`), wired into `specs/check.sh` and `make verify-specs`.
- Document the spec in `specs/README.md` and `docs/reference/guarantees.md`, including the abstracted retry machinery (`Recover` step) and what's out of scope (the `_rebuild_retry_counts` stream reconstruction).

## Test plan
- [x] `make verify-specs` runs all four specs (Checkpoint, Outbox, OCC, Recovery) and each config hits its expected pass/violation outcome
- [x] Core tests pass (`protean test`) — no source code changed, docs/spec only

Closes #1372