### PR TITLE
Document the absent-key change and file it as a behaviour break

### DIFF
--- a/changes/1391.fixed.md
+++ b/changes/1391.fixed.md
@@ -1,1 +1,5 @@
-The memory cache's `remove`, `remove_by_key`, and `set_ttl` now do nothing when the key is absent, matching the Redis adapter, instead of raising `KeyError`.
+The memory cache's `remove`, `remove_by_key`, and `set_ttl` now do nothing when the key is absent, instead of raising `KeyError`. The Redis cache has always been silent here (`DEL` and `PEXPIRE` are no-ops on a missing key), so the same call meant different things depending on which adapter was configured. An expired entry counts as absent on both adapters. `set_ttl` still rejects an invalid TTL when the key is absent, so a malformed TTL cannot hide behind a missing key.
+
+**Breaking (memory cache only).** Code that used the `KeyError` as a presence check no longer takes its `except` branch, and the call succeeds quietly. Nothing inside Protean relied on it, so only your own callers are affected. `get_ttl` is unchanged and still diverges between the two adapters.
+
+**Migration:** [The memory cache no longer raises on an absent key](https://docs.proteanhq.com/reference/migration/v0-18/#the-memory-cache-no-longer-raises-on-an-absent-key)

--- a/changes/1391.fixed.md
+++ b/changes/1391.fixed.md
@@ -1,0 +1,1 @@
+The memory cache's `remove`, `remove_by_key`, and `set_ttl` now do nothing when the key is absent, matching the Redis adapter, instead of raising `KeyError`.

--- a/docs/reference/adapters/cache/index.md
+++ b/docs/reference/adapters/cache/index.md
@@ -25,7 +25,9 @@ within the process. No external dependencies are needed.
 
 - **Use cases**: Development, testing, prototyping
 - All data is lost on process restart
-- No TTL enforcement (entries live until explicitly removed or process ends)
+- TTL is enforced lazily: every entry is written with an expiry, and an expired
+  entry is dropped the next time it is read, iterated or counted. There is no
+  background sweep, so an expired entry nobody touches still occupies memory.
 
 ### Redis
 
@@ -115,7 +117,7 @@ else:
 ```
 
 Needing that at all is the divergence, not the fix.
-[#1310](https://github.com/proteanhq/protean/issues/1310) tracks making the two
+[#1392](https://github.com/proteanhq/protean/issues/1392) tracks making the two
 adapters answer alike, at which point one of these branches goes away.
 
 ## Interface
@@ -130,11 +132,11 @@ All cache adapters implement these methods:
 | `get(key)` | Retrieve a projection by key |
 | `get_all(key_pattern, last_position, size)` | Retrieve projections matching a pattern |
 | `count(key_pattern)` | Count entries matching a pattern |
-| `remove(projection)` | Remove a cached projection |
-| `remove_by_key(key)` | Remove an entry by key |
+| `remove(projection)` | Remove a cached projection. Does nothing if no record exists for it |
+| `remove_by_key(key)` | Remove an entry by key. Does nothing if the key is absent |
 | `remove_by_key_pattern(key_pattern)` | Remove entries matching a pattern |
 | `flush_all()` | Remove all entries |
-| `set_ttl(key, ttl)` | Set a TTL on a specific key |
+| `set_ttl(key, ttl)` | Set a TTL on a specific key. Does nothing if the key is absent, but still rejects an invalid TTL |
 | `get_ttl(key)` | Seconds remaining before a key expires. See below for how adapters answer when there is no such key |
 
 ### Key Format

--- a/docs/reference/migration/v0-18.md
+++ b/docs/reference/migration/v0-18.md
@@ -22,6 +22,7 @@ now needs an extra, the CLI or the import tells you exactly which one.
 - [cffi and greenlet left the core install](#cffi-and-greenlet-left-the-core-install)
 - [werkzeug left the core install](#werkzeug-left-the-core-install)
 - [`check` and `verify` machine output changed shape and exit codes](#check-and-verify-machine-output-changed-shape-and-exit-codes)
+- [The memory cache no longer raises on an absent key](#the-memory-cache-no-longer-raises-on-an-absent-key): `remove`, `remove_by_key` and `set_ttl` are silent
 
 ---
 
@@ -202,3 +203,59 @@ usage errors (`2`).
 exactly one JSON object. Logs and error lines go to stderr, so
 `protean check --format json | jq` and `protean verify --json | jq` stay
 parseable.
+
+---
+
+## The memory cache no longer raises on an absent key
+
+**Behavioural break, memory cache only.** `remove(projection)`,
+`remove_by_key(key)` and `set_ttl(key, ttl)` raised `KeyError` when the key was
+not in the cache. They now do nothing, which is what the Redis cache has always
+done: Redis' `DEL` and `PEXPIRE` are no-ops on a missing key. The port
+documents the silent behaviour as the contract, so the two adapters answer
+alike.
+
+An expired entry counts as absent. A key whose TTL has run out is treated the
+same as one that was never written, on both adapters.
+
+### Who is affected
+
+Anyone who used the `KeyError` as a presence check on a memory-backed cache.
+That code no longer takes its `except` branch, and nothing tells you: the call
+succeeds quietly. It is the only shape that breaks.
+
+```python
+# Before: worked on the memory cache, never fired on Redis
+try:
+    cache.remove_by_key(key)
+except KeyError:
+    log.info("nothing cached for %s", key)
+
+# After: ask before removing, and it works on either adapter
+if cache.get(key) is None:
+    log.info("nothing cached for %s", key)
+cache.remove_by_key(key)
+```
+
+Nothing inside Protean relied on the `KeyError`, so this only affects your own
+code.
+
+### What did not change
+
+`set_ttl` still rejects an invalid TTL when the key is absent. A TTL that is
+not a positive, finite number of seconds raises `ConfigurationError` whether or
+not there is a key to apply it to, so a malformed TTL cannot hide behind a
+missing key.
+
+`get_ttl` is unaffected. It still raises `KeyError` on the memory cache and
+returns Redis' `-2` sentinel on Redis;
+[#1392](https://github.com/proteanhq/protean/issues/1392) tracks making those
+two answer alike.
+
+### Why it was not put behind a flag
+
+The behaviour was a divergence between two adapters of the same port, not an
+intentional contract, so no program that runs on both could have depended on
+it. A flag preserving the `KeyError` would have kept the divergence alive on
+the adapter that is documented for development and testing, which is the one
+place the inconsistency is least worth paying for.

--- a/src/protean/adapters/cache/memory.py
+++ b/src/protean/adapters/cache/memory.py
@@ -202,8 +202,9 @@ class MemoryCache(BaseCache):
         self._db.clear()
 
     def set_ttl(self, key: str, ttl: TTLValue) -> None:
+        resolved_ttl = self._ttl_for(ttl)
         if key in self._db:
-            self._db.set_ttl(key, self._ttl_for(ttl))
+            self._db.set_ttl(key, resolved_ttl)
 
     def get_ttl(self, key: str) -> float:
         return self._db.get_ttl(key)

--- a/src/protean/adapters/cache/memory.py
+++ b/src/protean/adapters/cache/memory.py
@@ -184,10 +184,10 @@ class MemoryCache(BaseCache):
         assert id_f.field_name is not None
         identifier = getattr(projection, id_f.field_name)
         key = f"{underscore(projection.__class__.__name__)}:::{identifier}"
-        del self._db[key]
+        self._db.pop(key, None)
 
     def remove_by_key(self, key: str) -> None:
-        del self._db[key]
+        self._db.pop(key, None)
 
     def remove_by_key_pattern(self, key_pattern: str) -> None:
         full_key_list = self._db.keys()
@@ -202,7 +202,8 @@ class MemoryCache(BaseCache):
         self._db.clear()
 
     def set_ttl(self, key: str, ttl: TTLValue) -> None:
-        self._db.set_ttl(key, self._ttl_for(ttl))
+        if key in self._db:
+            self._db.set_ttl(key, self._ttl_for(ttl))
 
     def get_ttl(self, key: str) -> float:
         return self._db.get_ttl(key)

--- a/src/protean/port/cache.py
+++ b/src/protean/port/cache.py
@@ -206,9 +206,10 @@ class BaseCache(metaclass=ABCMeta):
         """Set a TTL explicitly on a key.
 
         Takes the same shapes as `add`: a number, or a string holding one, and
-        rejects anything that is not a positive, finite number of seconds.
+        rejects anything that is not a positive, finite number of seconds,
+        whether or not the key is present.
 
-        Does nothing if the key is absent.
+        Otherwise, does nothing if the key is absent.
         """
 
     @abstractmethod

--- a/src/protean/port/cache.py
+++ b/src/protean/port/cache.py
@@ -181,11 +181,17 @@ class BaseCache(metaclass=ABCMeta):
 
     @abstractmethod
     def remove(self, projection: BaseProjection) -> None:
-        """Remove a cache record by projection object"""
+        """Remove a cache record by projection object
+
+        Does nothing if no record exists for the projection.
+        """
 
     @abstractmethod
     def remove_by_key(self, key: str) -> None:
-        """Remove a cache record by key"""
+        """Remove a cache record by key
+
+        Does nothing if the key is absent.
+        """
 
     @abstractmethod
     def remove_by_key_pattern(self, key_pattern: str) -> None:
@@ -201,6 +207,8 @@ class BaseCache(metaclass=ABCMeta):
 
         Takes the same shapes as `add`: a number, or a string holding one, and
         rejects anything that is not a positive, finite number of seconds.
+
+        Does nothing if the key is absent.
         """
 
     @abstractmethod

--- a/tests/adapters/cache/generic/test_remove.py
+++ b/tests/adapters/cache/generic/test_remove.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import time
+
 from .conftest import CacheEntry
 
 
@@ -19,4 +21,20 @@ class TestRemoveByKey:
         assert cache.get(_key("alpha")) is None
 
     def test_remove_by_key_is_silent_when_the_key_is_absent(self, cache):
+        # A neighbor must survive an absent-key `remove_by_key` untouched, so
+        # an implementation that clears the whole store (or the wrong key)
+        # cannot pass by accident.
+        cache.add(CacheEntry(key="alpha", value="one"))
+
         cache.remove_by_key(_key("does-not-exist"))
+
+        assert cache.get(_key("alpha")) is not None
+
+    def test_remove_by_key_is_silent_when_the_key_has_expired(self, cache):
+        cache.add(CacheEntry(key="alpha", value="one"), ttl=0.05)
+        time.sleep(0.3)
+        assert cache.get(_key("alpha")) is None
+
+        cache.remove_by_key(_key("alpha"))
+
+        assert cache.get(_key("alpha")) is None

--- a/tests/adapters/cache/generic/test_remove.py
+++ b/tests/adapters/cache/generic/test_remove.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
-
 from .conftest import CacheEntry
 
 
@@ -20,17 +18,5 @@ class TestRemoveByKey:
 
         assert cache.get(_key("alpha")) is None
 
-    def test_remove_by_key_is_silent_when_the_key_is_absent(self, cache, request):
-        if request.node.callspec.params["cache"]["provider"] == "memory":
-            request.applymarker(
-                pytest.mark.xfail(
-                    strict=True,
-                    reason=(
-                        "#1391: removing an absent key should do nothing. "
-                        "The memory cache raises KeyError; Redis is already "
-                        "silent."
-                    ),
-                )
-            )
-
+    def test_remove_by_key_is_silent_when_the_key_is_absent(self, cache):
         cache.remove_by_key(_key("does-not-exist"))

--- a/tests/adapters/cache/generic/test_roundtrip.py
+++ b/tests/adapters/cache/generic/test_roundtrip.py
@@ -7,8 +7,6 @@ without being duplicated per adapter.
 
 from __future__ import annotations
 
-import pytest
-
 from .conftest import CacheEntry
 
 
@@ -51,26 +49,5 @@ class TestRemoveByProjection:
 
         assert cache.get(_key("alpha")) is None
 
-    def test_remove_is_silent_when_the_projection_is_absent(self, cache, request):
-        """Same divergence as #1391, a different entry point.
-
-        `remove(projection)` on an absent projection raises `KeyError` on
-        the memory cache (`del self._db[key]`) and is silent on Redis
-        (`DEL` on a missing key). #1391 tables this alongside
-        `remove_by_key` and `set_ttl` as the same class of bug, reached
-        through `remove` instead.
-        """
-        if request.node.callspec.params["cache"]["provider"] == "memory":
-            request.applymarker(
-                pytest.mark.xfail(
-                    strict=True,
-                    reason=(
-                        "#1391: removing an absent key should do nothing, "
-                        "on every entry point. The memory cache raises "
-                        "KeyError from remove(); Redis' DEL is silently a "
-                        "no-op on a missing key."
-                    ),
-                )
-            )
-
+    def test_remove_is_silent_when_the_projection_is_absent(self, cache):
         cache.remove(CacheEntry(key="does-not-exist", value="x"))

--- a/tests/adapters/cache/generic/test_roundtrip.py
+++ b/tests/adapters/cache/generic/test_roundtrip.py
@@ -7,6 +7,8 @@ without being duplicated per adapter.
 
 from __future__ import annotations
 
+import time
+
 from .conftest import CacheEntry
 
 
@@ -50,4 +52,21 @@ class TestRemoveByProjection:
         assert cache.get(_key("alpha")) is None
 
     def test_remove_is_silent_when_the_projection_is_absent(self, cache):
+        # A neighbor must survive an absent-projection `remove` untouched, so
+        # an implementation that clears the whole store (or the wrong key)
+        # cannot pass by accident.
+        cache.add(CacheEntry(key="alpha", value="one"))
+
         cache.remove(CacheEntry(key="does-not-exist", value="x"))
+
+        assert cache.get(_key("alpha")) is not None
+
+    def test_remove_is_silent_when_the_projection_has_expired(self, cache):
+        entry = CacheEntry(key="alpha", value="one")
+        cache.add(entry, ttl=0.05)
+        time.sleep(0.3)
+        assert cache.get(_key("alpha")) is None
+
+        cache.remove(entry)
+
+        assert cache.get(_key("alpha")) is None

--- a/tests/adapters/cache/generic/test_ttl.py
+++ b/tests/adapters/cache/generic/test_ttl.py
@@ -10,6 +10,7 @@ here instead of shipping unnoticed.
 from __future__ import annotations
 
 import math
+import time
 
 import pytest
 
@@ -112,7 +113,33 @@ class TestFailedAddLeavesNothingCached:
 
 class TestSetTTLOnAMissingKey:
     def test_set_ttl_is_silent_when_the_key_is_absent(self, cache):
+        # A neighbor must survive an absent-key `set_ttl` untouched, and the
+        # absent key itself must not spring into existence as a side effect.
+        cache.add(CacheEntry(key="alpha", value="one"))
+
         cache.set_ttl(_key("does-not-exist"), 60)
+
+        assert cache.get(_key("alpha")) is not None
+        assert cache.get(_key("does-not-exist")) is None
+
+    @pytest.mark.parametrize("bad_ttl", REJECTED_TTLS)
+    def test_set_ttl_rejects_an_invalid_ttl_even_when_the_key_is_absent(
+        self, cache, bad_ttl
+    ):
+        # TTL validation must run whether or not the key exists: Redis
+        # resolves the TTL before touching the key (`_ttl_for` runs ahead of
+        # `pexpire`), so an absent key does not excuse a malformed TTL.
+        with pytest.raises(ConfigurationError):
+            cache.set_ttl(_key("does-not-exist"), bad_ttl)
+
+    def test_set_ttl_is_silent_when_the_key_has_expired(self, cache):
+        cache.add(CacheEntry(key="alpha", value="one"), ttl=0.05)
+        time.sleep(0.3)
+        assert cache.get(_key("alpha")) is None
+
+        cache.set_ttl(_key("alpha"), 60)
+
+        assert cache.get(_key("alpha")) is None
 
 
 class TestGetTTLOnAMissingKey:

--- a/tests/adapters/cache/generic/test_ttl.py
+++ b/tests/adapters/cache/generic/test_ttl.py
@@ -111,28 +111,7 @@ class TestFailedAddLeavesNothingCached:
 
 
 class TestSetTTLOnAMissingKey:
-    def test_set_ttl_is_silent_when_the_key_is_absent(self, cache, request):
-        """Same divergence as #1391, a different entry point.
-
-        `set_ttl` on a missing key raises `KeyError` on the memory cache
-        (`TTLDict.set_ttl` indexes `self._values[key]`) and is a silent
-        no-op on Redis (`PEXPIRE` on a missing key returns `False`, does not
-        raise). #1391 tables this alongside `remove_by_key` and `remove` as
-        the same class of bug, reached through `set_ttl` instead.
-        """
-        if request.node.callspec.params["cache"]["provider"] == "memory":
-            request.applymarker(
-                pytest.mark.xfail(
-                    strict=True,
-                    reason=(
-                        "#1391: acting on an absent key should do nothing, "
-                        "on every entry point. The memory cache raises "
-                        "KeyError from set_ttl; Redis' PEXPIRE is silently a "
-                        "no-op on a missing key."
-                    ),
-                )
-            )
-
+    def test_set_ttl_is_silent_when_the_key_is_absent(self, cache):
         cache.set_ttl(_key("does-not-exist"), 60)
 
 


### PR DESCRIPTION
## Summary

- The memory cache's `remove`, `remove_by_key` and `set_ttl` raised `KeyError` when the key was not there. `del self._db[key]` in the first two, and `TTLDict.set_ttl` indexing `self._values[key]` in the third. Redis has always been silent in all three: `DEL` and `PEXPIRE` are no-ops on a missing key. So the same call meant different things depending on which adapter was configured. All three now do nothing when the key is absent.
- An expired entry counts as absent. `TTLDict.__getitem__` drops an expired entry and raises, so `pop(key, None)` and `key in self._db` both read an expired key as gone, which matches what Redis does once a TTL has run out.
- `set_ttl` resolves the TTL before it checks for the key, so an invalid TTL is still rejected with `ConfigurationError` on an absent key. Redis already worked this way (`_ttl_for` runs ahead of `pexpire`), and without it a malformed TTL could hide behind a missing key.
- `remove_by_key_pattern` was left alone: it only deletes keys it just matched, so it cannot be handed an absent key. `get_ttl` is also unchanged and still diverges (#1392).

## Breaking change

Behavioural break, memory cache only. Code that caught the `KeyError` as a presence check no longer takes its `except` branch and the call succeeds quietly. Nothing inside Protean relied on it, so only callers outside the framework are affected. Documented in `docs/reference/migration/v0-18.md` with the before/after shape, plus a note on why it is not behind a flag: the behaviour was a divergence between two adapters of the same port, not an intended contract, so no program running on both could have depended on it.

## Docs

- `docs/reference/migration/v0-18.md`: new section, listed in the index at the top.
- `docs/reference/adapters/cache/index.md`: the interface table now states the silent behaviour for the three methods. Two fixes found while writing it: the page claimed the memory cache does "no TTL enforcement", which is wrong (every entry is written with an expiry and is dropped on the next read, iteration or count, with no background sweep), and a `get_ttl` note pointed at #1310 instead of #1392.
- `src/protean/port/cache.py`: the port docstrings now say the silent behaviour is the contract, not an adapter quirk.

## Test plan

The three tests that #1402 filed as `xfail(strict=True)` for this bug are now plain passing tests, one per entry point. Each was widened so a wrong fix cannot pass: an absent-key call must leave a neighbouring key alone, and `set_ttl` must not bring the absent key into existence.

- [x] Three new expiry tests, one per entry point: a key whose TTL has run out is treated the same as one that was never written.
- [x] `set_ttl` invalid-TTL rejection on an absent key, parametrized over the existing `REJECTED_TTLS`.
- [x] Core leg: `pytest tests/adapters/cache` -> 102 passed, 83 skipped, 2 xfailed
- [x] Redis leg: `pytest tests/adapters/cache --redis` -> 180 passed, 1 skipped, 6 xfailed
- [x] The remaining xfails are the other open divergences (#1392, #1393, #1399, #1401), untouched here.

Closes #1391
