### PR TITLE
Add ADR-0031 recording the handler transaction rule

### DIFF
--- a/docs/adr/0031-handlers-persist-or-call-out.md
+++ b/docs/adr/0031-handlers-persist-or-call-out.md
@@ -1,0 +1,148 @@
+# ADR-0031: A handler method persists or calls out, never both
+
+**Status:** Accepted
+
+**Date:** August 2026
+
+## Context
+
+`@handle` wraps every handler invocation in a `UnitOfWork`
+(`src/protean/utils/mixins.py`), and there is no way to influence that. Since
+ADR-0027 the Unit of Work is one real database transaction, so a handler that
+calls an external system holds row locks and a pooled connection for the length
+of that call. Version (OCC) and transient retry re-run the whole handler body, so
+a retry re-issues the call.
+
+A request came in for `@handle(SomeEvent, unit_of_work=False)`: run the handler
+with no wrapping Unit of Work so it can own its own transaction boundaries and
+commit sub-units independently. Working through the cases showed the request was
+pointing at something real and prescribing the wrong fix, and that most of what
+it asked for either already works or should not be built.
+
+Three facts drove the decision, all verified by running rather than by reading:
+
+1. **The Unit of Work is lazy.** `start()` opens no session. The session, and on
+   SQLAlchemy the real `BEGIN`, appears at the first repository access. A handler
+   method that persists nothing therefore already runs with no transaction. This
+   was an accident of the implementation rather than a promise.
+
+2. **Handler methods are already transactionally independent.** For event
+   handlers and projectors, `_dispatch_handlers` loops over every matching
+   handler method and each one gets its own `UnitOfWork`. One event handled by
+   three methods is already three independent transactions.
+
+3. **They are not independent in failure.** The loop propagates the first
+   exception, so sibling methods are skipped, and `_handlers` is a
+   `defaultdict(set)`, so which ones get skipped is arbitrary. With three methods
+   where the second fails, one sibling ran and one never did.
+
+Prior art was consulted rather than invented. Spring models this as a propagation
+enum (`REQUIRED`, `REQUIRES_NEW`, `NOT_SUPPORTED`, `NESTED`) and enforces
+guardrails, raising when a transactional event listener picks a propagation that
+cannot work. Axon makes the Unit of Work a lifecycle with phases and has
+components register work into a phase, with no opt-out. Django offers
+`on_commit()`, `atomic(durable=True)` and `non_atomic_requests`, and its
+`on_commit` callbacks are lost on a crash. NServiceBus is explicit that its outbox
+covers outgoing messages only and does not extend to HTTP, email, or the
+filesystem. Temporal records a side effect's result in history so replay returns
+the recorded value instead of re-executing.
+
+## Decision
+
+**A handler method either persists or talks to the outside world. Not both.**
+
+That is the whole rule, and it is what the framework teaches, checks, and
+documents. Around it:
+
+- **Guarantee: no persistence means no transaction.** A handler method that makes
+  no repository access runs no transaction and holds no connection. The lazy
+  session becomes a stated contract instead of an incidental optimization, which
+  is what makes the rule work without any new API.
+
+- **When a handler genuinely needs both**, because it needs an external result to
+  compute the local write, it does both in one method and the transaction stays
+  open for the call. The mitigation is the remote system's idempotency key, which
+  is the feature that exists for exactly this, and keeping the call short. Protean
+  does not build a mechanism for this case.
+
+- **An advisory diagnostic** reports a handler method that both persists and calls
+  out. It is advisory, not an error, because the previous point makes that shape
+  legitimate sometimes, and a check that fires on correct code is one people learn
+  to ignore. It is suppressible through the existing `suppress_checks` option.
+
+- **A failing handler method must not skip its siblings.** Fact 3 above is a
+  defect against the model this ADR states, and it is fixed rather than
+  documented.
+
+- **No ordering between handlers for the same event, ever.** If two reactions must
+  happen in order, the second is not reacting to the event, it is reacting to what
+  the first did, so it subscribes to an event the first raises. An ordering option
+  would bury that dependency in configuration where nothing at the call site
+  reveals it. An event chain puts it in the code, where correlation and causation
+  IDs already trace it and each step can be tested on its own.
+
+**No new API is added.** Everything else the request asked for already exists: the
+outbox for outbound messages, `idempotent=True` for redelivery, event chains for
+sequencing, and separate handler classes for full independence with their own
+subscriptions and checkpoints.
+
+## Consequences
+
+Positive:
+
+- The rule fits in one sentence and is checkable, both by a reader looking at a
+  single method and by a static rule.
+- The public surface does not grow. There is no flag, phase, scope, or journal to
+  learn, and no new interaction with retry, idempotency, or nesting to reason
+  about.
+- Sibling handler methods become genuinely independent, matching the model users
+  already have of them.
+- ADR-0027 is untouched. Nothing nests, nothing commits independently, and one
+  Unit of Work still maps to one use case.
+
+Negative:
+
+- A handler that needs an external result to compute its write still holds a
+  transaction across that call. Protean offers guidance and a diagnostic rather
+  than a mechanism, and an operator who ignores both will hold locks across the
+  network.
+- The "no persistence, no transaction" guarantee constrains the implementation.
+  Opening a session eagerly is no longer free, because handler methods that only
+  call out would start holding connections.
+- Splitting persistence from external calls means more handler methods, and the
+  data one needs from the other travels through an event rather than a local
+  variable.
+
+## Alternatives Considered
+
+- **`@handle(Event, unit_of_work=False)`**, the original request. Rejected on
+  granularity and on safety. It is Spring's `NOT_SUPPORTED` applied to a whole
+  handler rather than a block, so it switches off OCC retry and the idempotency
+  policy for everything else the handler does. Worse, delivery is at-least-once,
+  so a handler that commits three sub-units and dies on the fourth is redelivered
+  and re-applies the first three, turning a visible full rollback into a silent
+  duplicate. Django's `non_atomic_requests` is the closest precedent and is safe
+  for the one reason this is not: HTTP requests are not redelivered.
+
+- **A `prepare=` phase on `@handle`**, running before the transaction and not
+  replayed on retry. Rejected because the boundary is too thin to explain and it
+  fails a common case: a handler that must read aggregate state to decide whether
+  to make the call cannot do the deciding in a phase that may not read.
+
+- **A journaled side effect** in the style of Temporal's `SideEffect`, recording a
+  result against `(message_id, key)` so retries and redeliveries read it back.
+  Rejected as complexity in the wrong place. It exists only to make the
+  persist-and-call-out shape survivable, and the remote system's idempotency key
+  already solves that properly, at the layer that can actually guarantee it.
+
+- **A suspend scope**, a context manager running a block with no transaction.
+  Rejected as unnecessary rather than unwanted. The "no persistence, no
+  transaction" guarantee gives the same result by splitting the method, which is
+  the shape we want people to write anyway. Note that ADR-0027 does not rule this
+  out: its rejection of independent inner transactions rests on savepoint
+  reasoning, and removing a transaction needs no savepoints.
+
+- **Deterministic ordering for sibling handler methods.** Rejected. Making the
+  order stable would legitimize depending on it, which is the coupling this ADR
+  rules out. Sibling methods are independent, and the fix is that a failure in one
+  no longer skips the others.

--- a/docs/adr/0031-handlers-persist-or-call-out.md
+++ b/docs/adr/0031-handlers-persist-or-call-out.md
@@ -19,12 +19,12 @@ commit sub-units independently. Working through the cases showed the request was
 pointing at something real and prescribing the wrong fix, and that most of what
 it asked for either already works or should not be built.
 
-Three facts drove the decision, all verified by running rather than by reading:
+Three facts drove the decision:
 
 1. **The Unit of Work is lazy.** `start()` opens no session. The session, and on
-   SQLAlchemy the real `BEGIN`, appears at the first repository access. A handler
-   method that persists nothing therefore already runs with no transaction. This
-   was an accident of the implementation rather than a promise.
+   SQLAlchemy the real `BEGIN`, appears at the first repository access, confirmed
+   on the memory and SQLite providers. A handler method that persists nothing
+   already runs with no transaction, by accident of the implementation.
 
 2. **Handler methods are already transactionally independent.** For event
    handlers and projectors, `_dispatch_handlers` loops over every matching
@@ -36,60 +36,118 @@ Three facts drove the decision, all verified by running rather than by reading:
    `defaultdict(set)`, so which ones get skipped is arbitrary. With three methods
    where the second fails, one sibling ran and one never did.
 
-Prior art was consulted rather than invented. Spring models this as a propagation
-enum (`REQUIRED`, `REQUIRES_NEW`, `NOT_SUPPORTED`, `NESTED`) and enforces
-guardrails, raising when a transactional event listener picks a propagation that
-cannot work. Axon makes the Unit of Work a lifecycle with phases and has
-components register work into a phase, with no opt-out. Django offers
-`on_commit()`, `atomic(durable=True)` and `non_atomic_requests`, and its
-`on_commit` callbacks are lost on a crash. NServiceBus is explicit that its outbox
-covers outgoing messages only and does not extend to HTTP, email, or the
-filesystem. Temporal records a side effect's result in history so replay returns
-the recorded value instead of re-executing.
+Spring models this problem as a propagation enum (`REQUIRED`, `REQUIRES_NEW`,
+`NOT_SUPPORTED`, `NESTED`) and enforces guardrails, raising when a transactional
+event listener picks a propagation that cannot work. Axon makes the Unit of Work
+a lifecycle with phases and has components register work into a phase, with no
+opt-out. Django offers `on_commit()`, `atomic(durable=True)` and
+`non_atomic_requests`, and its `on_commit` callbacks are lost on a crash.
+NServiceBus is explicit that its outbox covers outgoing messages only and does not
+extend to HTTP, email, or the filesystem. Temporal records a side effect's result
+in history so replay returns the recorded value instead of re-executing.
 
 ## Decision
 
 **A handler method either persists or talks to the outside world. Not both.**
 
-That is the whole rule. Around it:
+Around it:
 
-- **Guarantee: no persistence means no transaction.** A handler method that makes
-  no repository access runs no transaction and holds no connection. The lazy
-  session becomes a stated contract instead of an incidental optimization, which
-  is what makes the rule work without any new API.
+- **No persistence, no transaction**: A handler method that makes no repository
+  access runs no transaction and holds no connection. The lazy session becomes a
+  stated contract.
 
-- **When a handler genuinely needs both**, because it needs an external result to
-  compute the local write, it does both in one method and the transaction stays
-  open for the call. The mitigation is the remote system's idempotency key, which
-  is the feature that exists for exactly this, and keeping the call short. Protean
-  does not build a mechanism for this case.
+- **Both in one method**: A handler that needs an external result to compute its
+  local write does both in one method, and the transaction stays open for the
+  call. The mitigation is the remote system's idempotency key and keeping the call
+  short. Protean builds no mechanism for this.
 
-- **An advisory diagnostic** will report a handler method that both persists and
-  calls out. It stays advisory rather than an error, because the previous point
-  makes that shape legitimate sometimes, and a check that fires on correct code is
-  one people learn to ignore. It is suppressible through the existing
-  `suppress_checks` option.
+- **An advisory diagnostic**: A handler method that both persists and calls out
+  will be reported. It is advisory. The previous point makes that shape legitimate
+  sometimes, and a check that fires on correct code is one people learn to ignore.
+  It is suppressible through the existing `suppress_checks` option.
 
-- **A failing handler method must not skip its siblings.** Fact 3 above is a
-  defect against the model this ADR states, so it gets fixed rather than written
-  down as behavior.
+- **Siblings are independent in failure**: Fact 3 above is a defect against the
+  model this ADR states, and it gets fixed.
 
-- **No ordering between handlers for the same event, ever.** If two reactions must
-  happen in order, the second is not reacting to the event, it is reacting to what
-  the first did, so it subscribes to an event the first raises. An ordering option
-  would bury that dependency in configuration where nothing at the call site
-  reveals it. An event chain puts it in the code, where correlation and causation
-  IDs already trace it and each step can be tested on its own.
+- **No ordering between handlers for the same event**: If two reactions must
+  happen in order, the second is reacting to what the first did, so it subscribes
+  to an event the first raises. An ordering option would bury that dependency in
+  configuration where nothing at the call site reveals it. An event chain puts it
+  in the code, where correlation and causation IDs already trace it and each step
+  can be tested on its own.
+
+### The shapes this produces
+
+Two reactions to one event, one persisting and one calling out. They are
+independent, run in no particular order, and neither can cancel the other:
+
+```python
+from protean import current_domain, handle
+
+@domain.event_handler(part_of=Order)
+class OrderReactions:
+    @handle(OrderPlaced)
+    def reserve_stock(self, event):
+        repo = current_domain.repository_for(Inventory)
+        stock = repo.find_by(product_id=event.product_id)
+        stock.reserve(event.quantity)
+        repo.add(stock)
+
+    @handle(OrderPlaced)
+    def notify_partner(self, event):
+        # No repository access, so this method runs no transaction.
+        httpx.post(PARTNER_URL, json={"order_id": event.order_id})
+```
+
+When the call has to follow the write, or needs a value the write produces, the
+persisting method raises an event and the calling method handles that event:
+
+```python
+@domain.event_handler(part_of=Order)
+class OrderConfirmation:
+    @handle(OrderPlaced)
+    def confirm(self, event):
+        repo = current_domain.repository_for(Order)
+        order = repo.get(event.order_id)
+        order.confirm()                     # raises OrderConfirmed
+        repo.add(order)
+
+
+@domain.event_handler(part_of=Order)
+class PartnerNotifier:
+    @handle(OrderConfirmed)
+    def notify_partner(self, event):
+        httpx.post(
+            PARTNER_URL,
+            json={"order_id": event.order_id, "confirmed_at": event.confirmed_at},
+        )
+```
+
+`OrderConfirmed` goes to the outbox inside the confirming transaction and is
+published once that transaction commits, so `notify_partner` runs after the write
+is durable. The value it needs travels on the event.
+
+The shape to avoid is one method doing both, where the external call sits inside
+the transaction that the repository access opened:
+
+```python
+@handle(OrderPlaced)
+def confirm_and_notify(self, event):
+    repo = current_domain.repository_for(Order)
+    order = repo.get(event.order_id)        # transaction opens here
+    order.confirm()
+    repo.add(order)
+    httpx.post(PARTNER_URL, json={"order_id": event.order_id})   # holds locks
+```
 
 **No new API is added.** Everything else the request asked for already exists: the
 outbox for outbound messages, `idempotent=True` for redelivery, event chains for
 sequencing, and separate handler classes for full independence with their own
 subscriptions and checkpoints.
 
-This records a decision, not the state of the code. The lazy Unit of Work already
-behaves as the guarantee requires, and a regression test locks that in. The
-advisory diagnostic does not exist yet, and the sibling-skipping defect is still
-live. Both are tracked as separate work.
+The lazy Unit of Work already behaves as the guarantee requires, and a regression
+test locks it in. The advisory diagnostic does not exist yet, and the
+sibling-skipping defect is still live. Both are tracked as separate work.
 
 ## Consequences
 
@@ -108,15 +166,13 @@ Positive:
 Negative:
 
 - A handler that needs an external result to compute its write still holds a
-  transaction across that call. Protean offers guidance and a diagnostic rather
-  than a mechanism, and an operator who ignores both will hold locks across the
-  network.
+  transaction across that call. Protean offers guidance and a diagnostic. An
+  operator who ignores both will hold locks across the network.
 - The "no persistence, no transaction" guarantee constrains the implementation.
   Opening a session eagerly is no longer free, because handler methods that only
   call out would start holding connections.
 - Splitting persistence from external calls means more handler methods, and the
-  data one needs from the other travels through an event rather than a local
-  variable.
+  value one needs from the other travels on an event.
 
 ## Alternatives Considered
 
@@ -126,8 +182,8 @@ Negative:
   policy for everything else the handler does. Worse, delivery is at-least-once,
   so a handler that commits three sub-units and dies on the fourth is redelivered
   and re-applies the first three, turning a visible full rollback into a silent
-  duplicate. Django's `non_atomic_requests` is the closest precedent and is safe
-  for the one reason this is not: HTTP requests are not redelivered.
+  duplicate. Django's `non_atomic_requests` is the closest precedent, and it is
+  safe because HTTP requests are not redelivered. Messages are.
 
 - **A `prepare=` phase on `@handle`**, running before the transaction and not
   replayed on retry. Rejected because the boundary is too thin to explain and it
@@ -138,14 +194,14 @@ Negative:
   result against `(message_id, key)` so retries and redeliveries read it back.
   Rejected as complexity in the wrong place. It exists only to make the
   persist-and-call-out shape survivable, and the remote system's idempotency key
-  already solves that properly, at the layer that can actually guarantee it.
+  already solves that at the layer that can guarantee it.
 
 - **A suspend scope**, a context manager running a block with no transaction.
-  Rejected as unnecessary rather than unwanted. The "no persistence, no
-  transaction" guarantee gives the same result by splitting the method, which is
-  the shape we want people to write anyway. Note that ADR-0027 does not rule this
-  out: its rejection of independent inner transactions rests on savepoint
-  reasoning, and removing a transaction needs no savepoints.
+  Rejected as unnecessary. The "no persistence, no transaction" guarantee gives
+  the same result by splitting the method, which is the shape we want people to
+  write anyway. ADR-0027 does not rule this out: its rejection of independent
+  inner transactions rests on savepoint reasoning, and removing a transaction
+  needs no savepoints.
 
 - **Deterministic ordering for sibling handler methods.** Rejected. Making the
   order stable would legitimize depending on it, which is the coupling this ADR

--- a/docs/adr/0031-handlers-persist-or-call-out.md
+++ b/docs/adr/0031-handlers-persist-or-call-out.md
@@ -82,8 +82,6 @@ Two reactions to one event, one persisting and one calling out. They are
 independent, run in no particular order, and neither can cancel the other:
 
 ```python
-from protean import current_domain, handle
-
 @domain.event_handler(part_of=Order)
 class OrderReactions:
     @handle(OrderPlaced)
@@ -146,7 +144,7 @@ sequencing, and separate handler classes for full independence with their own
 subscriptions and checkpoints.
 
 The lazy Unit of Work already behaves as the guarantee requires, and a regression
-test locks it in. The advisory diagnostic does not exist yet, and the
+test will lock it in. The advisory diagnostic does not exist yet, and the
 sibling-skipping defect is still live. Both are tracked as separate work.
 
 ## Consequences
@@ -158,16 +156,16 @@ Positive:
 - The public surface does not grow. There is no flag, phase, scope, or journal to
   learn, and no new interaction with retry, idempotency, or nesting to reason
   about.
-- Sibling handler methods become genuinely independent, matching the model users
-  already have of them.
+- Sibling handler methods become genuinely independent once the sibling-skipping
+  defect is fixed, matching the model users already have of them.
 - ADR-0027 is untouched. Nothing nests, nothing commits independently, and one
   Unit of Work still maps to one use case.
 
 Negative:
 
 - A handler that needs an external result to compute its write still holds a
-  transaction across that call. Protean offers guidance and a diagnostic. An
-  operator who ignores both will hold locks across the network.
+  transaction across that call. Protean answers with guidance and, once built, a
+  diagnostic. An operator who ignores both will hold locks across the network.
 - The "no persistence, no transaction" guarantee constrains the implementation.
   Opening a session eagerly is no longer free, because handler methods that only
   call out would start holding connections.

--- a/docs/adr/0031-handlers-persist-or-call-out.md
+++ b/docs/adr/0031-handlers-persist-or-call-out.md
@@ -51,8 +51,7 @@ the recorded value instead of re-executing.
 
 **A handler method either persists or talks to the outside world. Not both.**
 
-That is the whole rule, and it is what the framework teaches, checks, and
-documents. Around it:
+That is the whole rule. Around it:
 
 - **Guarantee: no persistence means no transaction.** A handler method that makes
   no repository access runs no transaction and holds no connection. The lazy
@@ -65,14 +64,15 @@ documents. Around it:
   is the feature that exists for exactly this, and keeping the call short. Protean
   does not build a mechanism for this case.
 
-- **An advisory diagnostic** reports a handler method that both persists and calls
-  out. It is advisory, not an error, because the previous point makes that shape
-  legitimate sometimes, and a check that fires on correct code is one people learn
-  to ignore. It is suppressible through the existing `suppress_checks` option.
+- **An advisory diagnostic** will report a handler method that both persists and
+  calls out. It stays advisory rather than an error, because the previous point
+  makes that shape legitimate sometimes, and a check that fires on correct code is
+  one people learn to ignore. It is suppressible through the existing
+  `suppress_checks` option.
 
 - **A failing handler method must not skip its siblings.** Fact 3 above is a
-  defect against the model this ADR states, and it is fixed rather than
-  documented.
+  defect against the model this ADR states, so it gets fixed rather than written
+  down as behavior.
 
 - **No ordering between handlers for the same event, ever.** If two reactions must
   happen in order, the second is not reacting to the event, it is reacting to what
@@ -85,6 +85,11 @@ documents. Around it:
 outbox for outbound messages, `idempotent=True` for redelivery, event chains for
 sequencing, and separate handler classes for full independence with their own
 subscriptions and checkpoints.
+
+This records a decision, not the state of the code. The lazy Unit of Work already
+behaves as the guarantee requires, and a regression test locks that in. The
+advisory diagnostic does not exist yet, and the sibling-skipping defect is still
+live. Both are tracked as separate work.
 
 ## Consequences
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -102,3 +102,4 @@ See `TEMPLATE.md` in the `adr/` directory for the ADR template.
 | [0028](0028-partition-per-key-sequential-processing.md) | Partition-Per-Key Sequential Processing (`sequential_by`) |
 | [0029](0029-runtime-dependency-boundary-and-extras.md) | Runtime Dependency Boundary and Feature Extras |
 | [0030](0030-canonical-project-layout.md) | Canonical Generated Project Layout |
+| [0031](0031-handlers-persist-or-call-out.md) | A Handler Method Persists or Calls Out, Never Both |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -427,6 +427,7 @@ nav:
       - adr/0028-partition-per-key-sequential-processing.md
       - adr/0029-runtime-dependency-boundary-and-extras.md
       - adr/0030-canonical-project-layout.md
+      - adr/0031-handlers-persist-or-call-out.md
     - Troubleshooting:
       - reference/troubleshooting.md
 


### PR DESCRIPTION
Closes #1405.

A handler method either persists or talks to the outside world, never both. This
writes down that rule, the guarantee it rests on, and what was rejected on the way
to it.

The guarantee is that a handler method making no repository access runs no
transaction. That already holds (the Unit of Work is lazy, and the session appears
at the first repository access, verified on the memory and SQLite providers), but
it held by accident. The ADR makes it a contract so the next change to the start
path knows it is load-bearing.

Rejections recorded with reasoning: `unit_of_work=False` on `@handle`, a
`prepare` phase, a journaled side effect, a suspend scope, and deterministic
sibling ordering.

It also corrects a misreading of ADR-0027 that came up while working this out. That
ADR's rejection of independent inner transactions rests on savepoint reasoning, so
it does not rule out a no-transaction scope. The scope is rejected here as
unnecessary rather than forbidden.

No changelog fragment: this records a decision and changes no behaviour. The
behaviour changes land in the sibling issues under #1403.