### PR TITLE
Make the memory cache key_pattern a glob, matching Redis

### DIFF
--- a/changes/1393.changed.md
+++ b/changes/1393.changed.md
@@ -1,0 +1,5 @@
+The cache `key_pattern` argument to `get_all`, `count`, and `remove_by_key_pattern` is now a glob on every adapter. The memory cache used to compile it as a Python regular expression while Redis passed it to `SCAN ... MATCH` as a glob, so the same string selected different keys depending on which adapter was configured. The memory cache now matches with `fnmatch`, the same glob language Redis uses.
+
+**Breaking (memory cache).** `BaseCache` is a Provisional API, so this lands in a minor release with no deprecation period. A pattern that leaned on regex behaviour on the memory cache selects differently now: `.` was "any character" and is now a literal dot, and regex anchors and character-class escapes are gone. Rewrite regex patterns as globs, for example `user_profile:::.*` becomes `user_profile:::*`.
+
+**Migration:** [Cache key patterns are a glob on every adapter](https://docs.proteanhq.com/reference/migration/v0-18/#cache-key-patterns-are-a-glob-on-every-adapter).

--- a/docs/reference/adapters/cache/index.md
+++ b/docs/reference/adapters/cache/index.md
@@ -141,6 +141,12 @@ order_summary:::ord-123
 user_profile:::usr-456
 ```
 
+The `key_pattern` on `get_all`, `count`, and `remove_by_key_pattern` is a glob.
+`*` matches any run of characters, `?` matches one, `[...]` is a character
+class, and other characters are literal. Every entry of one projection is
+`order_summary:::*`. Adapters agree on `*`, `?`, and literal characters; bracket
+negation and escaping can differ, so keep patterns to the `name:::*` shape.
+
 ## Configuring a cache
 
 1. **A default cache is required**, even if it is only the memory cache for

--- a/docs/reference/migration/v0-18.md
+++ b/docs/reference/migration/v0-18.md
@@ -25,6 +25,7 @@ now needs an extra, the CLI or the import tells you exactly which one.
 - [`events catalog`, `subscriptions status`, and `projection status` JSON moved onto the envelope](#events-catalog-subscriptions-status-and-projection-status-json-moved-onto-the-envelope)
 - [The memory cache no longer raises on an absent key](#the-memory-cache-no-longer-raises-on-an-absent-key): `remove`, `remove_by_key` and `set_ttl` are silent
 - [`get_ttl` returns `None` or `math.inf` instead of a raw sentinel](#get_ttl-returns-none-or-mathinf-instead-of-a-raw-sentinel): the same three answers on every adapter
+- [Cache key patterns are a glob on every adapter](#cache-key-patterns-are-a-glob-on-every-adapter): the memory cache matches with `fnmatch`, like Redis
 - [A failing handler method no longer stops its siblings](#a-failing-handler-method-no-longer-stops-its-siblings): every `@handle` method for an event now runs
 - [Sibling handler classes are independent in failure under synchronous dispatch](#sibling-handler-classes-are-independent-in-failure-under-synchronous-dispatch): every handler class for an event now runs under `event_processing = "sync"`
 
@@ -362,6 +363,42 @@ Like the absent-key change above, this was a divergence between two adapters of
 the same port, not an intentional contract. `BaseCache` is a Provisional API, so
 its signatures can still change without a deprecation period. Nothing inside
 Protean read `get_ttl`, so only your own callers are affected.
+
+---
+
+## Cache key patterns are a glob on every adapter
+
+**Behavioural break, memory cache.** `get_all`, `count`, and
+`remove_by_key_pattern` take a `key_pattern`. The memory cache used to compile
+it as a Python regular expression, while Redis passed it to `SCAN ... MATCH` as
+a glob. The same string selected different keys depending on which adapter you
+ran, and a pattern that leaned on regex behaviour matched nothing once you
+switched to Redis.
+
+The memory cache now matches with `fnmatch`, the same glob language Redis uses.
+`*` matches any run of characters, `?` matches one, `[...]` is a character class,
+and other characters, including `.`, are literal. Adapters agree on `*`, `?`, and
+literal characters; bracket negation and escaping can differ, so keep patterns to
+the `name:::*` shape.
+
+### Who is affected
+
+Anyone who passed a regex-flavoured `key_pattern` to the memory cache. Cache
+keys are `name:::identifier`, so most patterns are already a name and a `*`,
+which is a valid glob and needs no change. A pattern that used regex syntax
+needs rewriting:
+
+```python
+# Before, on the memory cache: a regex
+cache.get_all("user_profile:::.*")
+
+# After, on every adapter: a glob
+cache.get_all("user_profile:::*")
+```
+
+A literal `.` in a pattern used to match any character on the memory cache and
+now matches only a `.`. `BaseCache` is a Provisional API, so this lands in a
+minor release with no deprecation period.
 
 ---
 

--- a/src/protean/adapters/cache/memory.py
+++ b/src/protean/adapters/cache/memory.py
@@ -177,7 +177,11 @@ class MemoryCache(BaseCache):
         projection_name = key_pattern.split(":::")[0]
         projection_cls = self._projections[projection_name]
 
-        key_list = self._db.keys()
+        # Snapshot with list() so the matching below runs outside the store's
+        # lock: keys() is a lazy iterator that holds TTLDict's RLock for the
+        # whole traversal, so matching while iterating it would hold the lock
+        # across every fnmatch call.
+        key_list = list(self._db.keys())
         results = [key for key in key_list if fnmatchcase(key, key_pattern)]
 
         # Apply pagination
@@ -192,7 +196,8 @@ class MemoryCache(BaseCache):
         ]
 
     def count(self, key_pattern: str) -> int:
-        key_list = self._db.keys()
+        # list() snapshots under the store's lock; matching then runs lock-free.
+        key_list = list(self._db.keys())
         return sum(1 for key in key_list if fnmatchcase(key, key_pattern))
 
     def remove(self, projection: BaseProjection) -> None:
@@ -207,7 +212,8 @@ class MemoryCache(BaseCache):
         self._db.pop(key, None)
 
     def remove_by_key_pattern(self, key_pattern: str) -> None:
-        key_list = self._db.keys()
+        # list() snapshots under the store's lock; matching then runs lock-free.
+        key_list = list(self._db.keys())
         keys_to_delete = [key for key in key_list if fnmatchcase(key, key_pattern)]
         # A key can expire between the scan above and this delete, so use
         # `pop` with a default, the same as `remove` and `remove_by_key`.

--- a/src/protean/adapters/cache/memory.py
+++ b/src/protean/adapters/cache/memory.py
@@ -1,8 +1,8 @@
 import collections.abc
 import math
-import re
 import time
 from collections.abc import Iterator
+from fnmatch import fnmatchcase
 from threading import RLock
 from typing import Any
 
@@ -177,9 +177,8 @@ class MemoryCache(BaseCache):
         projection_name = key_pattern.split(":::")[0]
         projection_cls = self._projections[projection_name]
 
-        key_list = list(self._db.keys())
-        regex = re.compile(key_pattern)
-        results = list(filter(regex.match, key_list))
+        key_list = self._db.keys()
+        results = [key for key in key_list if fnmatchcase(key, key_pattern)]
 
         # Apply pagination
         page = results[last_position : last_position + size]
@@ -188,8 +187,7 @@ class MemoryCache(BaseCache):
 
     def count(self, key_pattern: str) -> int:
         key_list = self._db.keys()
-        regex = re.compile(key_pattern)
-        return len(list(filter(regex.match, key_list)))
+        return sum(1 for key in key_list if fnmatchcase(key, key_pattern))
 
     def remove(self, projection: BaseProjection) -> None:
         id_f = id_field(projection)
@@ -203,9 +201,8 @@ class MemoryCache(BaseCache):
         self._db.pop(key, None)
 
     def remove_by_key_pattern(self, key_pattern: str) -> None:
-        full_key_list = self._db.keys()
-        regex = re.compile(key_pattern)
-        keys_to_delete = list(filter(regex.match, full_key_list))
+        key_list = self._db.keys()
+        keys_to_delete = [key for key in key_list if fnmatchcase(key, key_pattern)]
         for key in keys_to_delete:
             del self._db[key]
 

--- a/src/protean/adapters/cache/memory.py
+++ b/src/protean/adapters/cache/memory.py
@@ -183,7 +183,13 @@ class MemoryCache(BaseCache):
         # Apply pagination
         page = results[last_position : last_position + size]
 
-        return [projection_cls(self._db.get(key)) for key in page]
+        # A key can expire between the scan above and this read, so a `get`
+        # can come back empty. Skip it, the same way the Redis adapter does.
+        return [
+            projection_cls(value)
+            for key in page
+            if (value := self._db.get(key)) is not None
+        ]
 
     def count(self, key_pattern: str) -> int:
         key_list = self._db.keys()
@@ -203,8 +209,10 @@ class MemoryCache(BaseCache):
     def remove_by_key_pattern(self, key_pattern: str) -> None:
         key_list = self._db.keys()
         keys_to_delete = [key for key in key_list if fnmatchcase(key, key_pattern)]
+        # A key can expire between the scan above and this delete, so use
+        # `pop` with a default, the same as `remove` and `remove_by_key`.
         for key in keys_to_delete:
-            del self._db[key]
+            self._db.pop(key, None)
 
     def flush_all(self) -> None:
         # Clear in place so the TTLDict (and its configured default TTL) is

--- a/src/protean/core/view.py
+++ b/src/protean/core/view.py
@@ -128,7 +128,9 @@ class ReadView:
         """Return the total number of projection records."""
         if self._is_cache_backed:
             projection_name = underscore(self._projection_cls.__name__)
-            key_pattern = f"{projection_name}:::.*"
+            # Keys are `name:::identifier`; count every entry for this
+            # projection with the glob the cache port expects.
+            key_pattern = f"{projection_name}:::*"
             return self._cache().count(key_pattern)
         else:
             return self.query.count()

--- a/src/protean/port/cache.py
+++ b/src/protean/port/cache.py
@@ -173,11 +173,22 @@ class BaseCache(metaclass=ABCMeta):
     def get_all(
         self, key_pattern: str, last_position: int = 0, size: int = 25
     ) -> list[BaseProjection]:
-        """Retrieve data by key pattern"""
+        """Retrieve data by key pattern.
+
+        `key_pattern` is a glob. `*` matches any run of characters, `?`
+        matches one, `[...]` is a character class, and other characters,
+        including `.`, are literal. Keys are `name:::identifier`, so a
+        projection's entries are `"user_profile:::*"`. Every adapter agrees on
+        `*`, `?`, and literal characters; bracket negation and escaping can
+        differ between adapters, so keep patterns to the `name:::*` shape.
+        """
 
     @abstractmethod
     def count(self, key_pattern: str) -> int:
-        """Retrieve count of data by key pattern"""
+        """Retrieve count of data by key pattern.
+
+        `key_pattern` is a glob. See `get_all` for the syntax.
+        """
 
     @abstractmethod
     def remove(self, projection: BaseProjection) -> None:
@@ -195,7 +206,10 @@ class BaseCache(metaclass=ABCMeta):
 
     @abstractmethod
     def remove_by_key_pattern(self, key_pattern: str) -> None:
-        """Remove a cache record by key pattern"""
+        """Remove a cache record by key pattern.
+
+        `key_pattern` is a glob. See `get_all` for the syntax.
+        """
 
     @abstractmethod
     def flush_all(self) -> None:

--- a/src/protean/utils/projection_rebuilder.py
+++ b/src/protean/utils/projection_rebuilder.py
@@ -160,7 +160,9 @@ def _truncate_projection(
     """
     if projection_cls.meta_.cache:
         cache = domain.cache_for(projection_cls)
-        key_pattern = f"{underscore(projection_cls.__name__)}::*"
+        # Keys are `name:::identifier`, so the glob for every entry of this
+        # projection is the name, the three-colon separator, then `*`.
+        key_pattern = f"{underscore(projection_cls.__name__)}:::*"
         cache.remove_by_key_pattern(key_pattern)
     else:
         repo = domain.repository_for(projection_cls)

--- a/tests/adapters/cache/generic/test_key_patterns.py
+++ b/tests/adapters/cache/generic/test_key_patterns.py
@@ -129,23 +129,10 @@ class TestPatternLanguageIsAGlobOnEveryAdapter:
         """A literal `.` is where glob and regex disagree.
 
         Redis' `SCAN ... MATCH` is a real glob, where `.` is an ordinary
-        character. The memory cache compiles `key_pattern` straight into a
-        Python regex, where `.` matches any character, so
-        a pattern built on a literal dot also matches an entry that has a
-        different character in that position.
+        character. The memory cache matches `key_pattern` with `fnmatch`, a
+        glob too, so a literal `.` matches only a literal `.` on both
+        adapters.
         """
-        if request.node.callspec.params["cache"]["provider"] == "memory":
-            request.applymarker(
-                pytest.mark.xfail(
-                    strict=True,
-                    reason=(
-                        "#1393: a key pattern should be a glob on every "
-                        "adapter. The memory cache compiles it as a regex, "
-                        "so a literal '.' also matches any character."
-                    ),
-                )
-            )
-
         literal_dot = CacheEntry(key="a.c", value="literal-dot")
         any_char = CacheEntry(key="abc", value="any-char")
         cache.add(literal_dot)
@@ -154,3 +141,31 @@ class TestPatternLanguageIsAGlobOnEveryAdapter:
         results = cache.get_all("cache_entry:::a.c")
 
         assert results == [literal_dot]
+
+    def test_count_treats_the_pattern_as_a_glob(self, cache):
+        """`count` reads `.` as a literal, the same as `get_all`.
+
+        The shared `count` test uses `*`, which selects the same keys under
+        a glob and under a regex, so it cannot tell the two apart. A literal
+        `.` can: under a regex it would also count the `abc` entry.
+        """
+        cache.add(CacheEntry(key="a.c", value="literal-dot"))
+        cache.add(CacheEntry(key="abc", value="any-char"))
+
+        assert cache.count("cache_entry:::a.c") == 1
+
+    def test_remove_by_key_pattern_treats_the_pattern_as_a_glob(self, cache):
+        """`remove_by_key_pattern` reads `.` as a literal, the same as
+        `get_all`.
+
+        Under a regex the `.` would also match `abc`, so the removal would
+        take both entries. Over-deletion on a truncate path is the dangerous
+        direction, so pin it: only the literal-dot key is removed.
+        """
+        cache.add(CacheEntry(key="a.c", value="literal-dot"))
+        cache.add(CacheEntry(key="abc", value="any-char"))
+
+        cache.remove_by_key_pattern("cache_entry:::a.c")
+
+        assert cache.get("cache_entry:::abc") is not None
+        assert cache.get("cache_entry:::a.c") is None

--- a/tests/adapters/cache/generic/test_key_patterns.py
+++ b/tests/adapters/cache/generic/test_key_patterns.py
@@ -125,7 +125,7 @@ class TestGetAllPaginationAgrees:
 
 
 class TestPatternLanguageIsAGlobOnEveryAdapter:
-    def test_pattern_is_a_glob_on_every_adapter(self, cache, request):
+    def test_pattern_is_a_glob_on_every_adapter(self, cache):
         """A literal `.` is where glob and regex disagree.
 
         Redis' `SCAN ... MATCH` is a real glob, where `.` is an ordinary

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -82,7 +82,7 @@ class TestCachePersistenceFlows:
         value = cache.get("token:::qux")
         assert value == token
 
-    def test_get_keys_by_keyname_regex(self, test_domain):
+    def test_get_keys_by_keyname_glob(self, test_domain):
         cache = test_domain.cache_for(Token)
 
         token1 = Token(key="qux", user_id="foo", email="bar@baz.com")

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -95,6 +95,33 @@ class TestCachePersistenceFlows:
         assert len(tokens) == 2
         assert all(token in tokens for token in [token1, token2])
 
+    def test_get_all_skips_a_key_that_vanishes_after_the_scan(
+        self, test_domain, monkeypatch
+    ):
+        """A key can expire between the key scan and the per-key read.
+
+        `get_all` collects the matching keys, then reads each one. If a key
+        is evicted in that window, the read comes back empty; skip it rather
+        than build a projection from nothing, the same as the Redis adapter.
+        """
+        cache = test_domain.cache_for(Token)
+        cache.add(Token(key="qux", user_id="foo", email="bar@baz.com"))
+        cache.add(Token(key="quux", user_id="fooo", email="baar@baz.com"))
+
+        original_get = cache._db.get
+
+        def get_with_one_eviction(key, default=None):
+            if key == "token:::qux":
+                return None
+            return original_get(key, default)
+
+        monkeypatch.setattr(cache._db, "get", get_with_one_eviction)
+
+        tokens = cache.get_all("token:::qu*")
+
+        assert len(tokens) == 1
+        assert tokens[0].key == "quux"
+
     def test_counting_keys_in_cache(self, test_domain):
         cache = test_domain.cache_for(Token)
 

--- a/tests/projection_rebuild/test_rebuild_edge_cases.py
+++ b/tests/projection_rebuild/test_rebuild_edge_cases.py
@@ -89,7 +89,9 @@ class TestCacheBackedProjectionTruncation:
         _truncate_projection(mock_domain, mock_projection_cls)
 
         mock_domain.cache_for.assert_called_once_with(mock_projection_cls)
-        mock_cache.remove_by_key_pattern.assert_called_once_with("cached_view::*")
+        # Keys are `name:::identifier`, so the truncation glob is the name,
+        # the three-colon separator, then `*`.
+        mock_cache.remove_by_key_pattern.assert_called_once_with("cached_view:::*")
 
     def test_truncate_uses_dao_when_database_backed(self):
         """_truncate_projection uses dao._delete_all for database-backed projections."""


### PR DESCRIPTION
## Summary

`get_all`, `count`, and `remove_by_key_pattern` took a `key_pattern` that meant two different things. The memory cache compiled it as a Python regex; the Redis cache passed it to `SCAN ... MATCH` as a glob. The same string selected different keys depending on which adapter was configured. The memory cache now matches with `fnmatch.fnmatchcase`, so both adapters read the pattern as a glob.

Two in-framework callers built regex-style patterns that would stop matching under a glob:

- `View.count()` used `name:::.*`. Under a glob that demands a literal dot right after the colons, so it would silently return `0` on a cache-backed projection. Now `name:::*`.
- `projection_rebuilder._truncate_projection` used a two-colon `name::*` that matched by accident under both languages. Now `name:::*`.

The port docstring, the cache adapter reference, and the 0.18 migration guide now state that `key_pattern` is a glob, and scope the cross-adapter guarantee to `*`, `?`, and literal characters (bracket negation and escaping can differ between `fnmatch` and Redis).

`BaseCache` is Provisional, so this ships in a minor release with a changelog fragment and a migration note, no deprecation period.

## Test plan

- [x] Memory and Redis legs green: `tests/adapters/cache/` (`--redis`), including the previously-xfailed `test_pattern_is_a_glob_on_every_adapter` now passing on memory
- [x] New literal-dot glob tests for `count` and `remove_by_key_pattern` (the shared `*` tests could not tell glob from regex apart)
- [x] `View.count()` on a cache-backed projection and the projection-rebuild truncation both covered
- [x] Revert check: each behavioral test goes red when its source change is reverted
- [x] `protean test` core suite, ruff, mypy clean; 100% patch coverage on changed lines

Closes #1393