### PR TITLE
Drop the Python 3.15 prerelease leg from per-PR CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # A prerelease leg is allowed to fail. The 3.15 line depends on upstream
-    # packages shipping cp315 wheels (or building from source against a moving
-    # prerelease C-API), which is out of Protean's control; a red 3.15 leg should
-    # surface as an early warning, not block a merge. `matrix.experimental` is
-    # unset (falsy) on every stable leg, so those still gate normally.
-    continue-on-error: ${{ matrix.experimental || false }}
     strategy:
       fail-fast: false
       matrix:
@@ -37,25 +31,24 @@ jobs:
         # a version-specific adapter regression on 3.11-3.13 is caught. See
         # ADR-0020.
         #
-        # 3.15 is a prerelease: setup-python resolves it to the newest rc/beta
-        # (allow-prereleases in the composite action). It runs CORE only and is
-        # marked experimental (non-blocking) until 3.15 reaches GA and the
-        # ecosystem ships cp315 wheels; promote it to a stable CORE leg then, and
-        # move the FULL/lowest-direct roles to it once it is the newest stable.
-        # The floor leg stays on 3.14 for now: the floors are pinned to
-        # first-cp314-wheel versions and need not have a cp315 wheel yet.
+        # 3.15 (prerelease) does NOT run per-PR. The ecosystem ships no cp315
+        # wheels yet, so a per-PR leg builds its native-extension dependencies
+        # (grpcio, pydantic-core, psycopg2, pyodbc, and more) from source on every
+        # run, which dominates the job. nightly.yml runs 3.15 with the full adapter
+        # suite and files an issue on failure, the right cadence for a non-blocking
+        # prerelease canary. Add a per-PR 3.15 CORE leg here once cp315 wheels land
+        # and the build is fast; move the FULL/lowest-direct roles to it once 3.15
+        # is the newest stable. The floor leg stays on 3.14: the floors are pinned
+        # to first-cp314-wheel versions and need not have a cp315 wheel yet.
         include:
           - { python-version: "3.11", full: false, resolution: highest }
           - { python-version: "3.12", full: false, resolution: highest }
           - { python-version: "3.13", full: false, resolution: highest }
           - { python-version: "3.14", full: true, resolution: highest }
           - { python-version: "3.14", full: false, resolution: lowest-direct }
-          - { python-version: "3.15", full: false, resolution: highest, experimental: true }
     # Check names are branch-protection contexts. The CORE legs and the
     # lowest-direct leg on 3.14 are `Python X Tests`; the FULL adapter leg is
-    # `Python 3.14 Full` (add it to the required checks so it gates merges). The
-    # prerelease leg is `Python 3.15 Tests`; leave it out of the required set
-    # while it is experimental.
+    # `Python 3.14 Full` (add it to the required checks so it gates merges).
     name: ${{ matrix.full && 'Python 3.14 Full' || (matrix.resolution == 'lowest-direct' && 'Python 3.14 Tests') || format('Python {0} Tests', matrix.python-version) }}
 
     steps:


### PR DESCRIPTION
## Summary

Removes the `3.15` leg from the per-PR `test` matrix in `ci.yml`. Nothing else changes; the four stable legs (3.11, 3.12, 3.13 CORE, 3.14 Full, 3.14 lowest-direct) are untouched.

## Why

The 3.15 leg was taking ~28 min and dragging out every PR. Almost all of that is a source build: on the newest commit the job logged `Prepared 188 packages in 17m 27s`, versus `Prepared 191 packages in 8.66s` on 3.11. The reason is that the ecosystem ships no `cp315` wheels yet, so uv compiles the native-extension deps (grpcio, pydantic-core, psycopg2, pyodbc, and more) from source. A cache does not help: all matrix legs share one uv cache key (keyed on `uv.lock`, not the target Python), it is write-once, and the fast stable legs win the save, so the 3.15 leg gets a cache "hit" with no `cp315` wheels and rebuilds from source every run.

The leg was already non-blocking (`experimental` / `continue-on-error`) and left out of the required checks, and it is a strict subset of what nightly already does: `nightly.yml` runs 3.15 with the **full** adapter suite daily and files a `ci-failure` issue on failure. So per-PR 3.15 added ~28 min of wall-clock for signal nightly already provides more thoroughly.

This matches the design already written into `nightly.yml`: per-PR CI stays cheap, and version-specific coverage lives in the nightly run.

## Trade-off

PRs lose the per-PR "did this change break 3.15" signal. It was advisory only (non-blocking), 3.15 breaks are usually upstream rc churn rather than a specific PR, and a red nightly is easy to bisect against the day's merges. Re-add a per-PR 3.15 CORE leg once `cp315` wheels land and the build is fast (the comment in `ci.yml` says how).

## Effect

Per-PR CI settles in ~12 min (the long pole becomes `Python 3.14 Full`), down from ~28.