### PR TITLE
Add a bounded read_all iterator on the event-store port

### DIFF
--- a/changes/1358.added.md
+++ b/changes/1358.added.md
@@ -1,0 +1,1 @@
+Added `read_all` on the event-store port: a generator that pages through a whole stream (`$all`, a category, or a specific stream) in bounded batches instead of relying on the `no_of_messages=1_000_000` sentinel that silently truncates past the read cap. Projection rebuilds now read every event through it, so a rebuild over a store larger than the old cap replays completely.

--- a/docs/guides/change-state/event-store-setup.md
+++ b/docs/guides/change-state/event-store-setup.md
@@ -116,6 +116,12 @@ messages = store.read("myapp::account-acc-001", position=5)
 
 # Read last message
 last = store.read_last_message("myapp::account-acc-001")
+
+# Page through a whole stream without a size cap. `read_all` is a generator
+# that reads in `page_size` batches until the stream is exhausted, so it is
+# safe to iterate a store larger than a single `read` returns.
+for message in store.read_all("myapp::account", page_size=1000):
+    ...  # handle each message
 ```
 
 ---

--- a/src/protean/port/event_store.py
+++ b/src/protean/port/event_store.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict, deque
+from collections.abc import Iterator
 from dataclasses import dataclass
 from dataclasses import field as dc_field
 from datetime import datetime
@@ -113,6 +114,86 @@ class BaseEventStore(metaclass=ABCMeta):
         messages = [Message.deserialize(raw_message) for raw_message in raw_messages]
 
         return messages
+
+    def read_all(
+        self, stream: str = "$all", *, page_size: int = 1000
+    ) -> Iterator[Message]:
+        """Yield every message in ``stream``, paging through the store in bounded batches.
+
+        A cold-load read that must be complete (a full projection rebuild, a
+        backup, an integrity check) cannot rely on a single large ``read`` with a
+        sentinel ``no_of_messages``: past the cap it silently truncates. This
+        iterator loops ``read`` in ``page_size`` batches and advances a cursor
+        until a short page signals the end, so it reads the whole stream at a
+        bounded memory cost regardless of size.
+
+        The cursor field follows the stream shape (ADR-0024): ``$all`` and a bare
+        category page by ``global_position``; a specific stream (``category-id``)
+        pages by its own per-stream ``position``. Reads are inclusive
+        (``>= position``), so each next page resumes one past the last row seen,
+        which avoids re-emitting the boundary row.
+
+        Args:
+            stream: The stream to read. ``$all`` (default), a category, or a
+                specific ``category-id`` stream.
+            page_size: Number of messages to read per underlying ``read`` call.
+
+        Yields:
+            Every `Message` in ``stream``, in read order, with no gaps and
+            no duplicates across page boundaries.
+
+        Raises:
+            IncorrectUsageError: If ``page_size`` is not a positive integer.
+        """
+        # Check the type before the value: a float or ``None`` slipping through
+        # would flow into the adapter's row limit and either page oddly or raise
+        # a bare ``TypeError`` far from the cause. ``bool`` is an ``int``, and
+        # ``True`` (== 1) is harmless, so it is not special-cased.
+        if not isinstance(page_size, int) or page_size < 1:
+            raise IncorrectUsageError(
+                f"`page_size` must be a positive integer, got {page_size!r}"
+            )
+
+        # A category read (`$all` or a bare category) pages by `global_position`;
+        # a specific stream pages by its per-stream `position`. `category(stream)`
+        # strips the `-id` suffix, so it equals `stream` only for a category/$all.
+        pages_by_global_position = stream == self.category(stream)
+
+        cursor = 0
+        while True:
+            page = self.read(stream, position=cursor, no_of_messages=page_size)
+            yield from page
+
+            # A short page is the last page: the store had no more rows to fill
+            # it. This also terminates the empty-stream case after one read.
+            if len(page) < page_size:
+                return
+
+            cursor = self._next_cursor(page[-1], pages_by_global_position)
+
+    @staticmethod
+    def _next_cursor(message: Message, by_global_position: bool) -> int:
+        """The ``position`` to resume a paged read after ``message``.
+
+        Reads are inclusive, so resume one past the last row seen. A persisted
+        message always carries the relevant position; a missing one is a corrupt
+        row that would otherwise loop or truncate the read silently, so raise.
+        ``EventStoreMeta`` is attached when *either* position is present, so a row
+        can carry an ``event_store`` whose chosen field is still ``None``.
+        """
+        event_store = message.metadata.event_store if message.metadata else None
+        last: int | None = None
+        if event_store is not None:
+            last = (
+                event_store.global_position
+                if by_global_position
+                else event_store.position
+            )
+        if last is None:
+            raise IncorrectUsageError(
+                "Cannot page the event store: a message is missing its position."
+            )
+        return last + 1
 
     def read_last_message(self, stream: str) -> Message | None:
         raw_message = self._read_last_message(stream)

--- a/src/protean/utils/projection_rebuilder.py
+++ b/src/protean/utils/projection_rebuilder.py
@@ -201,19 +201,16 @@ def _replay_projector(
 
     # Collect all messages from all categories.
     #
-    # A full rebuild replays every event in a category, so we read the whole
-    # category in a single call rather than paginating — it is the simplest
-    # correct pass, and on production stores (MessageDB) a single large read per
-    # category is equally efficient thanks to server-side cursors.
+    # A full rebuild replays every event in a category, so we page through the
+    # whole category with `read_all`. The win over the old single sentinel-capped
+    # read is completeness: a category larger than the read cap is no longer
+    # silently truncated. `batch_size` sets the page size, so each round-trip to
+    # the store is bounded; peak memory is still O(all events), since the merge
+    # below collects every message into one list to sort by `global_position`.
     all_messages: list[Message] = []
     event_store = domain._require_event_store()
     for category in stream_categories:
-        messages = event_store.read(
-            category,
-            position=0,
-            no_of_messages=1_000_000,
-        )
-        all_messages.extend(messages)
+        all_messages.extend(event_store.read_all(category, page_size=batch_size))
 
     # Sort by global_position for correct cross-category ordering
     def _global_position(message: Message) -> int:

--- a/tests/adapters/event_store/memory_event_store/test_paging.py
+++ b/tests/adapters/event_store/memory_event_store/test_paging.py
@@ -1,0 +1,215 @@
+"""Paging the whole store with ``read_all`` on the memory event store.
+
+``read_all`` loops ``read`` in bounded pages and advances a cursor until a short
+page, so a cold-load reader (projection rebuild, backup, verify) reads the whole
+stream without the ``no_of_messages=1_000_000`` sentinel that silently truncates
+past the read cap.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from protean.exceptions import IncorrectUsageError
+from protean.port.event_store import BaseEventStore
+from protean.utils.eventing import Message
+
+
+def _metadata(stream_name, message_type, message_id):
+    return {
+        "domain": {"kind": "EVENT"},
+        "headers": {"id": message_id, "type": message_type, "stream": stream_name},
+    }
+
+
+def _write_n(store, stream_name, count):
+    """Write ``count`` messages to ``stream_name``."""
+    for i in range(count):
+        store._write(
+            stream_name,
+            "Ticked",
+            {"n": i},
+            _metadata(stream_name, "Ticked", f"{stream_name}-{i}"),
+        )
+
+
+def _global_positions(messages):
+    return [m.metadata.event_store.global_position for m in messages]
+
+
+def test_read_all_pages_across_boundary_no_gaps_no_dups(test_domain):
+    """A store holding ``page_size + 5`` messages is fully paged, in order."""
+    store = test_domain.event_store.store
+    page_size = 10
+    _write_n(store, "counter-1", page_size + 5)
+
+    paged = list(store.read_all("$all", page_size=page_size))
+    gpos = _global_positions(paged)
+
+    assert len(gpos) == page_size + 5  # nothing truncated at the read cap
+    assert gpos == sorted(gpos)  # global_position order
+    assert len(set(gpos)) == len(gpos)  # no duplicates across the boundary
+    # The same messages a single uncapped read would return.
+    baseline = _global_positions(store.read("$all", no_of_messages=1_000_000))
+    assert gpos == baseline
+
+
+def test_read_all_exact_multiple_of_page_size(test_domain):
+    """A store whose size is an exact multiple of ``page_size`` returns every
+    message once, then terminates with a single extra empty read.
+
+    The final full page is followed by an empty page: the branch a partial-page
+    test never exercises, and where an off-by-one in the terminate condition
+    would drop the boundary row or loop.
+    """
+    store = test_domain.event_store.store
+    page_size = 5
+    _write_n(store, "counter-1", page_size * 2)
+
+    with patch.object(store, "read", wraps=store.read) as spy:
+        paged = list(store.read_all("$all", page_size=page_size))
+
+    gpos = _global_positions(paged)
+    assert len(gpos) == page_size * 2
+    assert len(set(gpos)) == page_size * 2  # no boundary-row duplicate
+    assert gpos == sorted(gpos)
+    # Two full pages, then one empty read that signals the end.
+    assert spy.call_count == 3
+
+
+def test_read_all_page_size_one(test_domain):
+    """``page_size=1`` reads one row at a time without looping or dropping.
+
+    This is the size where a dropped ``+ 1`` in the cursor advance would hang
+    (re-reading the same single row forever) instead of merely duplicating.
+    """
+    store = test_domain.event_store.store
+    _write_n(store, "counter-1", 5)
+
+    paged = list(store.read_all("$all", page_size=1))
+    gpos = _global_positions(paged)
+
+    assert len(gpos) == 5
+    assert gpos == sorted(gpos)
+    assert len(set(gpos)) == 5
+
+
+def test_read_all_empty_stream_yields_nothing_in_one_read(test_domain):
+    """An empty stream yields nothing and issues a single underlying read."""
+    store = test_domain.event_store.store
+
+    with patch.object(store, "read", wraps=store.read) as spy:
+        result = list(store.read_all("$all", page_size=10))
+
+    assert result == []
+    assert spy.call_count == 1
+
+
+def test_read_all_specific_stream_pages_by_position(test_domain):
+    """A specific stream (``category-id``) pages by its per-stream ``position``."""
+    store = test_domain.event_store.store
+    _write_n(store, "counter-1", 7)
+    # A second stream in the same category must not leak into a specific read.
+    _write_n(store, "counter-2", 4)
+
+    paged = list(store.read_all("counter-1", page_size=3))
+
+    assert len(paged) == 7
+    assert all(m.metadata.headers.stream == "counter-1" for m in paged)
+    positions = [m.metadata.event_store.position for m in paged]
+    assert positions == list(range(7))  # gapless per-stream, in order
+
+
+def test_read_all_specific_stream_with_interleaved_writes(test_domain):
+    """A specific stream pages by per-stream ``position`` even when a sibling
+    stream's rows sit between its rows in ``global_position`` order.
+
+    Writes alternate between the two streams, so ``counter-1``'s global
+    positions are non-contiguous. Paging this stream by ``global_position``
+    would skip rows; paging by per-stream ``position`` returns all of them.
+    """
+    store = test_domain.event_store.store
+    for i in range(6):
+        _write_n(store, "counter-1", 1)
+        if i < 4:
+            _write_n(store, "counter-2", 1)
+
+    paged = list(store.read_all("counter-1", page_size=2))
+
+    assert all(m.metadata.headers.stream == "counter-1" for m in paged)
+    positions = [m.metadata.event_store.position for m in paged]
+    assert positions == list(range(6))  # every row, none skipped by interleaving
+
+
+def test_read_all_category_pages_by_global_position(test_domain):
+    """A bare category read pages by ``global_position`` across its streams."""
+    store = test_domain.event_store.store
+    _write_n(store, "counter-1", 6)
+    _write_n(store, "counter-2", 6)
+
+    paged = list(store.read_all("counter", page_size=5))
+    gpos = _global_positions(paged)
+
+    assert len(gpos) == 12
+    assert gpos == sorted(gpos)
+    assert len(set(gpos)) == 12
+
+
+def test_read_all_category_excludes_other_categories(test_domain):
+    """A category read returns only that category's streams, not the whole store."""
+    store = test_domain.event_store.store
+    _write_n(store, "counter-1", 4)
+    _write_n(store, "other-1", 3)
+
+    paged = list(store.read_all("counter", page_size=2))
+
+    assert len(paged) == 4
+    assert all(m.metadata.headers.stream.startswith("counter-") for m in paged)
+
+
+def test_read_all_defaults_to_all_stream(test_domain):
+    """``read_all()`` with no stream reads ``$all``."""
+    store = test_domain.event_store.store
+    _write_n(store, "counter-1", 3)
+
+    assert len(list(store.read_all())) == 3
+
+
+@pytest.mark.parametrize("bad", [0, -1, 1.5, None])
+def test_read_all_rejects_non_positive_page_size(test_domain, bad):
+    """A page size that is not a positive integer is a usage error, not an
+    infinite loop or a bare TypeError from the adapter's row limit."""
+    store = test_domain.event_store.store
+
+    with pytest.raises(IncorrectUsageError, match="page_size"):
+        list(store.read_all("$all", page_size=bad))
+
+
+def test_next_cursor_raises_when_event_store_meta_absent():
+    """A row with no event-store metadata raises instead of looping.
+
+    The paging cursor cannot advance without a position, so a corrupt/missing
+    one is a loud error rather than a silent infinite loop or truncated read.
+    """
+    message = Message.deserialize(
+        {"type": "X", "data": {}, "metadata": {"headers": {"id": "1"}}}
+    )
+    assert message.metadata.event_store is None  # no position -> no meta
+
+    with pytest.raises(IncorrectUsageError, match="missing its position"):
+        BaseEventStore._next_cursor(message, by_global_position=True)
+
+
+def test_next_cursor_raises_when_chosen_position_is_none():
+    """Metadata attaches when *either* position is present, so a row can carry
+    an ``event_store`` whose requested field is still ``None`` — that raises."""
+    # `position` is set, so event_store meta is attached, but global_position
+    # is absent. Asking for the global cursor must still raise.
+    message = Message.deserialize(
+        {"type": "X", "data": {}, "position": 3, "metadata": {"headers": {"id": "1"}}}
+    )
+    assert message.metadata.event_store is not None
+    assert message.metadata.event_store.global_position is None
+
+    with pytest.raises(IncorrectUsageError, match="missing its position"):
+        BaseEventStore._next_cursor(message, by_global_position=True)

--- a/tests/adapters/event_store/message_db_event_store/tests.py
+++ b/tests/adapters/event_store/message_db_event_store/tests.py
@@ -199,3 +199,55 @@ class TestMessageDBEventStore:
         assert head_a >= 0
         assert head_b >= 0
         assert head_a != head_b
+
+    def test_read_all_paging_covers_whole_store(self, test_domain):
+        """read_all pages `$all` past a small page_size, in global order."""
+        store = test_domain.event_store.store
+        metadata = {"domain": {"kind": "EVENT"}}
+        for i in range(12):
+            store._write("testStream-123", "Event1", {"n": i}, metadata)
+
+        paged = list(store.read_all("$all", page_size=5))
+        gpos = [m.metadata.event_store.global_position for m in paged]
+
+        assert len(gpos) == 12  # nothing truncated across page boundaries
+        assert gpos == sorted(gpos)  # global_position order
+        assert len(set(gpos)) == 12  # no duplicates at the boundaries
+
+    def test_read_all_paging_exact_multiple_of_page_size(self, test_domain):
+        """A store sized to an exact multiple of page_size returns every row once.
+
+        The final full page is followed by an empty page: the boundary a
+        partial-page test never exercises.
+        """
+        store = test_domain.event_store.store
+        metadata = {"domain": {"kind": "EVENT"}}
+        for i in range(10):
+            store._write("testStream-123", "Event1", {"n": i}, metadata)
+
+        paged = list(store.read_all("$all", page_size=5))
+        gpos = [m.metadata.event_store.global_position for m in paged]
+
+        assert len(gpos) == 10
+        assert gpos == sorted(gpos)
+        assert len(set(gpos)) == 10
+
+    def test_read_all_paging_specific_stream_by_position(self, test_domain):
+        """A specific stream pages by its per-stream position, no leak."""
+        store = test_domain.event_store.store
+        metadata = {"domain": {"kind": "EVENT"}}
+        for i in range(7):
+            store._write("testStream-123", "Event1", {"n": i}, metadata)
+        # A sibling stream in the same category must not leak into the read.
+        for i in range(4):
+            store._write("testStream-456", "Event1", {"n": i}, metadata)
+
+        paged = list(store.read_all("testStream-123", page_size=3))
+        positions = [m.metadata.event_store.position for m in paged]
+
+        assert positions == list(range(7))
+
+    def test_read_all_paging_empty_store_yields_nothing(self, test_domain):
+        """An empty store yields nothing."""
+        store = test_domain.event_store.store
+        assert list(store.read_all("$all", page_size=5)) == []

--- a/tests/projection_rebuild/test_rebuild_edge_cases.py
+++ b/tests/projection_rebuild/test_rebuild_edge_cases.py
@@ -74,6 +74,40 @@ class TestLargeEventCount:
         assert balance is not None
         assert balance.balance == 25.0
 
+    def test_paged_rebuild_matches_single_page_rebuild(self, test_domain):
+        """A rebuild that pages (small batch_size) yields the same projection
+        state as one that reads every event in a single page.
+
+        The rebuilder reads each category through ``read_all``; a small page
+        size forces many page boundaries. If paging dropped or double-counted an
+        event across a boundary, the balance would drift from the single-page
+        result.
+        """
+        user = User.register(email="pager@example.com", name="Pager")
+        current_domain.repository_for(User).add(user)
+
+        count = 25
+        for _i in range(count):
+            txn = Transaction.transact(user_id=user.id, amount=1.0)
+            current_domain.repository_for(Transaction).add(txn)
+
+        # One page holds every event.
+        test_domain.rebuild_projection(Balances, batch_size=1_000)
+        single_page = current_domain.repository_for(Balances).get(user.id).balance
+
+        # A small page forces read_all across many page boundaries. Pin the
+        # premise so a future change to `count` cannot quietly collapse this to
+        # a single page and prove nothing.
+        paged_batch = 4
+        assert count > paged_batch
+        result = test_domain.rebuild_projection(Balances, batch_size=paged_batch)
+        paged = current_domain.repository_for(Balances).get(user.id).balance
+
+        assert result.success
+        # 1 Registered + `count` Transacted, dispatched exactly once each.
+        assert result.events_dispatched == count + 1
+        assert paged == single_page == float(count)
+
 
 class TestCacheBackedProjectionTruncation:
     def test_truncate_uses_cache_when_cache_backed(self):


### PR DESCRIPTION
## Summary

Whole-store reads used a `no_of_messages=1_000_000` sentinel that silently truncates past the read cap. This adds `read_all` on `BaseEventStore`, a generator that pages through a stream in bounded batches, and switches the projection rebuilder to it.

- `read_all(stream="$all", *, page_size=1000)` loops `read`, advances the cursor one past the last row, and stops on a short page. The cursor field follows ADR-0024: `global_position` for `$all` and category reads, per-stream `position` for a specific `category-id` stream. Reads are inclusive, so resuming at `last + 1` avoids re-emitting the boundary row and skips none.
- A non-positive or non-integer `page_size` raises `IncorrectUsageError` before any read.
- The projection rebuilder reads each category through `read_all`, so a rebuild over a store larger than the old cap replays completely. `batch_size` now sets the page size (it was passed through but unused in the read before).

The iterator lives on the port and drives the existing `read`, so both adapters share it with no adapter method changes (ADR-0024 already made their paging semantics agree).

## Scope

Per the epic's decision, only the readers that must be complete are switched. The projection rebuilder is done here; the backup and verify readers come later in the epic. The remaining sentinel readers (causation tracing in the port, the `protean events` CLI, the observatory timeline) are left as they are.

## Test plan

- [x] Memory paging tests: cross-boundary no gaps/dups, exact page-size multiple (with a read-count assertion), `page_size=1`, empty-stream single read, specific-stream by per-stream position (including interleaved writes), category excludes other categories, `$all` default, invalid `page_size`.
- [x] `_next_cursor` guard: a row missing its position raises instead of looping (covers the former `# pragma: no cover` branch).
- [x] MessageDB paging tests (marker-gated), run against the real MessageDB: whole-store, exact multiple, specific stream, empty store.
- [x] Rebuild-equivalence: a paged rebuild (small `batch_size`, many page boundaries) produces the same projection state as a single-page rebuild.
- [x] Revert-test: injecting single-page truncation turns the completeness tests and the rebuild-equivalence test red.
- [x] Core suite, memory + MessageDB event-store legs, ruff, mypy, 100% patch coverage.

Closes #1358
