### PR TITLE
Add the ChangePlan schema and read-only preview

### DIFF
--- a/changes/1327.added.md
+++ b/changes/1327.added.md
@@ -1,0 +1,1 @@
+Added a `protean.scaffold` package with a versioned `ChangePlan`: a serializable, previewable description of a change (create-file, edit-file, and structured config operations) that round-trips through JSON and renders a read-only preview without touching the filesystem.

--- a/docs/adr/0033-change-plan-versioned-structural-contract.md
+++ b/docs/adr/0033-change-plan-versioned-structural-contract.md
@@ -47,10 +47,14 @@ The plan follows the existing serialization house style, matching `protean.ir`: 
 frozen dataclass serialized by an explicit `to_dict`/`from_dict` JSON dump, not
 pydantic (pydantic is reserved for domain elements). The serialized form carries a
 `plan_version` marker, and a versioned JSON Schema lives at
-`schema/v<version>/schema.json`, starting at `0.1.0`. `from_dict` rejects a
-`plan_version` it does not understand, an unknown operation `kind`, and any
-missing required field with a clear `ValueError`, the same way `load_config` and
-`load_stored_ir` reject malformed input.
+`schema/v<version>/schema.json`, starting at `0.1.0`. The schema pins
+`plan_version` to its own version with `const`, so validating a plan against the
+wrong schema fails there too, not just in `from_dict`. `from_dict` rejects a
+`plan_version` it does not understand, a non-object entry in `operations`, an
+unknown operation `kind`, and any missing or wrongly-typed required field with a
+clear `ValueError`, the same way `load_config` and `load_stored_ir` reject
+malformed input. `to_json` sorts its keys, so the same plan always serializes to
+the same bytes and previews and stored plans diff cleanly.
 
 Preview is read-only and separate from an operation's representation. A
 `render_preview(plan)` function builds a human-readable summary as pure strings: a
@@ -69,8 +73,9 @@ that writes `domain.toml` lands with the config applier, not now.
 - The preview is safe to run anywhere: it is provably read-only, so it needs no
   confirmation and no rollback.
 - Versioning the schema means an old build meeting a newer plan fails loudly
-  instead of silently misapplying it. The cost is that `plan_version` and the
-  JSON Schema must be bumped together whenever the shape changes.
+  instead of silently misapplying it. The cost is that `PLAN_VERSION`, the schema
+  directory name, and the schema's `plan_version` const must all be bumped
+  together whenever the shape changes.
 - Keeping config structured means the applier works against parsed config, not
   text, so a reformatted or commented `domain.toml` cannot break a config edit.
   The cost is that config is not one uniform "diff" with file edits; a renderer

--- a/docs/adr/0033-change-plan-versioned-structural-contract.md
+++ b/docs/adr/0033-change-plan-versioned-structural-contract.md
@@ -1,0 +1,92 @@
+# ADR-0033: ChangePlan is a Versioned Structural Contract
+
+**Status:** Accepted
+
+**Date:** August 2026
+
+## Context
+
+Commands that change a project on the user's behalf (a deterministic `add`, a
+versioned upgrade) need a shape for "a proposed change." Without it, a command
+cannot show what it would do, ask for confirmation, and then apply the same thing
+it showed. The change has to be data first: something you can build, print, diff,
+store, and only later execute.
+
+Two properties matter. The change must be **inert until applied**: producing it
+touches no files, so a preview is safe to run and a plan is safe to pass around.
+And the change is a **contract between producers and a consumer that ship on
+different schedules**: the `add` engine and versioned upgrades both emit plans,
+and an applier (a later epic) executes them. A contract read by code that was
+written against a different version of it has to fail loudly rather than
+misread, so the shape is versioned.
+
+The `add`/change machinery is neither IR nor CLI glue, so it gets its own package,
+`protean.scaffold`, that later scaffolding work populates.
+
+## Decision
+
+We define a `ChangePlan`: an ordered tuple of operations plus an optional
+description, homed in `protean.scaffold`.
+
+The operation set is a discriminated union tagged by a `kind` field, with three
+variants:
+
+- **create** (`kind="create"`) carries a `path` and the whole file `content`.
+- **edit** (`kind="edit"`) carries a `path` and a `diff`, a unified-diff string.
+  Unified diff is reviewable and standard; a structural (LibCST) applier can come
+  with the patch engine later without changing this shape.
+- **config** (`kind="config"`) is a **structured** key-path set/merge over
+  `domain.toml`: an ordered `key_path` (e.g. `("databases", "default",
+  "provider")`), a `value`, and an `operation` of `"set"` or `"merge"`. Config is
+  structured data, not a text diff. A line-context diff over a reformatted,
+  commented `domain.toml` breaks easily on the one operation `add` runs most, and
+  it would contradict the tomlkit-for-config direction the program has already
+  committed to.
+
+The plan follows the existing serialization house style, matching `protean.ir`: a
+frozen dataclass serialized by an explicit `to_dict`/`from_dict` JSON dump, not
+pydantic (pydantic is reserved for domain elements). The serialized form carries a
+`plan_version` marker, and a versioned JSON Schema lives at
+`schema/v<version>/schema.json`, starting at `0.1.0`. `from_dict` rejects a
+`plan_version` it does not understand, an unknown operation `kind`, and any
+missing required field with a clear `ValueError`, the same way `load_config` and
+`load_stored_ir` reject malformed input.
+
+Preview is read-only and separate from an operation's representation. A
+`render_preview(plan)` function builds a human-readable summary as pure strings: a
+create shows a header plus its content, an edit shows its unified diff, and a
+config op shows `key.path = value  (set|merge)`. The renderer opens, stats, and
+creates nothing.
+
+Applying a plan is out of scope here. This issue defines the shape and the
+preview; the transactional applier is a later epic, and the `tomlkit` dependency
+that writes `domain.toml` lands with the config applier, not now.
+
+## Consequences
+
+- A command can build one `ChangePlan`, preview it, and hand the same object to an
+  applier, so show and apply stay in sync because they read one shape.
+- The preview is safe to run anywhere: it is provably read-only, so it needs no
+  confirmation and no rollback.
+- Versioning the schema means an old build meeting a newer plan fails loudly
+  instead of silently misapplying it. The cost is that `plan_version` and the
+  JSON Schema must be bumped together whenever the shape changes.
+- Keeping config structured means the applier works against parsed config, not
+  text, so a reformatted or commented `domain.toml` cannot break a config edit.
+  The cost is that config is not one uniform "diff" with file edits; a renderer
+  and an applier each special-case it.
+- Deferring the applier leaves a shape with no executor in this epic. That is
+  deliberate: the contract is designed alongside its first consumer (the `add`
+  engine) rather than in isolation.
+
+## Alternatives Considered
+
+- **A text diff for config.** Rejected: a line-context diff over a reformatted,
+  commented `domain.toml` is fragile, and it contradicts the committed
+  tomlkit-for-config direction. Config stays structured.
+- **pydantic models for the plan.** Rejected for consistency: the IR
+  serialization house style is frozen dataclasses with an explicit JSON dump.
+  pydantic is reserved for domain elements.
+- **One combined "file operation" covering create and edit.** Rejected: a create
+  carries whole content and an edit carries a diff; they are different shapes, and
+  a discriminated union keeps each one's required fields honest.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -104,3 +104,4 @@ See `TEMPLATE.md` in the `adr/` directory for the ADR template.
 | [0030](0030-canonical-project-layout.md) | Canonical Generated Project Layout |
 | [0031](0031-handlers-persist-or-call-out.md) | A Handler Method Persists or Calls Out, Never Both |
 | [0032](0032-annotation-file-for-the-event-model.md) | Annotation File for the Event Model Renderer |
+| [0033](0033-change-plan-versioned-structural-contract.md) | ChangePlan is a Versioned Structural Contract |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -432,6 +432,7 @@ nav:
       - adr/0030-canonical-project-layout.md
       - adr/0031-handlers-persist-or-call-out.md
       - adr/0032-annotation-file-for-the-event-model.md
+      - adr/0033-change-plan-versioned-structural-contract.md
     - Troubleshooting:
       - reference/troubleshooting.md
 

--- a/src/protean/scaffold/__init__.py
+++ b/src/protean/scaffold/__init__.py
@@ -1,0 +1,55 @@
+"""Protean scaffold — the change/add machinery.
+
+Homes the shape a command like ``add`` or an upgrade uses to describe a proposed
+change: a :class:`ChangePlan` of ordered operations (create a file, edit a file,
+patch config), serializable to JSON, previewable without touching the
+filesystem. A plan is inert; a separate applier (a later epic) executes it.
+
+The schema is versioned as a structural contract. ``SCHEMA_VERSION``,
+``SCHEMA_PATH``, and :func:`load_schema` expose the JSON Schema the serialized
+plan validates against, the same way ``protean.ir`` does.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from protean.scaffold.change_plan import (
+    PLAN_VERSION,
+    ChangePlan,
+    ConfigOperation,
+    CreateFileOperation,
+    EditFileOperation,
+    Operation,
+)
+from protean.scaffold.preview import render_preview
+
+__all__ = [
+    "PLAN_VERSION",
+    "SCHEMA_PATH",
+    "SCHEMA_VERSION",
+    "ChangePlan",
+    "ConfigOperation",
+    "CreateFileOperation",
+    "EditFileOperation",
+    "Operation",
+    "load_schema",
+    "render_preview",
+]
+
+# The JSON Schema version tracks the serialized plan shape and stays in
+# lock-step with ``PLAN_VERSION``.
+SCHEMA_VERSION = PLAN_VERSION
+
+_SCAFFOLD_DIR = Path(__file__).parent
+SCHEMA_PATH = _SCAFFOLD_DIR / "schema" / f"v{SCHEMA_VERSION}" / "schema.json"
+
+
+def load_schema() -> dict[str, Any]:
+    """Load and return the ChangePlan JSON Schema as a Python dict."""
+    # json.loads is untyped (returns Any); annotate the local to hold the
+    # declared return type.
+    schema: dict[str, Any] = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    return schema

--- a/src/protean/scaffold/change_plan.py
+++ b/src/protean/scaffold/change_plan.py
@@ -143,16 +143,18 @@ def _operation_from_dict(data: dict[str, Any]) -> Operation:
 
     if kind == _KIND_CREATE:
         return CreateFileOperation(
-            path=_require(data, "path", kind),
-            content=_require(data, "content", kind),
+            path=_require_str(data, "path", kind),
+            content=_require_str(data, "content", kind),
         )
     if kind == _KIND_EDIT:
         return EditFileOperation(
-            path=_require(data, "path", kind),
-            diff=_require(data, "diff", kind),
+            path=_require_str(data, "path", kind),
+            diff=_require_str(data, "diff", kind),
         )
     if kind == _KIND_CONFIG:
-        key_path = _require(data, "key_path", kind)
+        if "key_path" not in data:
+            raise ValueError("config operation is missing required field 'key_path'")
+        key_path = data["key_path"]
         if not isinstance(key_path, list) or not all(
             isinstance(seg, str) for seg in key_path
         ):
@@ -172,11 +174,23 @@ def _operation_from_dict(data: dict[str, Any]) -> Operation:
     raise ValueError(f"Unknown operation kind: {kind!r}")
 
 
-def _require(data: dict[str, Any], key: str, kind: str) -> Any:
-    """Return ``data[key]`` or raise a clear :exc:`ValueError` naming *kind*."""
+def _require_str(data: dict[str, Any], key: str, kind: str) -> str:
+    """Return ``data[key]`` as a string, or raise a clear :exc:`ValueError`.
+
+    Checks both presence and type, so ``from_dict`` is at least as strict as the
+    JSON Schema, which marks ``path``/``content``/``diff`` as ``type: string``. A
+    ``None`` or numeric value is rejected here rather than surfacing later as an
+    ``AttributeError`` in the preview renderer.
+    """
     if key not in data:
         raise ValueError(f"{kind!r} operation is missing required field {key!r}")
-    return data[key]
+    value = data[key]
+    if not isinstance(value, str):
+        raise ValueError(
+            f"{kind!r} operation field {key!r} must be a string, "
+            f"got {type(value).__name__}"
+        )
+    return value
 
 
 @dataclass(frozen=True)

--- a/src/protean/scaffold/change_plan.py
+++ b/src/protean/scaffold/change_plan.py
@@ -132,11 +132,20 @@ class ConfigOperation:
 Operation = CreateFileOperation | EditFileOperation | ConfigOperation
 
 
-def _operation_from_dict(data: dict[str, Any]) -> Operation:
+def _operation_from_dict(data: Any) -> Operation:
     """Reconstruct one operation from its serialized dict, dispatching on ``kind``.
 
-    Raises :exc:`ValueError` on an unknown ``kind`` or a missing required field.
+    *data* is typed ``Any`` because it arrives straight off ``json.loads``. An
+    entry that is not an object at all is rejected here with a clear
+    :exc:`ValueError` rather than blowing up as a :exc:`TypeError`.
+
+    Raises :exc:`ValueError` on a non-object entry, an unknown ``kind``, or a
+    missing required field.
     """
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"Each entry in 'operations' must be an object, got {type(data).__name__}"
+        )
     if "kind" not in data:
         raise ValueError("Operation is missing its 'kind' discriminator")
     kind = data["kind"]
@@ -220,8 +229,14 @@ class ChangePlan:
         return result
 
     def to_json(self, *, indent: int | None = None) -> str:
-        """Serialize to a JSON string."""
-        return json.dumps(self.to_dict(), indent=indent)
+        """Serialize to a JSON string with keys sorted.
+
+        Plans are meant to be previewed and diffed, so the output has to be
+        stable: the same plan always serializes to the same bytes, whatever
+        order the producer happened to build its dicts in. This follows the IR
+        serializers, which all emit with ``sort_keys=True``.
+        """
+        return json.dumps(self.to_dict(), indent=indent, sort_keys=True)
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ChangePlan:

--- a/src/protean/scaffold/change_plan.py
+++ b/src/protean/scaffold/change_plan.py
@@ -1,0 +1,252 @@
+"""The ``ChangePlan`` type — a serializable, previewable description of a change.
+
+A :class:`ChangePlan` is an ordered list of operations that a command like
+``add`` or an upgrade would make to a project: create a file, edit a file, or
+patch config. A plan is inert data. Producing one makes no filesystem change; a
+separate applier (a later epic) executes it.
+
+The plan follows the IR serialization house style: frozen dataclasses serialized
+by an explicit ``to_dict``/``from_dict`` JSON dump, with a version marker
+(``plan_version``) carried on the serialized form. No pydantic here; pydantic is
+reserved for domain elements.
+
+Operations are a discriminated union tagged by a ``kind`` field:
+
+- ``"create"`` (:class:`CreateFileOperation`) — a new file, carrying its whole
+  ``content``.
+- ``"edit"`` (:class:`EditFileOperation`) — an edit to an existing file, carried
+  as a unified-diff string.
+- ``"config"`` (:class:`ConfigOperation`) — a structured key-path set/merge over
+  ``domain.toml``. Config is structured data, never a text diff.
+
+Usage::
+
+    from protean.scaffold import ChangePlan, CreateFileOperation
+
+    plan = ChangePlan(
+        operations=(
+            CreateFileOperation(path="app/domain.py", content="from protean ..."),
+        ),
+        description="Scaffold the domain module",
+    )
+    payload = plan.to_json()
+    restored = ChangePlan.from_json(payload)
+    assert restored == plan
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+__all__ = [
+    "PLAN_VERSION",
+    "ChangePlan",
+    "ConfigOperation",
+    "CreateFileOperation",
+    "EditFileOperation",
+    "Operation",
+]
+
+# The version marker carried on every serialized plan. Bumped when the
+# serialized shape changes incompatibly; a plan_version the code does not
+# understand is rejected loudly by ``from_dict``. Kept in lock-step with the
+# JSON Schema under ``schema/v<PLAN_VERSION>/schema.json``.
+PLAN_VERSION = "0.1.0"
+
+# Discriminator tags for the operation union. A serialized operation carries its
+# tag under the ``kind`` key.
+_KIND_CREATE = "create"
+_KIND_EDIT = "edit"
+_KIND_CONFIG = "config"
+
+# Valid values for a config op's ``operation`` field.
+_CONFIG_OPERATIONS = frozenset({"set", "merge"})
+
+
+@dataclass(frozen=True)
+class CreateFileOperation:
+    """Create a new file at *path*, carrying its whole *content*."""
+
+    path: str
+    content: str
+    kind: str = field(default=_KIND_CREATE, init=False)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-ready dict, tagged with ``kind``."""
+        return {"kind": _KIND_CREATE, "path": self.path, "content": self.content}
+
+
+@dataclass(frozen=True)
+class EditFileOperation:
+    """Edit an existing file at *path*, carried as a unified-diff string."""
+
+    path: str
+    diff: str
+    kind: str = field(default=_KIND_EDIT, init=False)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-ready dict, tagged with ``kind``."""
+        return {"kind": _KIND_EDIT, "path": self.path, "diff": self.diff}
+
+
+@dataclass(frozen=True)
+class ConfigOperation:
+    """Set or merge a value at a key path in ``domain.toml``.
+
+    Config is structured, never a text diff. ``key_path`` is the ordered
+    sequence of key segments (e.g. ``("databases", "default", "provider")``),
+    ``value`` is the JSON value to set or merge, and ``operation`` is ``"set"``
+    or ``"merge"``.
+    """
+
+    key_path: tuple[str, ...]
+    value: Any
+    operation: str = "set"
+    kind: str = field(default=_KIND_CONFIG, init=False)
+
+    def __post_init__(self) -> None:
+        if self.operation not in _CONFIG_OPERATIONS:
+            raise ValueError(
+                f"Invalid config operation: {self.operation!r}. "
+                f"Must be one of: {', '.join(sorted(_CONFIG_OPERATIONS))}"
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-ready dict, tagged with ``kind``.
+
+        ``key_path`` is a tuple in Python but serializes to a JSON array; it is
+        restored to a tuple by :meth:`ChangePlan.from_dict`.
+        """
+        return {
+            "kind": _KIND_CONFIG,
+            "key_path": list(self.key_path),
+            "value": self.value,
+            "operation": self.operation,
+        }
+
+
+# The operation union. A plan holds an ordered tuple of these; an applier
+# executes them in sequence.
+Operation = CreateFileOperation | EditFileOperation | ConfigOperation
+
+
+def _operation_from_dict(data: dict[str, Any]) -> Operation:
+    """Reconstruct one operation from its serialized dict, dispatching on ``kind``.
+
+    Raises :exc:`ValueError` on an unknown ``kind`` or a missing required field.
+    """
+    if "kind" not in data:
+        raise ValueError("Operation is missing its 'kind' discriminator")
+    kind = data["kind"]
+
+    if kind == _KIND_CREATE:
+        return CreateFileOperation(
+            path=_require(data, "path", kind),
+            content=_require(data, "content", kind),
+        )
+    if kind == _KIND_EDIT:
+        return EditFileOperation(
+            path=_require(data, "path", kind),
+            diff=_require(data, "diff", kind),
+        )
+    if kind == _KIND_CONFIG:
+        key_path = _require(data, "key_path", kind)
+        if not isinstance(key_path, list) or not all(
+            isinstance(seg, str) for seg in key_path
+        ):
+            raise ValueError(
+                "config operation 'key_path' must be a list of string segments"
+            )
+        # ``value`` is required but may legitimately be null/false/0, so check
+        # for presence rather than truthiness.
+        if "value" not in data:
+            raise ValueError("config operation is missing required field 'value'")
+        return ConfigOperation(
+            key_path=tuple(key_path),
+            value=data["value"],
+            operation=data.get("operation", "set"),
+        )
+
+    raise ValueError(f"Unknown operation kind: {kind!r}")
+
+
+def _require(data: dict[str, Any], key: str, kind: str) -> Any:
+    """Return ``data[key]`` or raise a clear :exc:`ValueError` naming *kind*."""
+    if key not in data:
+        raise ValueError(f"{kind!r} operation is missing required field {key!r}")
+    return data[key]
+
+
+@dataclass(frozen=True)
+class ChangePlan:
+    """An ordered, serializable description of a change.
+
+    Attributes
+    ----------
+    operations:
+        The operations to apply, in order. An applier executes them in
+        sequence, so position is semantic.
+    description:
+        An optional human-readable summary of the plan.
+    """
+
+    operations: tuple[Operation, ...] = ()
+    description: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-ready dict, carrying the ``plan_version`` marker."""
+        result: dict[str, Any] = {
+            "plan_version": PLAN_VERSION,
+            "operations": [op.to_dict() for op in self.operations],
+        }
+        if self.description is not None:
+            result["description"] = self.description
+        return result
+
+    def to_json(self, *, indent: int | None = None) -> str:
+        """Serialize to a JSON string."""
+        return json.dumps(self.to_dict(), indent=indent)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ChangePlan:
+        """Reconstruct a :class:`ChangePlan` from its serialized dict.
+
+        Raises :exc:`ValueError` on a ``plan_version`` the code does not
+        understand, on a missing ``operations`` list, on an unknown operation
+        ``kind``, or on a missing required field. A corrupt or newer plan fails
+        loud rather than parsing best-effort.
+        """
+        version = data.get("plan_version")
+        if version != PLAN_VERSION:
+            raise ValueError(
+                f"Unsupported plan_version: {version!r}. "
+                f"This build understands {PLAN_VERSION!r}."
+            )
+
+        raw_operations = data.get("operations")
+        if not isinstance(raw_operations, list):
+            raise ValueError("ChangePlan 'operations' must be a list")
+
+        operations = tuple(_operation_from_dict(op) for op in raw_operations)
+
+        description = data.get("description")
+        if description is not None and not isinstance(description, str):
+            raise ValueError("ChangePlan 'description' must be a string or omitted")
+
+        return cls(operations=operations, description=description)
+
+    @classmethod
+    def from_json(cls, payload: str) -> ChangePlan:
+        """Reconstruct a :class:`ChangePlan` from a JSON string.
+
+        Raises :exc:`ValueError` on invalid JSON or a malformed plan.
+        """
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid ChangePlan JSON: {exc}") from exc
+        if not isinstance(data, dict):
+            raise ValueError("A serialized ChangePlan must be a JSON object")
+        return cls.from_dict(data)

--- a/src/protean/scaffold/change_plan.py
+++ b/src/protean/scaffold/change_plan.py
@@ -242,11 +242,14 @@ class ChangePlan:
     def from_dict(cls, data: dict[str, Any]) -> ChangePlan:
         """Reconstruct a :class:`ChangePlan` from its serialized dict.
 
-        Raises :exc:`ValueError` on a ``plan_version`` the code does not
-        understand, on a missing ``operations`` list, on an unknown operation
-        ``kind``, or on a missing required field. A corrupt or newer plan fails
-        loud rather than parsing best-effort.
+        Raises :exc:`ValueError` on a non-object payload, on a ``plan_version``
+        the code does not understand, on a missing ``operations`` list, on an
+        unknown operation ``kind``, or on a missing required field. A corrupt or
+        newer plan fails loud rather than parsing best-effort.
         """
+        if not isinstance(data, dict):
+            raise ValueError("A serialized ChangePlan must be a mapping")
+
         version = data.get("plan_version")
         if version != PLAN_VERSION:
             raise ValueError(

--- a/src/protean/scaffold/preview.py
+++ b/src/protean/scaffold/preview.py
@@ -1,0 +1,76 @@
+"""Read-only preview rendering for a :class:`~protean.scaffold.ChangePlan`.
+
+:func:`render_preview` turns a plan into a human-readable summary of what would
+change. It touches no files: every path is handled as a plain string, and the
+renderer never opens, stats, or creates anything. The rendering is a separate
+concern from an operation's representation — a create shows a header plus its
+content, an edit shows its unified diff, and a config op shows ``key.path =
+value  (set|merge)``.
+"""
+
+from __future__ import annotations
+
+import json
+
+from protean.scaffold.change_plan import (
+    ChangePlan,
+    ConfigOperation,
+    CreateFileOperation,
+    EditFileOperation,
+    Operation,
+)
+
+__all__ = ["render_preview"]
+
+
+def render_preview(plan: ChangePlan) -> str:
+    """Render *plan* as a human-readable summary. Touches no files.
+
+    An empty plan renders a single "no operations" line. Otherwise each
+    operation is rendered as its own block, in plan order.
+    """
+    lines: list[str] = ["Change plan"]
+    if plan.description is not None:
+        lines.append(f"  {plan.description}")
+
+    if not plan.operations:
+        lines.append("")
+        lines.append("(no operations)")
+        return "\n".join(lines)
+
+    for index, operation in enumerate(plan.operations, start=1):
+        lines.append("")
+        lines.extend(_render_operation(index, operation))
+
+    return "\n".join(lines)
+
+
+def _render_operation(index: int, operation: Operation) -> list[str]:
+    """Render a single operation as a labelled block of lines."""
+    if isinstance(operation, CreateFileOperation):
+        return _render_create(index, operation)
+    if isinstance(operation, EditFileOperation):
+        return _render_edit(index, operation)
+    if isinstance(operation, ConfigOperation):
+        return _render_config(index, operation)
+    # The union is closed; a new variant must add a branch here.
+    raise ValueError(f"Cannot render unknown operation: {operation!r}")
+
+
+def _render_create(index: int, operation: CreateFileOperation) -> list[str]:
+    line_count = operation.content.count("\n") + 1 if operation.content else 0
+    header = f"{index}. create {operation.path}  ({line_count} lines)"
+    body = [f"    {line}" for line in operation.content.splitlines()]
+    return [header, *body]
+
+
+def _render_edit(index: int, operation: EditFileOperation) -> list[str]:
+    header = f"{index}. edit {operation.path}"
+    body = [f"    {line}" for line in operation.diff.splitlines()]
+    return [header, *body]
+
+
+def _render_config(index: int, operation: ConfigOperation) -> list[str]:
+    key = ".".join(operation.key_path)
+    value = json.dumps(operation.value)
+    return [f"{index}. config {key} = {value}  ({operation.operation})"]

--- a/src/protean/scaffold/preview.py
+++ b/src/protean/scaffold/preview.py
@@ -70,5 +70,7 @@ def _render_edit(index: int, operation: EditFileOperation) -> list[str]:
 
 def _render_config(index: int, operation: ConfigOperation) -> list[str]:
     key = ".".join(operation.key_path)
-    value = json.dumps(operation.value)
+    # sort_keys so a dict-valued config op renders the same way every time,
+    # whatever order the producer built it in. Previews get diffed.
+    value = json.dumps(operation.value, sort_keys=True)
     return [f"{index}. config {key} = {value}  ({operation.operation})"]

--- a/src/protean/scaffold/preview.py
+++ b/src/protean/scaffold/preview.py
@@ -51,16 +51,14 @@ def _render_operation(index: int, operation: Operation) -> list[str]:
         return _render_create(index, operation)
     if isinstance(operation, EditFileOperation):
         return _render_edit(index, operation)
-    if isinstance(operation, ConfigOperation):
-        return _render_config(index, operation)
-    # The union is closed; a new variant must add a branch here.
-    raise ValueError(f"Cannot render unknown operation: {operation!r}")
+    # The union is closed; mypy narrows the remainder to ConfigOperation, so a new
+    # variant must add a branch above or the type check fails.
+    return _render_config(index, operation)
 
 
 def _render_create(index: int, operation: CreateFileOperation) -> list[str]:
-    line_count = operation.content.count("\n") + 1 if operation.content else 0
-    header = f"{index}. create {operation.path}  ({line_count} lines)"
     body = [f"    {line}" for line in operation.content.splitlines()]
+    header = f"{index}. create {operation.path}  ({len(body)} lines)"
     return [header, *body]
 
 

--- a/src/protean/scaffold/schema/v0.1.0/schema.json
+++ b/src/protean/scaffold/schema/v0.1.0/schema.json
@@ -7,8 +7,8 @@
   "type": "object",
   "properties": {
     "plan_version": {
-      "type": "string",
-      "description": "Semantic version of the ChangePlan format"
+      "const": "0.1.0",
+      "description": "Semantic version of the ChangePlan format. Pinned so a plan written for a different version fails validation here instead of being read against the wrong schema."
     },
     "description": {
       "type": "string",

--- a/src/protean/scaffold/schema/v0.1.0/schema.json
+++ b/src/protean/scaffold/schema/v0.1.0/schema.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://protean.dev/scaffold/v0.1.0/schema.json",
+  "title": "Protean ChangePlan v0.1.0",
+  "description": "A serializable, previewable description of a change: an ordered list of operations (create a file, edit a file, patch config) that a command like `add` or an upgrade would apply.",
+
+  "type": "object",
+  "properties": {
+    "plan_version": {
+      "type": "string",
+      "description": "Semantic version of the ChangePlan format"
+    },
+    "description": {
+      "type": "string",
+      "description": "Optional human-readable summary of the plan"
+    },
+    "operations": {
+      "type": "array",
+      "description": "The operations to apply, in order; position is semantic",
+      "items": {
+        "$ref": "#/$defs/operation"
+      }
+    }
+  },
+  "required": ["plan_version", "operations"],
+  "additionalProperties": false,
+
+  "$defs": {
+    "operation": {
+      "oneOf": [
+        { "$ref": "#/$defs/create_operation" },
+        { "$ref": "#/$defs/edit_operation" },
+        { "$ref": "#/$defs/config_operation" }
+      ]
+    },
+
+    "create_operation": {
+      "type": "object",
+      "description": "Create a new file carrying its whole content",
+      "properties": {
+        "kind": { "const": "create" },
+        "path": {
+          "type": "string",
+          "description": "Target path of the file to create"
+        },
+        "content": {
+          "type": "string",
+          "description": "Full content of the new file"
+        }
+      },
+      "required": ["kind", "path", "content"],
+      "additionalProperties": false
+    },
+
+    "edit_operation": {
+      "type": "object",
+      "description": "Edit an existing file, carried as a unified-diff string",
+      "properties": {
+        "kind": { "const": "edit" },
+        "path": {
+          "type": "string",
+          "description": "Target path of the file to edit"
+        },
+        "diff": {
+          "type": "string",
+          "description": "Unified diff describing the edit"
+        }
+      },
+      "required": ["kind", "path", "diff"],
+      "additionalProperties": false
+    },
+
+    "config_operation": {
+      "type": "object",
+      "description": "A structured set/merge over a key path in domain.toml (never a text diff)",
+      "properties": {
+        "kind": { "const": "config" },
+        "key_path": {
+          "type": "array",
+          "description": "Ordered key segments identifying the target, e.g. [\"databases\", \"default\", \"provider\"]",
+          "items": { "type": "string" }
+        },
+        "value": {
+          "description": "The JSON value to set or merge"
+        },
+        "operation": {
+          "type": "string",
+          "enum": ["set", "merge"],
+          "description": "Whether to set (replace) or merge the value"
+        }
+      },
+      "required": ["kind", "key_path", "value", "operation"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/protean/scaffold/schema/v0.1.0/schema.json
+++ b/src/protean/scaffold/schema/v0.1.0/schema.json
@@ -86,10 +86,10 @@
         "operation": {
           "type": "string",
           "enum": ["set", "merge"],
-          "description": "Whether to set (replace) or merge the value"
+          "description": "Whether to set (replace) or merge the value; optional, defaults to set"
         }
       },
-      "required": ["kind", "key_path", "value", "operation"],
+      "required": ["kind", "key_path", "value"],
       "additionalProperties": false
     }
   }

--- a/tests/scaffold/test_change_plan.py
+++ b/tests/scaffold/test_change_plan.py
@@ -1,7 +1,7 @@
 """Tests for the ChangePlan type: JSON round-trip, schema, and loud errors."""
 
 import pytest
-from jsonschema import validate
+from jsonschema import ValidationError, validate
 
 from protean.scaffold import (
     PLAN_VERSION,
@@ -102,6 +102,33 @@ def test_empty_plan_round_trips():
     assert ChangePlan.from_json(plan.to_json()) == plan
 
 
+def test_to_json_emits_keys_in_sorted_order():
+    # Plans are previewed and diffed, so serialization must be byte-stable
+    # regardless of the order a producer inserted keys.
+    plan = ChangePlan(
+        operations=(
+            ConfigOperation(key_path=("a",), value={"z": 1, "a": 2}, operation="merge"),
+        ),
+        description="d",
+    )
+
+    payload = plan.to_json()
+
+    assert payload.index('"description"') < payload.index('"operations"')
+    assert payload.index('"operations"') < payload.index('"plan_version"')
+    assert '{"a": 2, "z": 1}' in payload
+
+
+def test_to_json_is_stable_across_differently_ordered_equal_plans():
+    left = ChangePlan(
+        operations=(ConfigOperation(key_path=("a",), value={"x": 1, "y": 2}),)
+    )
+    right = ChangePlan(
+        operations=(ConfigOperation(key_path=("a",), value={"y": 2, "x": 1}),)
+    )
+    assert left.to_json() == right.to_json()
+
+
 def test_description_is_omitted_when_absent():
     plan = ChangePlan(operations=(CreateFileOperation(path="a.py", content="x"),))
     assert "description" not in plan.to_dict()
@@ -148,6 +175,20 @@ def test_schema_version_matches_plan_version():
     assert SCHEMA_VERSION == PLAN_VERSION
 
 
+def test_schema_pins_plan_version_to_the_supported_version(schema):
+    # The schema is versioned by path, so the const has to track PLAN_VERSION.
+    assert schema["properties"]["plan_version"]["const"] == PLAN_VERSION
+
+
+def test_schema_rejects_a_mismatched_plan_version(schema):
+    # A plan written for another version must fail validation here rather than
+    # being read against the wrong schema.
+    data = _sample_plan().to_dict()
+    data["plan_version"] = "9.9.9"
+    with pytest.raises(ValidationError):
+        validate(instance=data, schema=schema)
+
+
 def test_serialized_plan_validates_against_the_schema(schema):
     validate(instance=_sample_plan().to_dict(), schema=schema)
 
@@ -175,6 +216,23 @@ def test_each_op_kind_validates_against_the_schema(operation, schema):
 def test_from_dict_rejects_an_unknown_kind():
     data = {"plan_version": PLAN_VERSION, "operations": [{"kind": "rename"}]}
     with pytest.raises(ValueError, match="Unknown operation kind"):
+        ChangePlan.from_dict(data)
+
+
+@pytest.mark.parametrize(
+    ("entry", "type_name"),
+    [
+        pytest.param(7, "int", id="int"),
+        pytest.param("create", "str", id="str"),
+        pytest.param(["create", "a.py"], "list", id="list"),
+        pytest.param(None, "NoneType", id="null"),
+    ],
+)
+def test_from_dict_rejects_a_non_object_operation_entry(entry, type_name):
+    # from_dict promises ValueError on malformed input; a non-object entry must
+    # not leak a TypeError from the discriminator lookup.
+    data = {"plan_version": PLAN_VERSION, "operations": [entry]}
+    with pytest.raises(ValueError, match=f"must be an object, got {type_name}"):
         ChangePlan.from_dict(data)
 
 

--- a/tests/scaffold/test_change_plan.py
+++ b/tests/scaffold/test_change_plan.py
@@ -1,0 +1,266 @@
+"""Tests for the ChangePlan type: JSON round-trip, schema, and loud errors."""
+
+import pytest
+from jsonschema import validate
+
+from protean.scaffold import (
+    PLAN_VERSION,
+    SCHEMA_VERSION,
+    ChangePlan,
+    ConfigOperation,
+    CreateFileOperation,
+    EditFileOperation,
+    load_schema,
+)
+
+pytestmark = pytest.mark.no_test_domain
+
+
+@pytest.fixture(scope="module")
+def schema():
+    """Load the ChangePlan JSON Schema once per module."""
+    return load_schema()
+
+
+def _sample_plan() -> ChangePlan:
+    """A plan mixing all three op kinds in a specific order."""
+    return ChangePlan(
+        operations=(
+            CreateFileOperation(path="app/domain.py", content="line1\nline2\n"),
+            EditFileOperation(
+                path="app/config.py",
+                diff="--- a/app/config.py\n+++ b/app/config.py\n@@ -1 +1 @@\n-x\n+y\n",
+            ),
+            ConfigOperation(
+                key_path=("databases", "default", "provider"),
+                value="postgresql",
+                operation="set",
+            ),
+        ),
+        description="A mixed plan",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-operation round-trips
+# ---------------------------------------------------------------------------
+
+
+def test_create_operation_round_trips_through_a_plan():
+    plan = ChangePlan(operations=(CreateFileOperation(path="a.py", content="body"),))
+    assert ChangePlan.from_dict(plan.to_dict()) == plan
+    assert ChangePlan.from_json(plan.to_json()) == plan
+
+
+def test_edit_operation_round_trips_through_a_plan():
+    plan = ChangePlan(operations=(EditFileOperation(path="a.py", diff="@@ diff @@"),))
+    assert ChangePlan.from_dict(plan.to_dict()) == plan
+    assert ChangePlan.from_json(plan.to_json()) == plan
+
+
+def test_config_operation_round_trips_through_a_plan():
+    plan = ChangePlan(
+        operations=(
+            ConfigOperation(key_path=("a", "b"), value={"k": 1}, operation="merge"),
+        )
+    )
+    assert ChangePlan.from_dict(plan.to_dict()) == plan
+    assert ChangePlan.from_json(plan.to_json()) == plan
+
+
+# ---------------------------------------------------------------------------
+# Full plan round-trip and ordering
+# ---------------------------------------------------------------------------
+
+
+def test_full_plan_round_trips_and_preserves_order():
+    plan = _sample_plan()
+
+    restored = ChangePlan.from_json(plan.to_json())
+
+    assert restored == plan
+    # Assert the whole ordered sequence by kind, including position.
+    assert [op.kind for op in restored.operations] == ["create", "edit", "config"]
+
+
+def test_operation_kind_tags_are_set_on_serialization():
+    plan = _sample_plan()
+    kinds = [op["kind"] for op in plan.to_dict()["operations"]]
+    assert kinds == ["create", "edit", "config"]
+
+
+def test_serialized_plan_carries_the_version_marker():
+    plan = _sample_plan()
+    payload = plan.to_dict()
+    assert payload["plan_version"] == SCHEMA_VERSION
+    assert payload["plan_version"] == PLAN_VERSION
+
+
+def test_empty_plan_round_trips():
+    plan = ChangePlan()
+    assert plan.to_dict()["operations"] == []
+    assert ChangePlan.from_json(plan.to_json()) == plan
+
+
+def test_description_is_omitted_when_absent():
+    plan = ChangePlan(operations=(CreateFileOperation(path="a.py", content="x"),))
+    assert "description" not in plan.to_dict()
+
+
+# ---------------------------------------------------------------------------
+# Config op specifics
+# ---------------------------------------------------------------------------
+
+
+def test_config_key_path_stays_an_ordered_tuple_through_round_trip():
+    op = ConfigOperation(key_path=("databases", "default", "provider"), value="pg")
+    restored = ChangePlan.from_dict(ChangePlan(operations=(op,)).to_dict()).operations[
+        0
+    ]
+    assert isinstance(restored, ConfigOperation)
+    assert restored.key_path == ("databases", "default", "provider")
+    assert isinstance(restored.key_path, tuple)
+
+
+def test_config_operation_defaults_to_set():
+    op = ConfigOperation(key_path=("a",), value=1)
+    assert op.operation == "set"
+
+
+def test_config_operation_rejects_an_unknown_mode():
+    with pytest.raises(ValueError, match="Invalid config operation"):
+        ConfigOperation(key_path=("a",), value=1, operation="delete")
+
+
+def test_config_value_may_be_falsy():
+    # value is required-by-presence, so null/false/0 must survive the round-trip.
+    for value in (None, False, 0, ""):
+        plan = ChangePlan(operations=(ConfigOperation(key_path=("a",), value=value),))
+        assert ChangePlan.from_json(plan.to_json()) == plan
+
+
+# ---------------------------------------------------------------------------
+# Schema validation
+# ---------------------------------------------------------------------------
+
+
+def test_schema_version_matches_plan_version():
+    assert SCHEMA_VERSION == PLAN_VERSION
+
+
+def test_serialized_plan_validates_against_the_schema(schema):
+    validate(instance=_sample_plan().to_dict(), schema=schema)
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        pytest.param(CreateFileOperation(path="a.py", content="x"), id="create"),
+        pytest.param(EditFileOperation(path="a.py", diff="@@ @@"), id="edit"),
+        pytest.param(
+            ConfigOperation(key_path=("a", "b"), value=1, operation="merge"),
+            id="config",
+        ),
+    ],
+)
+def test_each_op_kind_validates_against_the_schema(operation, schema):
+    validate(instance=ChangePlan(operations=(operation,)).to_dict(), schema=schema)
+
+
+# ---------------------------------------------------------------------------
+# Negative: from_dict fails loud on malformed input
+# ---------------------------------------------------------------------------
+
+
+def test_from_dict_rejects_an_unknown_kind():
+    data = {"plan_version": PLAN_VERSION, "operations": [{"kind": "rename"}]}
+    with pytest.raises(ValueError, match="Unknown operation kind"):
+        ChangePlan.from_dict(data)
+
+
+def test_from_dict_rejects_an_operation_without_a_kind():
+    data = {"plan_version": PLAN_VERSION, "operations": [{"path": "a.py"}]}
+    with pytest.raises(ValueError, match="missing its 'kind'"):
+        ChangePlan.from_dict(data)
+
+
+def test_from_dict_rejects_a_create_missing_content():
+    data = {
+        "plan_version": PLAN_VERSION,
+        "operations": [{"kind": "create", "path": "a.py"}],
+    }
+    with pytest.raises(ValueError, match="'content'"):
+        ChangePlan.from_dict(data)
+
+
+def test_from_dict_rejects_an_edit_missing_diff():
+    data = {
+        "plan_version": PLAN_VERSION,
+        "operations": [{"kind": "edit", "path": "a.py"}],
+    }
+    with pytest.raises(ValueError, match="'diff'"):
+        ChangePlan.from_dict(data)
+
+
+def test_from_dict_rejects_a_config_missing_value():
+    data = {
+        "plan_version": PLAN_VERSION,
+        "operations": [{"kind": "config", "key_path": ["a"], "operation": "set"}],
+    }
+    with pytest.raises(ValueError, match="'value'"):
+        ChangePlan.from_dict(data)
+
+
+def test_from_dict_rejects_a_config_with_a_non_string_key_path():
+    data = {
+        "plan_version": PLAN_VERSION,
+        "operations": [
+            {"kind": "config", "key_path": ["a", 2], "value": 1, "operation": "set"}
+        ],
+    }
+    with pytest.raises(ValueError, match="key_path"):
+        ChangePlan.from_dict(data)
+
+
+def test_from_dict_rejects_a_config_with_a_bad_operation():
+    data = {
+        "plan_version": PLAN_VERSION,
+        "operations": [
+            {"kind": "config", "key_path": ["a"], "value": 1, "operation": "wipe"}
+        ],
+    }
+    with pytest.raises(ValueError, match="Invalid config operation"):
+        ChangePlan.from_dict(data)
+
+
+def test_from_dict_rejects_an_unrecognized_plan_version():
+    data = {"plan_version": "9.9.9", "operations": []}
+    with pytest.raises(ValueError, match="Unsupported plan_version"):
+        ChangePlan.from_dict(data)
+
+
+def test_from_dict_rejects_a_missing_plan_version():
+    with pytest.raises(ValueError, match="Unsupported plan_version"):
+        ChangePlan.from_dict({"operations": []})
+
+
+def test_from_dict_rejects_non_list_operations():
+    data = {"plan_version": PLAN_VERSION, "operations": "not-a-list"}
+    with pytest.raises(ValueError, match="'operations' must be a list"):
+        ChangePlan.from_dict(data)
+
+
+def test_from_dict_rejects_a_non_string_description():
+    data = {"plan_version": PLAN_VERSION, "operations": [], "description": 3}
+    with pytest.raises(ValueError, match="'description' must be a string"):
+        ChangePlan.from_dict(data)
+
+
+def test_from_json_rejects_invalid_json():
+    with pytest.raises(ValueError, match="Invalid ChangePlan JSON"):
+        ChangePlan.from_json("{not json")
+
+
+def test_from_json_rejects_a_non_object_payload():
+    with pytest.raises(ValueError, match="must be a JSON object"):
+        ChangePlan.from_json("[1, 2, 3]")

--- a/tests/scaffold/test_change_plan.py
+++ b/tests/scaffold/test_change_plan.py
@@ -362,3 +362,11 @@ def test_from_json_rejects_invalid_json():
 def test_from_json_rejects_a_non_object_payload():
     with pytest.raises(ValueError, match="must be a JSON object"):
         ChangePlan.from_json("[1, 2, 3]")
+
+
+@pytest.mark.parametrize("payload", [None, [], "plan", 3])
+def test_from_dict_rejects_a_non_mapping_payload(payload):
+    # from_dict promises ValueError on malformed input; a non-mapping payload
+    # must fail loud the same way from_json does, not blow up as AttributeError.
+    with pytest.raises(ValueError, match="must be a mapping"):
+        ChangePlan.from_dict(payload)

--- a/tests/scaffold/test_change_plan.py
+++ b/tests/scaffold/test_change_plan.py
@@ -202,6 +202,46 @@ def test_from_dict_rejects_an_edit_missing_diff():
         ChangePlan.from_dict(data)
 
 
+def test_from_dict_rejects_a_config_missing_key_path():
+    data = {
+        "plan_version": PLAN_VERSION,
+        "operations": [{"kind": "config", "value": 1, "operation": "set"}],
+    }
+    with pytest.raises(ValueError, match="missing required field 'key_path'"):
+        ChangePlan.from_dict(data)
+
+
+@pytest.mark.parametrize(
+    ("op", "field"),
+    [
+        ({"kind": "create", "path": "a.py", "content": None}, "content"),
+        ({"kind": "create", "path": 123, "content": "x"}, "path"),
+        ({"kind": "edit", "path": "a.py", "diff": None}, "diff"),
+    ],
+)
+def test_from_dict_rejects_a_non_string_field(op, field):
+    # from_dict is the loud gate: a value the schema marks type:string but that
+    # arrives as null/int is rejected here, not surfaced later as an
+    # AttributeError in the preview renderer.
+    data = {"plan_version": PLAN_VERSION, "operations": [op]}
+    with pytest.raises(ValueError, match=f"field {field!r} must be a string"):
+        ChangePlan.from_dict(data)
+
+
+def test_config_operation_is_optional_in_schema_and_from_dict(schema):
+    # The schema and from_dict must agree: operation is optional (it has a "set"
+    # default in the dataclass). A config op with no operation validates against
+    # the schema AND parses, defaulting to "set".
+    data = {
+        "plan_version": PLAN_VERSION,
+        "operations": [{"kind": "config", "key_path": ["a"], "value": 1}],
+    }
+    validate(instance=data, schema=schema)
+    restored = ChangePlan.from_dict(data).operations[0]
+    assert isinstance(restored, ConfigOperation)
+    assert restored.operation == "set"
+
+
 def test_from_dict_rejects_a_config_missing_value():
     data = {
         "plan_version": PLAN_VERSION,

--- a/tests/scaffold/test_preview.py
+++ b/tests/scaffold/test_preview.py
@@ -1,0 +1,89 @@
+"""Tests for the read-only ChangePlan preview renderer."""
+
+import pytest
+
+from protean.scaffold import (
+    ChangePlan,
+    ConfigOperation,
+    CreateFileOperation,
+    EditFileOperation,
+    render_preview,
+)
+
+pytestmark = pytest.mark.no_test_domain
+
+
+def _sample_plan(base: str) -> ChangePlan:
+    """A plan whose paths point inside *base* (used by the no-write test)."""
+    return ChangePlan(
+        operations=(
+            CreateFileOperation(
+                path=f"{base}/new_file.py", content="first line\nsecond line"
+            ),
+            EditFileOperation(
+                path=f"{base}/existing.py",
+                diff="--- a/existing.py\n+++ b/existing.py\n@@ -1 +1 @@\n-old\n+new",
+            ),
+            ConfigOperation(
+                key_path=("databases", "default", "provider"),
+                value="postgresql",
+                operation="merge",
+            ),
+        ),
+        description="A sample change",
+    )
+
+
+def test_preview_names_each_target_path():
+    text = render_preview(_sample_plan("app"))
+    assert "app/new_file.py" in text
+    assert "app/existing.py" in text
+
+
+def test_preview_shows_the_unified_diff_for_an_edit():
+    text = render_preview(_sample_plan("app"))
+    assert "@@ -1 +1 @@" in text
+    assert "-old" in text
+    assert "+new" in text
+
+
+def test_preview_renders_a_config_op_as_key_path_value_with_mode():
+    text = render_preview(_sample_plan("app"))
+    assert 'databases.default.provider = "postgresql"  (merge)' in text
+
+
+def test_preview_shows_create_content_and_line_count():
+    text = render_preview(
+        ChangePlan(
+            operations=(CreateFileOperation(path="a.py", content="one\ntwo\nthree"),)
+        )
+    )
+    assert "create a.py  (3 lines)" in text
+    assert "one" in text
+    assert "three" in text
+
+
+def test_preview_of_an_empty_plan_renders_without_error():
+    text = render_preview(ChangePlan())
+    assert "(no operations)" in text
+
+
+def test_preview_touches_no_files(tmp_path):
+    """Rendering a plan whose ops point inside tmp_path writes nothing there."""
+    plan = _sample_plan(str(tmp_path))
+
+    def snapshot():
+        return {
+            p.relative_to(tmp_path).as_posix(): p.read_bytes()
+            for p in sorted(tmp_path.rglob("*"))
+            if p.is_file()
+        }
+
+    before = snapshot()
+    text = render_preview(plan)
+    after = snapshot()
+
+    # The renderer produced output but changed nothing on disk.
+    assert text
+    assert before == after
+    assert after == {}  # tmp_path started empty and stays empty

--- a/tests/scaffold/test_preview.py
+++ b/tests/scaffold/test_preview.py
@@ -52,6 +52,22 @@ def test_preview_renders_a_config_op_as_key_path_value_with_mode():
     assert 'databases.default.provider = "postgresql"  (merge)' in text
 
 
+def test_preview_sorts_the_keys_of_a_dict_config_value():
+    # Previews get diffed, so a dict value must render the same way whatever
+    # order the producer built it in.
+    def render(value):
+        return render_preview(
+            ChangePlan(
+                operations=(ConfigOperation(key_path=("databases",), value=value),)
+            )
+        )
+
+    text = render({"provider": "postgresql", "database_uri": "postgresql://"})
+
+    assert '{"database_uri": "postgresql://", "provider": "postgresql"}' in text
+    assert text == render({"database_uri": "postgresql://", "provider": "postgresql"})
+
+
 def test_preview_shows_create_content_and_line_count():
     text = render_preview(
         ChangePlan(

--- a/tests/scaffold/test_preview.py
+++ b/tests/scaffold/test_preview.py
@@ -63,6 +63,15 @@ def test_preview_shows_create_content_and_line_count():
     assert "three" in text
 
 
+def test_preview_create_line_count_ignores_a_trailing_newline():
+    # A full-content file normally ends in a trailing newline. The reported count
+    # must match the rendered body lines: "a\nb\n" is two lines, not three.
+    text = render_preview(
+        ChangePlan(operations=(CreateFileOperation(path="a.py", content="a\nb\n"),))
+    )
+    assert "create a.py  (2 lines)" in text
+
+
 def test_preview_of_an_empty_plan_renders_without_error():
     text = render_preview(ChangePlan())
     assert "(no operations)" in text


### PR DESCRIPTION
## Summary
- Adds a `protean.scaffold` package holding `ChangePlan`: an ordered, serializable description of a proposed change. Operations are a discriminated union tagged by `kind`: `create` (path + whole content), `edit` (path + unified diff), and `config` (a structured key-path set/merge over `domain.toml`, never a text diff).
- The serialized form carries a `plan_version` marker and validates against a versioned JSON Schema at `src/protean/scaffold/schema/v0.1.0/schema.json`. `from_dict` rejects an unknown version, an unknown `kind`, a missing required field, and a wrong-typed field with a clear `ValueError`.
- `render_preview(plan)` renders a plan as plain strings. It opens, stats, and creates nothing, so previewing is safe to run anywhere.
- ADR-0033 records why the plan is versioned, why config stays structured, and why applying is left to a later epic. A plan is inert: nothing here writes to disk.

## Test plan
- [x] `tests/scaffold` passes (42 tests): round-trips for each operation kind, order preservation, schema validation of every serialized shape, and the full set of malformed-input rejections
- [x] A test asserts the preview writes nothing to a `tmp_path` directory
- [x] `SCHEMA_VERSION` is asserted equal to `PLAN_VERSION`, so the two cannot drift
- [x] `ruff check`, `ruff format --check`, and `mypy --strict` clean on `src/protean/scaffold`
- [x] 100% line and branch coverage on the new package

Closes #1327