### PR TITLE
Add 'protean add <element> <name>' to preview a new aggregate slice

### DIFF
--- a/changes/1340.added.md
+++ b/changes/1340.added.md
@@ -1,1 +1,1 @@
-Add `protean add <element> <name>`, which computes a create-only ChangePlan for one aggregate slice and previews it without writing.
+Add `protean add <element-type> <name>`, which computes a create-only ChangePlan for one aggregate slice and previews it without writing.

--- a/changes/1340.added.md
+++ b/changes/1340.added.md
@@ -1,0 +1,1 @@
+Add `protean add <element> <name>`, which computes a create-only ChangePlan for one aggregate slice and previews it without writing.

--- a/docs/reference/cli/project/add.md
+++ b/docs/reference/cli/project/add.md
@@ -1,0 +1,70 @@
+# `protean add`
+
+The `protean add` command previews the files a new element slice would add to
+your project. It computes a change plan and prints it. It writes nothing: this is
+a read-only preview.
+
+## Usage
+
+```shell
+protean add [OPTIONS] ELEMENT_TYPE NAME
+```
+
+## Arguments
+
+| Argument       | Description                                        | Default | Required |
+|----------------|----------------------------------------------------|---------|----------|
+| `ELEMENT_TYPE` | The element type to add. Only `aggregate` for now. | None    | Yes      |
+| `NAME`         | The aggregate name, e.g. `Order`.                  | None    | Yes      |
+
+## Options
+
+- `--path`, `-p`: Project directory to plan against. Defaults to the current
+  directory.
+- `--help`: Show the help message and exit.
+
+## What it plans
+
+For `aggregate`, `add` plans one complete write-side vertical slice under
+`src/<package>/<name-lowercased>/`, one concept per module:
+
+- `__init__.py`: a docstring only, so the package initializer stays side-effect
+  free (see [ADR-0030](../../../adr/0030-canonical-project-layout.md)).
+- `aggregate.py`: the aggregate with a `create` factory that raises the created
+  event.
+- `commands.py`: the `Create<Name>` command.
+- `events.py`: the `<Name>Created` event.
+- `command_handlers.py`: the handler that creates the aggregate and adds it to
+  its repository.
+
+The slice sits exactly one directory below the domain root, so
+`domain.init(traverse=True)` discovers and registers it.
+
+The project is resolved from `src/<package>/domain.py`. `add` reads the package
+name and the domain variable (the name your `@domain.aggregate` decorators use)
+straight from that file, without importing it.
+
+## Examples
+
+Preview the `Order` aggregate slice in the current project:
+
+```shell
+protean add aggregate Order
+```
+
+Point at another project directory:
+
+```shell
+protean add aggregate Order --path ./my-project
+```
+
+## Exit codes
+
+- `0`: the plan was computed and printed.
+- `2`: a usage error. An unsupported element type, an invalid name, or a project
+  the planner could not resolve (no `src/<package>/domain.py`, or more than one).
+
+## What it does not do
+
+`add` writes nothing. It only previews the plan. Applying the plan (creating the
+files on disk) is a separate step, added in a later release.

--- a/docs/reference/cli/project/add.md
+++ b/docs/reference/cli/project/add.md
@@ -61,8 +61,13 @@ protean add aggregate Order --path ./my-project
 ## Exit codes
 
 - `0`: the plan was computed and printed.
-- `2`: a usage error. An unsupported element type, an invalid name, or a project
-  the planner could not resolve (no `src/<package>/domain.py`, or more than one).
+- `2`: a usage error. Any of:
+  - an unsupported element type (only `aggregate` is supported today);
+  - an invalid name: not a Python identifier, or a Python keyword (which would
+    produce a slice that does not compile);
+  - a project the planner could not resolve: no `src/` directory, no
+    `src/<package>/domain.py`, more than one such file, a `domain.py` that does
+    not parse, or a `domain.py` that constructs no `Domain`.
 
 ## What it does not do
 

--- a/docs/reference/cli/project/add.md
+++ b/docs/reference/cli/project/add.md
@@ -26,7 +26,7 @@ protean add [OPTIONS] ELEMENT_TYPE NAME
 ## What it plans
 
 For `aggregate`, `add` plans one complete write-side vertical slice under
-`src/<package>/<name-lowercased>/`, one concept per module:
+`src/<package>/<slug>/`, one concept per module:
 
 - `__init__.py`: a docstring only, so the package initializer stays side-effect
   free (see [ADR-0030](../../../adr/0030-canonical-project-layout.md)).
@@ -39,6 +39,17 @@ For `aggregate`, `add` plans one complete write-side vertical slice under
 
 The slice sits exactly one directory below the domain root, so
 `domain.init(traverse=True)` discovers and registers it.
+
+## How the name is used
+
+`add` splits `NAME` into words on underscores and on case changes, then builds
+two things from them: the class name is the PascalCase join, and the slug (the
+directory name, the local variable, and the id-field prefix) is the snake_case
+one. So `OrderItem`, `orderItem` and `order_item` all plan the same slice:
+`class OrderItem` in `src/<package>/order_item/`.
+
+A run of capitals counts as one word, so `HTTPServer` stays `HTTPServer` and its
+slug is `http_server`.
 
 The project is resolved from `src/<package>/domain.py`. `add` reads the package
 name and the domain variable (the name your `@domain.aggregate` decorators use)
@@ -63,8 +74,10 @@ protean add aggregate Order --path ./my-project
 - `0`: the plan was computed and printed.
 - `2`: a usage error. Any of:
   - an unsupported element type (only `aggregate` is supported today);
-  - an invalid name: not a Python identifier, or a Python keyword (which would
-    produce a slice that does not compile);
+  - an invalid name. It is invalid if it is not a Python identifier, if it has
+    no words in it (`_`), or if the class name and slug it derives are a Python
+    keyword or not valid Python names. Each of those would produce a slice that
+    does not compile;
   - a project the planner could not resolve: no `src/` directory, no
     `src/<package>/domain.py`, more than one such file, a `domain.py` that does
     not parse, or a `domain.py` that constructs no `Domain`.

--- a/docs/reference/cli/project/index.md
+++ b/docs/reference/cli/project/index.md
@@ -3,6 +3,7 @@
 Commands for creating, exploring, and working with Protean projects.
 
 - [`protean new`](./new.md): Scaffold a new project
+- [`protean add`](./add.md): Preview the files a new element slice would add
 - [`protean shell`](./shell.md): Interactive shell with domain context
 - [Domain Discovery](./discovery.md): How Protean finds your domain
 - [`protean docs`](./docs.md): Serve documentation locally

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -325,6 +325,7 @@ nav:
       - Project:
         - reference/cli/project/index.md
         - reference/cli/project/new.md
+        - reference/cli/project/add.md
         - reference/cli/project/discovery.md
         - reference/cli/project/shell.md
         - reference/cli/project/docs.md

--- a/src/protean/cli/__init__.py
+++ b/src/protean/cli/__init__.py
@@ -29,6 +29,7 @@ from protean.cli._helpers import (
     cli_exception_handler,
     handle_cli_exceptions,  # noqa: F401 — re-exported
 )
+from protean.cli.add import add
 from protean.cli.check import check
 from protean.cli.database import app as db_app
 from protean.cli.dlq import app as dlq_app
@@ -61,6 +62,7 @@ logger = get_logger(__name__)
 #   `no_args_is_help=True` will show the help message when no arguments are passed
 app = typer.Typer(no_args_is_help=True)
 
+app.command()(add)
 app.command()(check)
 app.command()(verify)
 app.command()(recover)

--- a/src/protean/cli/add.py
+++ b/src/protean/cli/add.py
@@ -1,0 +1,61 @@
+"""CLI command for ``protean add`` — preview a new element slice.
+
+``add`` computes a :class:`~protean.scaffold.ChangePlan` for one element slice and
+prints it. It writes nothing: this stage is a read-only preview. Applying the plan
+(actually creating the files) is a later command.
+
+Usage::
+
+    # Preview the aggregate slice for `Order` in the current project
+    protean add aggregate Order
+
+    # Point at a project directory other than the current one
+    protean add aggregate Order --path ./my-project
+
+Only ``aggregate`` is supported for now; it emits one write-side vertical slice
+(the aggregate, its create command, its created event, and the command handler).
+An unsupported element type, an invalid name, or a project the planner cannot
+resolve exits ``2`` (a usage error) with a clear message.
+"""
+
+from typing import Annotated
+
+import typer
+
+from protean.scaffold import AddPlanError, plan_add_slice, render_preview
+
+# A usage error: a bad argument or a project that could not be resolved. Matches
+# the CLI-wide convention (and Click's own default) that 2 means "usage".
+_EXIT_USAGE = 2
+
+
+def add(
+    element_type: Annotated[
+        str,
+        typer.Argument(help="The element type to add. Only 'aggregate' for now."),
+    ],
+    name: Annotated[
+        str,
+        typer.Argument(help="The aggregate name, e.g. 'Order'."),
+    ],
+    path: Annotated[
+        str,
+        typer.Option(
+            "--path",
+            "-p",
+            help="Project directory to plan against (default: current directory).",
+        ),
+    ] = ".",
+) -> None:
+    """Preview the ChangePlan for a new element slice, without writing anything."""
+    try:
+        plan = plan_add_slice(path, element_type, name)
+    except AddPlanError as exc:
+        # Every planning failure is a usage error: the arguments or the project
+        # layout are wrong. Print the message and exit 2. Use typer.echo, not
+        # rich's print: the preview and some messages carry bracketed tokens
+        # (e.g. `Annotated[str, Field(...)]`) that rich would parse as markup.
+        typer.echo(f"Error: {exc}")
+        raise typer.Exit(code=_EXIT_USAGE) from exc
+
+    typer.echo(render_preview(plan))

--- a/src/protean/scaffold/__init__.py
+++ b/src/protean/scaffold/__init__.py
@@ -16,6 +16,11 @@ import json
 from pathlib import Path
 from typing import Any
 
+from protean.scaffold.add_plan import (
+    SUPPORTED_ELEMENT_TYPES,
+    AddPlanError,
+    plan_add_slice,
+)
 from protean.scaffold.change_plan import (
     PLAN_VERSION,
     ChangePlan,
@@ -30,12 +35,15 @@ __all__ = [
     "PLAN_VERSION",
     "SCHEMA_PATH",
     "SCHEMA_VERSION",
+    "SUPPORTED_ELEMENT_TYPES",
+    "AddPlanError",
     "ChangePlan",
     "ConfigOperation",
     "CreateFileOperation",
     "EditFileOperation",
     "Operation",
     "load_schema",
+    "plan_add_slice",
     "render_preview",
 ]
 

--- a/src/protean/scaffold/add_plan.py
+++ b/src/protean/scaffold/add_plan.py
@@ -160,11 +160,13 @@ def _read_domain_variable(domain_py: Path) -> str:
 
     Reads the module with :mod:`ast` only, so a ``domain.py`` that imports heavy
     or uninstalled dependencies still resolves. Raises :class:`AddPlanError` when
-    the file cannot be parsed or binds no ``Domain`` at module level.
+    the file cannot be read or parsed, or binds no ``Domain`` at module level.
     """
     try:
         tree = ast.parse(domain_py.read_text(encoding="utf-8"), filename=str(domain_py))
-    except (OSError, SyntaxError) as exc:
+    # A file that is not valid UTF-8 raises UnicodeDecodeError from read_text;
+    # catch it here so a bad encoding is a usage error, not a traceback.
+    except (OSError, SyntaxError, UnicodeError) as exc:
         raise AddPlanError(f"Could not read {domain_py}: {exc}") from exc
 
     for node in tree.body:

--- a/src/protean/scaffold/add_plan.py
+++ b/src/protean/scaffold/add_plan.py
@@ -1,0 +1,326 @@
+"""Plan a new element slice as a :class:`~protean.scaffold.ChangePlan`.
+
+``protean add <element-type> <name>`` computes what it *would* write and previews
+it, without touching the filesystem. This module is the pure planner behind that
+command: given a project directory and a name, it returns a
+:class:`~protean.scaffold.ChangePlan` of :class:`CreateFileOperation`\\ s in the
+ADR-0030 canonical layout. It writes nothing; the CLI renders the plan.
+
+For this first cut the only supported element type is ``aggregate``, which emits
+one complete write-side vertical slice: the aggregate, its create command, its
+created event, and the command handler that ties them together.
+
+The project is resolved the same way discovery resolves it, but independently and
+without importing anything: locate the single ``src/<package>/domain.py``, then
+AST-parse it to read the package directory name (the import root) and the variable
+bound to the ``Domain(...)`` call (the name the generated decorators reference).
+AST-parsing keeps the planner deterministic and unit-testable against a directory
+of files, and correct even when a project's domain variable differs from its
+package name.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Callable
+from pathlib import Path
+
+from protean.scaffold.change_plan import ChangePlan, CreateFileOperation
+
+# A renderer turns a slice's parameters into one file's whole content.
+_Renderer = Callable[["_SliceContext"], str]
+
+__all__ = ["SUPPORTED_ELEMENT_TYPES", "AddPlanError", "plan_add_slice"]
+
+# The element types ``add`` can plan today. The POC ships the write-side
+# aggregate slice; more types come in later issues.
+SUPPORTED_ELEMENT_TYPES = ("aggregate",)
+
+
+class AddPlanError(Exception):
+    """A user-facing planning failure: an unsupported type, a bad name, or a
+    project the planner cannot resolve. The CLI turns this into a clear message
+    and a usage exit code, so the message is written to be read by a human."""
+
+
+def plan_add_slice(project_path: str, element_type: str, name: str) -> ChangePlan:
+    """Compute a create-only :class:`ChangePlan` for one element slice.
+
+    *project_path* is the project root (the directory that holds ``src/``).
+    *element_type* must be ``"aggregate"`` for now. *name* is the aggregate name
+    (e.g. ``"Order"``); it must be a valid Python identifier.
+
+    Returns a plan whose operations are all :class:`CreateFileOperation`\\ s at the
+    canonical ADR-0030 paths under ``src/<package>/<slug>/``. Touches no files.
+
+    Raises :class:`AddPlanError` on an unsupported element type, a name that is
+    not a valid identifier, or a project the planner cannot resolve (no
+    ``src/<package>/domain.py``, more than one candidate, or a ``domain.py`` that
+    does not construct a ``Domain``).
+    """
+    normalized_type = element_type.lower()
+    if normalized_type not in SUPPORTED_ELEMENT_TYPES:
+        supported = ", ".join(SUPPORTED_ELEMENT_TYPES)
+        raise AddPlanError(
+            f"Unsupported element type {element_type!r}. Supported: {supported}."
+        )
+
+    if not name.isidentifier():
+        raise AddPlanError(
+            f"Invalid name {name!r}: an element name must be a valid Python "
+            "identifier (letters, digits, and underscores; not starting with a "
+            "digit)."
+        )
+
+    package, domain_var = _resolve_project(project_path)
+
+    # Class names follow the Example slice: Order / CreateOrder / OrderCreated /
+    # OrderCommandHandler. The slug (the directory and the id-field prefix) is the
+    # name lower-cased, so ``Order`` lands in ``order/`` (ADR-0030).
+    class_name = name[:1].upper() + name[1:]
+    slug = name.lower()
+
+    context = _SliceContext(
+        package=package,
+        domain_var=domain_var,
+        name=class_name,
+        slug=slug,
+    )
+
+    base = f"src/{package}/{slug}"
+    operations = tuple(
+        CreateFileOperation(path=f"{base}/{filename}", content=render(context))
+        for filename, render in _SLICE_FILES
+    )
+
+    return ChangePlan(
+        operations=operations,
+        description=(
+            f"Add the {class_name} aggregate slice "
+            f"(aggregate, command, event, command handler)"
+        ),
+    )
+
+
+def _resolve_project(project_path: str) -> tuple[str, str]:
+    """Resolve ``(package, domain_var)`` from a project's ``src/`` tree.
+
+    Locates the single ``src/<package>/domain.py``, then AST-parses it to read the
+    variable bound to a ``Domain(...)`` call. No import, no installed deps.
+
+    Raises :class:`AddPlanError` when ``src/`` is missing, when there is not
+    exactly one ``domain.py`` candidate, or when ``domain.py`` binds no ``Domain``.
+    """
+    src = Path(project_path) / "src"
+    if not src.is_dir():
+        raise AddPlanError(
+            f"No 'src' directory under {project_path!r}. Run 'add' from a project "
+            "root generated by 'protean new'."
+        )
+
+    candidates = sorted(
+        child
+        for child in src.iterdir()
+        if child.is_dir() and (child / "domain.py").is_file()
+    )
+    if not candidates:
+        raise AddPlanError(
+            f"No 'src/<package>/domain.py' found under {project_path!r}. "
+            "The project must have a composition root (see ADR-0030)."
+        )
+    if len(candidates) > 1:
+        names = ", ".join(candidate.name for candidate in candidates)
+        raise AddPlanError(
+            f"Found more than one 'src/<package>/domain.py' under {project_path!r} "
+            f"({names}). 'add' targets a single composition root."
+        )
+
+    package_dir = candidates[0]
+    package = package_dir.name
+    domain_var = _read_domain_variable(package_dir / "domain.py")
+    return package, domain_var
+
+
+def _read_domain_variable(domain_py: Path) -> str:
+    """Return the name of the top-level variable bound to a ``Domain(...)`` call.
+
+    Reads the module with :mod:`ast` only, so a ``domain.py`` that imports heavy
+    or uninstalled dependencies still resolves. Raises :class:`AddPlanError` when
+    the file cannot be parsed or binds no ``Domain`` at module level.
+    """
+    try:
+        tree = ast.parse(domain_py.read_text(encoding="utf-8"), filename=str(domain_py))
+    except (OSError, SyntaxError) as exc:
+        raise AddPlanError(f"Could not read {domain_py}: {exc}") from exc
+
+    for node in tree.body:
+        # Only plain ``name = Domain(...)`` assignments name the composition root.
+        # Annotated assignments (``name: T = Domain(...)``) are handled too.
+        target_name: str | None = None
+        value: ast.expr | None = None
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target = node.targets[0]
+            if isinstance(target, ast.Name):
+                target_name = target.id
+                value = node.value
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            target_name = node.target.id
+            value = node.value
+
+        if target_name is not None and value is not None and _is_domain_call(value):
+            return target_name
+
+    raise AddPlanError(
+        f"{domain_py} does not construct a Domain at module level. "
+        "Expected a line like `<name> = Domain(name=...)`."
+    )
+
+
+def _is_domain_call(value: ast.expr) -> bool:
+    """Whether *value* is a call to ``Domain(...)`` (bare or attribute form)."""
+    if not isinstance(value, ast.Call):
+        return False
+    func = value.func
+    if isinstance(func, ast.Name):
+        return func.id == "Domain"
+    if isinstance(func, ast.Attribute):
+        return func.attr == "Domain"
+    return False
+
+
+class _SliceContext:
+    """The parameters that fill in one slice's file contents."""
+
+    __slots__ = ("domain_var", "name", "package", "slug")
+
+    def __init__(self, package: str, domain_var: str, name: str, slug: str) -> None:
+        self.package = package
+        self.domain_var = domain_var
+        self.name = name
+        self.slug = slug
+
+
+def _render_init(ctx: _SliceContext) -> str:
+    # ADR-0030 rule 4: the package initializer is side-effect free (docstring
+    # only). A re-export here would run during traversal and risk the
+    # partially-initialized-module cycle that broke init(traverse=True) in #1316.
+    return (
+        f'"""The {ctx.name} slice.\n\n'
+        "Modules are discovered independently by ``domain.init()``. Keep this\n"
+        "package initializer side-effect free so relative imports during\n"
+        "traversal cannot create partially initialized-module cycles.\n"
+        '"""\n'
+    )
+
+
+def _render_aggregate(ctx: _SliceContext) -> str:
+    return f'''"""The {ctx.name} aggregate."""
+
+from typing import Annotated
+
+from pydantic import Field
+
+from {ctx.package}.domain import {ctx.domain_var}
+
+from .events import {ctx.name}Created
+
+
+@{ctx.domain_var}.aggregate
+class {ctx.name}:
+    """The {ctx.name} aggregate root."""
+
+    name: Annotated[str, Field(max_length=100)]
+
+    @classmethod
+    def create(cls, name: str) -> "{ctx.name}":
+        """Create a new {ctx.name} and raise {ctx.name}Created."""
+        {ctx.slug} = cls(name=name)
+
+        {ctx.slug}.raise_(
+            {ctx.name}Created(
+                {ctx.slug}_id={ctx.slug}.id,
+                name={ctx.slug}.name,
+            )
+        )
+
+        return {ctx.slug}
+'''
+
+
+def _render_commands(ctx: _SliceContext) -> str:
+    return f'''"""Commands for the {ctx.name} aggregate."""
+
+from typing import Annotated
+
+from pydantic import Field
+
+from {ctx.package}.domain import {ctx.domain_var}
+
+
+@{ctx.domain_var}.command(part_of="{ctx.name}")
+class Create{ctx.name}:
+    """Command to create a new {ctx.name}."""
+
+    name: Annotated[str, Field(max_length=100)]
+'''
+
+
+def _render_events(ctx: _SliceContext) -> str:
+    return f'''"""Events emitted by the {ctx.name} aggregate."""
+
+from typing import Annotated
+
+from pydantic import Field
+
+from {ctx.package}.domain import {ctx.domain_var}
+
+
+@{ctx.domain_var}.event(part_of="{ctx.name}")
+class {ctx.name}Created:
+    """Event emitted when a {ctx.name} is created."""
+
+    {ctx.slug}_id: str
+    name: Annotated[str, Field(max_length=100)]
+'''
+
+
+def _render_command_handlers(ctx: _SliceContext) -> str:
+    return f'''"""Command handlers for the {ctx.name} aggregate."""
+
+from protean import handle
+
+from {ctx.package}.domain import {ctx.domain_var}
+
+from .aggregate import {ctx.name}
+from .commands import Create{ctx.name}
+
+
+@{ctx.domain_var}.command_handler(part_of="{ctx.name}")
+class {ctx.name}CommandHandler:
+    """Handle commands for the {ctx.name} aggregate."""
+
+    @handle(Create{ctx.name})
+    def handle_create_{ctx.slug}(self, command: Create{ctx.name}) -> str:
+        """Create a {ctx.name} from the command and persist it.
+
+        Returns the new aggregate's id so a synchronous caller can look it up
+        right after ``domain.process``.
+        """
+        {ctx.slug} = {ctx.name}.create(name=command.name)
+
+        repo = {ctx.domain_var}.repository_for({ctx.name})
+        repo.add({ctx.slug})
+
+        return {ctx.slug}.id
+'''
+
+
+# The slice's files, in the order they render into the plan. Each entry is
+# ``(filename, renderer)``; every renderer returns the file's whole content.
+_SLICE_FILES: tuple[tuple[str, _Renderer], ...] = (
+    ("__init__.py", _render_init),
+    ("aggregate.py", _render_aggregate),
+    ("commands.py", _render_commands),
+    ("events.py", _render_events),
+    ("command_handlers.py", _render_command_handlers),
+)

--- a/src/protean/scaffold/add_plan.py
+++ b/src/protean/scaffold/add_plan.py
@@ -51,15 +51,17 @@ def plan_add_slice(project_path: str, element_type: str, name: str) -> ChangePla
 
     *project_path* is the project root (the directory that holds ``src/``).
     *element_type* must be ``"aggregate"`` for now. *name* is the aggregate name
-    (e.g. ``"Order"``); it must be a valid Python identifier.
+    (e.g. ``"Order"``); it must be a valid Python identifier. It is normalized:
+    the class name is the PascalCase form and the slug the snake_case one, so
+    ``OrderItem``, ``orderItem`` and ``order_item`` all plan the same slice.
 
     Returns a plan whose operations are all :class:`CreateFileOperation`\\ s at the
     canonical ADR-0030 paths under ``src/<package>/<slug>/``. Touches no files.
 
     Raises :class:`AddPlanError` on an unsupported element type, a name that is
-    not a valid identifier, or a project the planner cannot resolve (no
-    ``src/<package>/domain.py``, more than one candidate, or a ``domain.py`` that
-    does not construct a ``Domain``).
+    not a valid identifier or that derives no valid class name and slug, or a
+    project the planner cannot resolve (no ``src/<package>/domain.py``, more than
+    one candidate, or a ``domain.py`` that does not construct a ``Domain``).
     """
     normalized_type = element_type.lower()
     if normalized_type not in SUPPORTED_ELEMENT_TYPES:
@@ -77,9 +79,26 @@ def plan_add_slice(project_path: str, element_type: str, name: str) -> ChangePla
 
     # Class names follow the Example slice: Order / CreateOrder / OrderCreated /
     # OrderCommandHandler. The slug (the directory and the id-field prefix) is the
-    # name lower-cased, so ``Order`` lands in ``order/`` (ADR-0030).
-    class_name = name[:1].upper() + name[1:]
-    slug = name.lower()
+    # snake_case form, so ``Order`` lands in ``order/`` (ADR-0030) and
+    # ``OrderItem`` in ``order_item/``. Both are derived from the same word split,
+    # so ``order_item``, ``orderItem`` and ``OrderItem`` all plan the same slice.
+    words = _split_words(name)
+    if not words:
+        raise AddPlanError(
+            f"Invalid name {name!r}: an element name must contain at least one "
+            "letter or digit."
+        )
+    class_name = "".join(word[:1].upper() + word[1:] for word in words)
+    slug = "_".join(word.lower() for word in words)
+
+    # A name like ``_2fa`` is a valid identifier but its words are not: the class
+    # would be ``2fa`` and the variable ``2fa``, neither of which compiles.
+    if not class_name.isidentifier() or not slug.isidentifier():
+        raise AddPlanError(
+            f"Invalid name {name!r}: it derives the class {class_name!r} and the "
+            f"module variable {slug!r}, which are not valid Python names. Start "
+            "each word with a letter or an underscore."
+        )
 
     # A Python keyword is a valid identifier to ``str.isidentifier`` but cannot be
     # a class name or a variable name, so it would emit code that does not compile
@@ -114,6 +133,36 @@ def plan_add_slice(project_path: str, element_type: str, name: str) -> ChangePla
             f"(aggregate, command, event, command handler)"
         ),
     )
+
+
+def _split_words(name: str) -> list[str]:
+    """Split an identifier into the words its generated names are built from.
+
+    Underscores separate words, and so does a case change, so ``order_item``,
+    ``orderItem`` and ``OrderItem`` all split into two words and render the same
+    class ``OrderItem`` and the same slug ``order_item``. A run of capitals stays
+    one word except for the last capital, which starts the next one (``XMLHttp``
+    gives ``["XML", "Http"]``). The rest of each word keeps its original casing,
+    which is what keeps ``HTTPServer`` from becoming ``HttpServer``.
+    """
+    words: list[str] = []
+    current = ""
+    for index, char in enumerate(name):
+        if char == "_":
+            if current:
+                words.append(current)
+                current = ""
+            continue
+        if char.isupper() and current:
+            follows_lower = not current[-1].isupper()
+            starts_word = index + 1 < len(name) and name[index + 1].islower()
+            if follows_lower or starts_word:
+                words.append(current)
+                current = ""
+        current += char
+    if current:
+        words.append(current)
+    return words
 
 
 def _resolve_project(project_path: str) -> tuple[str, str]:

--- a/src/protean/scaffold/add_plan.py
+++ b/src/protean/scaffold/add_plan.py
@@ -10,18 +10,21 @@ For this first cut the only supported element type is ``aggregate``, which emits
 one complete write-side vertical slice: the aggregate, its create command, its
 created event, and the command handler that ties them together.
 
-The project is resolved the same way discovery resolves it, but independently and
-without importing anything: locate the single ``src/<package>/domain.py``, then
-AST-parse it to read the package directory name (the import root) and the variable
-bound to the ``Domain(...)`` call (the name the generated decorators reference).
-AST-parsing keeps the planner deterministic and unit-testable against a directory
-of files, and correct even when a project's domain variable differs from its
-package name.
+The project is resolved from the ADR-0030 layout, without importing anything:
+locate the single ``src/<package>/domain.py``, then AST-parse it to read the
+package directory name (the import root) and the variable bound to the
+``Domain(...)`` call (the name the generated decorators reference). This is not
+the same mechanism as runtime discovery (``derive_domain`` honors
+``PROTEAN_DOMAIN`` and a ``path:instance`` selector and imports the domain); the
+planner only needs the package and the domain variable, and AST-reading them
+keeps it deterministic and unit-testable against a directory of files, and correct
+even when a project's domain variable differs from its package name.
 """
 
 from __future__ import annotations
 
 import ast
+import keyword
 from collections.abc import Callable
 from pathlib import Path
 
@@ -72,13 +75,24 @@ def plan_add_slice(project_path: str, element_type: str, name: str) -> ChangePla
             "digit)."
         )
 
-    package, domain_var = _resolve_project(project_path)
-
     # Class names follow the Example slice: Order / CreateOrder / OrderCreated /
     # OrderCommandHandler. The slug (the directory and the id-field prefix) is the
     # name lower-cased, so ``Order`` lands in ``order/`` (ADR-0030).
     class_name = name[:1].upper() + name[1:]
     slug = name.lower()
+
+    # A Python keyword is a valid identifier to ``str.isidentifier`` but cannot be
+    # a class name or a variable name, so it would emit code that does not compile
+    # (``class None:``, ``for = cls(...)``). Both derived names matter: ``None``
+    # gives class ``None``; ``class`` gives slug ``class``. Reject either.
+    if keyword.iskeyword(class_name) or keyword.iskeyword(slug):
+        raise AddPlanError(
+            f"Invalid name {name!r}: it derives a Python keyword "
+            f"(class {class_name!r}, module variable {slug!r}), so the generated "
+            "slice would not compile. Choose a name that is not a keyword."
+        )
+
+    package, domain_var = _resolve_project(project_path)
 
     context = _SliceContext(
         package=package,
@@ -177,7 +191,13 @@ def _read_domain_variable(domain_py: Path) -> str:
 
 
 def _is_domain_call(value: ast.expr) -> bool:
-    """Whether *value* is a call to ``Domain(...)`` (bare or attribute form)."""
+    """Whether *value* is a call to ``Domain(...)`` (bare or attribute form).
+
+    Matches on the name ``Domain``, so an import alias (``from protean import
+    Domain as D`` then ``D(...)``) is not recognized. A ``protean new`` project
+    always writes the bare ``Domain(...)`` form, so this only limits hand-written
+    composition roots; resolving aliases is left for when that need is real.
+    """
     if not isinstance(value, ast.Call):
         return False
     func = value.func

--- a/tests/cli/test_add.py
+++ b/tests/cli/test_add.py
@@ -74,12 +74,22 @@ def _subprocess_env(project: Path) -> dict[str, str]:
     return env
 
 
-_INIT_AND_LIST = (
+_INIT_AND_EXERCISE = (
     "import sys; sys.path.insert(0, 'src')\n"
     "from scaffolded.domain import scaffolded as domain\n"
     "domain.init()\n"
     "names = sorted(domain.registry._elements_by_name.keys())\n"
     "print('NAMES:' + ','.join(names))\n"
+    # Drive the slice end to end: process the command through the generated
+    # handler (which calls the generated `create` factory), then fetch the
+    # persisted aggregate back. command_processing is sync in the scaffold, so
+    # process runs the handler inline and returns the aggregate id.
+    "from scaffolded.order.commands import CreateOrder\n"
+    "from scaffolded.order.aggregate import Order\n"
+    "with domain.domain_context():\n"
+    "    order_id = domain.process(CreateOrder(name='Widget'))\n"
+    "    fetched = domain.repository_for(Order).get(order_id)\n"
+    "    print('PERSISTED:' + fetched.name)\n"
 )
 
 
@@ -118,14 +128,20 @@ def test_add_writes_nothing(tmp_path):
 
 def test_planned_slice_loads_and_registers_under_traversal(tmp_path):
     """Acceptance #3: the planned files register when the domain inits with
-    traversal on. Materialize the plan, init the real domain, and require the new
-    elements to be in the registry by name."""
+    traversal on, and the slice actually works. Materialize the plan, init the
+    real domain, require all four elements in the registry by name, then process a
+    command through the generated handler and assert the aggregate persists.
+
+    Asserting only the registry names is not enough: a broken `create` factory or
+    a handler missing its decorator can still leave the names present. Running the
+    command exercises the factory and the handler body, so those regressions fail
+    here."""
     project = _generate(tmp_path)
     plan = plan_add_slice(str(project), "aggregate", "Order")
     _materialize(project, plan)
 
     completed = subprocess.run(
-        [sys.executable, "-c", _INIT_AND_LIST],
+        [sys.executable, "-c", _INIT_AND_EXERCISE],
         cwd=project,
         env=_subprocess_env(project),
         capture_output=True,
@@ -133,7 +149,7 @@ def test_planned_slice_loads_and_registers_under_traversal(tmp_path):
     )
 
     assert completed.returncode == 0, (
-        "the domain must init with the planned slice in place:\n"
+        "the domain must init and process the planned slice's command:\n"
         f"{completed.stdout}\n{completed.stderr}"
     )
     line = next(
@@ -141,11 +157,16 @@ def test_planned_slice_loads_and_registers_under_traversal(tmp_path):
         "",
     )
     registered = set(line[len("NAMES:") :].split(","))
-    for element in ("Order", "CreateOrder", "OrderCreated"):
+    for element in ("Order", "CreateOrder", "OrderCreated", "OrderCommandHandler"):
         assert element in registered, (
             f"{element} did not register under traversal; registered: "
             f"{sorted(registered)}"
         )
+    # The command ran through the generated handler and the aggregate came back.
+    assert "PERSISTED:Widget" in completed.stdout, (
+        "the generated handler did not create and persist the aggregate:\n"
+        f"{completed.stdout}\n{completed.stderr}"
+    )
 
 
 def test_unsupported_type_exits_nonzero_and_writes_nothing(tmp_path):
@@ -155,8 +176,27 @@ def test_unsupported_type_exits_nonzero_and_writes_nothing(tmp_path):
     result = CliRunner().invoke(app, ["add", "widget", "Foo", "--path", str(project)])
     after = _snapshot(project)
 
-    assert result.exit_code != 0
+    # 2 is the documented usage exit code; pin it, not just "non-zero".
+    assert result.exit_code == 2, result.output
     assert "aggregate" in result.output, (
         f"the error should name aggregate as the supported type:\n{result.output}"
+    )
+    assert before == after, "a rejected add must not touch the project tree"
+
+
+def test_keyword_name_exits_two_and_writes_nothing(tmp_path):
+    """A Python keyword would produce a slice that does not compile, so the
+    command must reject it with the usage exit code and write nothing."""
+    project = _generate(tmp_path)
+
+    before = _snapshot(project)
+    result = CliRunner().invoke(
+        app, ["add", "aggregate", "class", "--path", str(project)]
+    )
+    after = _snapshot(project)
+
+    assert result.exit_code == 2, result.output
+    assert "keyword" in result.output, (
+        f"the error should explain the name is a Python keyword:\n{result.output}"
     )
     assert before == after, "a rejected add must not touch the project tree"

--- a/tests/cli/test_add.py
+++ b/tests/cli/test_add.py
@@ -1,0 +1,162 @@
+"""Tests for ``protean add``: it previews a create-only aggregate slice, writes
+nothing, and the slice it plans actually registers under traversal.
+
+The traversal-load test is the sharp edge (issue acceptance #3): a slice that is
+placed wrong, or whose ``__init__.py`` is not side-effect free, or whose imports
+do not resolve, makes ``init(traverse=True)`` crash or silently under-discover.
+Here we materialize the planned files into a real generated project and assert the
+registry holds the new elements after init.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from protean.cli import app
+from protean.scaffold import CreateFileOperation
+from protean.scaffold.add_plan import plan_add_slice
+
+# These generate and start their own projects; the autouse domain fixture would
+# build an unrelated Domain per test for nothing.
+pytestmark = pytest.mark.no_test_domain
+
+_PACKAGE = "scaffolded"
+
+
+def _generate(tmp_path: Path, name: str = _PACKAGE) -> Path:
+    """Run ``protean new`` and return the generated project root."""
+    out = tmp_path / "out"
+    out.mkdir(parents=True, exist_ok=True)
+    result = CliRunner().invoke(
+        app,
+        ["new", name, "-o", str(out), "--defaults", "--skip-setup"],
+    )
+    assert result.exit_code == 0, f"protean new failed: {result.output}"
+    return out / name
+
+
+def _snapshot(root: Path) -> dict[str, bytes]:
+    """Map every file under *root* to its bytes, for a before/after compare."""
+    return {
+        str(path.relative_to(root)): path.read_bytes()
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+    }
+
+
+def _materialize(project: Path, plan) -> None:
+    """Write a plan's create operations into *project*, as apply would."""
+    for op in plan.operations:
+        assert isinstance(op, CreateFileOperation)
+        target = project / op.path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(op.content)
+
+
+def _subprocess_env(project: Path) -> dict[str, str]:
+    """Env for running the generated project uninstalled (its ``src/`` on the
+    path, and the leak-prone vars dropped). Mirrors the working-project test."""
+    src = str(project / "src")
+    existing = os.environ.get("PYTHONPATH", "")
+    env = {
+        **os.environ,
+        "PYTHONPATH": src + os.pathsep + existing if existing else src,
+    }
+    env.pop("VIRTUAL_ENV", None)
+    env.pop("PROTEAN_ENV", None)
+    env.pop("PROTEAN_DEBUG", None)
+    return env
+
+
+_INIT_AND_LIST = (
+    "import sys; sys.path.insert(0, 'src')\n"
+    "from scaffolded.domain import scaffolded as domain\n"
+    "domain.init()\n"
+    "names = sorted(domain.registry._elements_by_name.keys())\n"
+    "print('NAMES:' + ','.join(names))\n"
+)
+
+
+def test_add_previews_the_five_create_operations(tmp_path):
+    project = _generate(tmp_path)
+
+    result = CliRunner().invoke(
+        app, ["add", "aggregate", "Order", "--path", str(project)]
+    )
+
+    assert result.exit_code == 0, result.output
+    for path in (
+        "src/scaffolded/order/__init__.py",
+        "src/scaffolded/order/aggregate.py",
+        "src/scaffolded/order/commands.py",
+        "src/scaffolded/order/events.py",
+        "src/scaffolded/order/command_handlers.py",
+    ):
+        assert f"create {path}" in result.output, (
+            f"preview did not name a create for {path}:\n{result.output}"
+        )
+
+
+def test_add_writes_nothing(tmp_path):
+    project = _generate(tmp_path)
+
+    before = _snapshot(project)
+    result = CliRunner().invoke(
+        app, ["add", "aggregate", "Order", "--path", str(project)]
+    )
+    after = _snapshot(project)
+
+    assert result.exit_code == 0, result.output
+    assert before == after, "protean add must not touch the project tree"
+
+
+def test_planned_slice_loads_and_registers_under_traversal(tmp_path):
+    """Acceptance #3: the planned files register when the domain inits with
+    traversal on. Materialize the plan, init the real domain, and require the new
+    elements to be in the registry by name."""
+    project = _generate(tmp_path)
+    plan = plan_add_slice(str(project), "aggregate", "Order")
+    _materialize(project, plan)
+
+    completed = subprocess.run(
+        [sys.executable, "-c", _INIT_AND_LIST],
+        cwd=project,
+        env=_subprocess_env(project),
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, (
+        "the domain must init with the planned slice in place:\n"
+        f"{completed.stdout}\n{completed.stderr}"
+    )
+    line = next(
+        (ln for ln in completed.stdout.splitlines() if ln.startswith("NAMES:")),
+        "",
+    )
+    registered = set(line[len("NAMES:") :].split(","))
+    for element in ("Order", "CreateOrder", "OrderCreated"):
+        assert element in registered, (
+            f"{element} did not register under traversal; registered: "
+            f"{sorted(registered)}"
+        )
+
+
+def test_unsupported_type_exits_nonzero_and_writes_nothing(tmp_path):
+    project = _generate(tmp_path)
+
+    before = _snapshot(project)
+    result = CliRunner().invoke(app, ["add", "widget", "Foo", "--path", str(project)])
+    after = _snapshot(project)
+
+    assert result.exit_code != 0
+    assert "aggregate" in result.output, (
+        f"the error should name aggregate as the supported type:\n{result.output}"
+    )
+    assert before == after, "a rejected add must not touch the project tree"

--- a/tests/cli/test_add.py
+++ b/tests/cli/test_add.py
@@ -74,23 +74,29 @@ def _subprocess_env(project: Path) -> dict[str, str]:
     return env
 
 
-_INIT_AND_EXERCISE = (
-    "import sys; sys.path.insert(0, 'src')\n"
-    "from scaffolded.domain import scaffolded as domain\n"
-    "domain.init()\n"
-    "names = sorted(domain.registry._elements_by_name.keys())\n"
-    "print('NAMES:' + ','.join(names))\n"
-    # Drive the slice end to end: process the command through the generated
-    # handler (which calls the generated `create` factory), then fetch the
-    # persisted aggregate back. command_processing is sync in the scaffold, so
-    # process runs the handler inline and returns the aggregate id.
-    "from scaffolded.order.commands import CreateOrder\n"
-    "from scaffolded.order.aggregate import Order\n"
-    "with domain.domain_context():\n"
-    "    order_id = domain.process(CreateOrder(name='Widget'))\n"
-    "    fetched = domain.repository_for(Order).get(order_id)\n"
-    "    print('PERSISTED:' + fetched.name)\n"
-)
+def _init_and_exercise(class_name: str, slug: str) -> str:
+    """The script the traversal test runs inside the generated project: init the
+    domain, print the registry, then drive the planned slice end to end.
+
+    Takes the slice's class name and slug so a multi-word aggregate is exercised
+    through its own module path (``order_item/``) and class (``OrderItem``)."""
+    return (
+        "import sys; sys.path.insert(0, 'src')\n"
+        "from scaffolded.domain import scaffolded as domain\n"
+        "domain.init()\n"
+        "names = sorted(domain.registry._elements_by_name.keys())\n"
+        "print('NAMES:' + ','.join(names))\n"
+        # Drive the slice end to end: process the command through the generated
+        # handler (which calls the generated `create` factory), then fetch the
+        # persisted aggregate back. command_processing is sync in the scaffold, so
+        # process runs the handler inline and returns the aggregate id.
+        f"from scaffolded.{slug}.commands import Create{class_name}\n"
+        f"from scaffolded.{slug}.aggregate import {class_name}\n"
+        "with domain.domain_context():\n"
+        f"    new_id = domain.process(Create{class_name}(name='Widget'))\n"
+        f"    fetched = domain.repository_for({class_name}).get(new_id)\n"
+        "    print('PERSISTED:' + fetched.name)\n"
+    )
 
 
 def test_add_previews_the_five_create_operations(tmp_path):
@@ -126,7 +132,18 @@ def test_add_writes_nothing(tmp_path):
     assert before == after, "protean add must not touch the project tree"
 
 
-def test_planned_slice_loads_and_registers_under_traversal(tmp_path):
+@pytest.mark.parametrize(
+    ("name", "class_name", "slug"),
+    [
+        ("Order", "Order", "order"),
+        # A multi-word name: the slice lands in `order_item/` and the traversal
+        # has to discover it there under the derived class names.
+        ("order_item", "OrderItem", "order_item"),
+    ],
+)
+def test_planned_slice_loads_and_registers_under_traversal(
+    tmp_path, name, class_name, slug
+):
     """Acceptance #3: the planned files register when the domain inits with
     traversal on, and the slice actually works. Materialize the plan, init the
     real domain, require all four elements in the registry by name, then process a
@@ -137,11 +154,11 @@ def test_planned_slice_loads_and_registers_under_traversal(tmp_path):
     command exercises the factory and the handler body, so those regressions fail
     here."""
     project = _generate(tmp_path)
-    plan = plan_add_slice(str(project), "aggregate", "Order")
+    plan = plan_add_slice(str(project), "aggregate", name)
     _materialize(project, plan)
 
     completed = subprocess.run(
-        [sys.executable, "-c", _INIT_AND_EXERCISE],
+        [sys.executable, "-c", _init_and_exercise(class_name, slug)],
         cwd=project,
         env=_subprocess_env(project),
         capture_output=True,
@@ -157,7 +174,12 @@ def test_planned_slice_loads_and_registers_under_traversal(tmp_path):
         "",
     )
     registered = set(line[len("NAMES:") :].split(","))
-    for element in ("Order", "CreateOrder", "OrderCreated", "OrderCommandHandler"):
+    for element in (
+        class_name,
+        f"Create{class_name}",
+        f"{class_name}Created",
+        f"{class_name}CommandHandler",
+    ):
         assert element in registered, (
             f"{element} did not register under traversal; registered: "
             f"{sorted(registered)}"

--- a/tests/scaffold/test_add_plan.py
+++ b/tests/scaffold/test_add_plan.py
@@ -140,6 +140,85 @@ def test_lowercase_name_still_yields_pascal_case_class_and_lowercase_slug(tmp_pa
     assert "class Order:" in _content_for(plan, "aggregate.py")
 
 
+@pytest.mark.parametrize("name", ["order_item", "orderItem", "OrderItem"])
+def test_multi_word_name_yields_pascal_case_class_and_snake_case_slug(tmp_path, name):
+    """A multi-word name splits into words, whichever way it is written. The class
+    is the PascalCase join and the slug the snake_case one, so ``order_item`` does
+    not become ``Order_item`` and ``OrderItem`` does not land in ``orderitem/``."""
+    project = _write_project(tmp_path / "proj", "myproj", "myproj")
+
+    plan = plan_add_slice(str(project), "aggregate", name)
+
+    paths = [op.path for op in plan.operations]
+    assert paths == [
+        "src/myproj/order_item/__init__.py",
+        "src/myproj/order_item/aggregate.py",
+        "src/myproj/order_item/commands.py",
+        "src/myproj/order_item/events.py",
+        "src/myproj/order_item/command_handlers.py",
+    ]
+
+    assert "class OrderItem:" in _content_for(plan, "aggregate.py")
+    assert "class CreateOrderItem:" in _content_for(plan, "commands.py")
+    assert "class OrderItemCreated:" in _content_for(plan, "events.py")
+    assert "class OrderItemCommandHandler:" in _content_for(plan, "command_handlers.py")
+
+    # The slug is the variable name and the id-field prefix inside the slice.
+    assert "order_item = cls(name=name)" in _content_for(plan, "aggregate.py")
+    assert "order_item_id: str" in _content_for(plan, "events.py")
+    assert "def handle_create_order_item(" in _content_for(plan, "command_handlers.py")
+
+    for op in plan.operations:
+        compile(op.content, op.path, "exec")
+
+
+def test_all_spellings_of_a_multi_word_name_plan_the_same_slice(tmp_path):
+    """The three spellings are the same slice, file for file, so re-running ``add``
+    with a different spelling cannot plan a second copy of it."""
+    project = _write_project(tmp_path / "proj", "myproj", "myproj")
+
+    plans = [
+        plan_add_slice(str(project), "aggregate", name)
+        for name in ("order_item", "orderItem", "OrderItem")
+    ]
+
+    rendered = [[(op.path, op.content) for op in plan.operations] for plan in plans]
+    assert rendered[0] == rendered[1] == rendered[2]
+    assert {plan.description for plan in plans} == {plans[0].description}
+
+
+def test_acronym_survives_into_the_class_name(tmp_path):
+    """A run of capitals is one word, so ``HTTPServer`` stays ``HTTPServer`` and
+    only its slug is split."""
+    project = _write_project(tmp_path / "proj", "myproj", "myproj")
+
+    plan = plan_add_slice(str(project), "aggregate", "HTTPServer")
+
+    assert plan.operations[0].path == "src/myproj/http_server/__init__.py"
+    assert "class HTTPServer:" in _content_for(plan, "aggregate.py")
+
+
+def test_name_with_no_words_raises(tmp_path):
+    """``_`` is a valid identifier but has no words, so it derives no class name."""
+    project = _write_project(tmp_path / "proj", "myproj", "myproj")
+
+    with pytest.raises(AddPlanError) as exc_info:
+        plan_add_slice(str(project), "aggregate", "_")
+
+    assert "letter or digit" in str(exc_info.value)
+
+
+def test_name_whose_words_are_not_identifiers_raises(tmp_path):
+    """``_2fa`` is a valid identifier, but dropping the leading underscore leaves
+    ``2fa``, which cannot be a class or a variable name."""
+    project = _write_project(tmp_path / "proj", "myproj", "myproj")
+
+    with pytest.raises(AddPlanError) as exc_info:
+        plan_add_slice(str(project), "aggregate", "_2fa")
+
+    assert "2fa" in str(exc_info.value)
+
+
 def test_domain_variable_is_read_from_domain_py_not_assumed(tmp_path):
     """When ``domain.py`` binds a variable that is not the package name, the
     decorators and the import use that variable. Proves the AST resolution and
@@ -204,6 +283,7 @@ def test_invalid_name_raises(tmp_path):
         "None",  # class `None` -> `class None:` does not compile
         "True",
         "none",  # PascalCase is `None`, still a keyword
+        "class_",  # a trailing underscore is not a word, so the slug is `class`
     ],
 )
 def test_keyword_name_raises(tmp_path, name):

--- a/tests/scaffold/test_add_plan.py
+++ b/tests/scaffold/test_add_plan.py
@@ -184,8 +184,52 @@ def test_unsupported_element_type_raises(tmp_path):
 def test_invalid_name_raises(tmp_path):
     project = _write_project(tmp_path / "proj", "myproj", "myproj")
 
-    with pytest.raises(AddPlanError):
+    with pytest.raises(AddPlanError) as exc_info:
         plan_add_slice(str(project), "aggregate", "not a name")
+
+    # The message must name the input and explain what a valid name is.
+    message = str(exc_info.value)
+    assert "not a name" in message
+    assert "identifier" in message
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "class",  # slug `class` -> `class = cls(...)` does not compile
+        "for",
+        "import",
+        "return",
+        "lambda",
+        "None",  # class `None` -> `class None:` does not compile
+        "True",
+        "none",  # PascalCase is `None`, still a keyword
+    ],
+)
+def test_keyword_name_raises(tmp_path, name):
+    """A Python keyword passes ``str.isidentifier`` but cannot be a class or
+    variable name, so the guard must reject it before it emits code that does not
+    compile (acceptance #3: the planned content is valid Python)."""
+    project = _write_project(tmp_path / "proj", "myproj", "myproj")
+
+    with pytest.raises(AddPlanError) as exc_info:
+        plan_add_slice(str(project), "aggregate", name)
+
+    assert "keyword" in str(exc_info.value)
+
+
+def test_every_planned_file_compiles_for_an_awkward_name(tmp_path):
+    """Guards the keyword class directly: any name the planner accepts produces
+    content that compiles. ``match`` is a soft keyword and a legitimate name, so
+    it is planned; its files must still be valid Python."""
+    project = _write_project(tmp_path / "proj", "myproj", "myproj")
+
+    plan = plan_add_slice(str(project), "aggregate", "match")
+
+    assert len(plan.operations) > 0
+    for op in plan.operations:
+        assert isinstance(op, CreateFileOperation)
+        compile(op.content, op.path, "exec")
 
 
 def test_no_src_directory_raises(tmp_path):
@@ -232,6 +276,19 @@ def test_domain_py_without_domain_call_raises(tmp_path):
     package_dir = tmp_path / "proj" / "src" / "myproj"
     package_dir.mkdir(parents=True)
     (package_dir / "domain.py").write_text("x = 1\n")
+
+    with pytest.raises(AddPlanError) as exc_info:
+        plan_add_slice(str(tmp_path / "proj"), "aggregate", "Order")
+
+    assert "Domain" in str(exc_info.value)
+
+
+def test_domain_py_with_non_name_call_target_raises(tmp_path):
+    """A call whose function is itself a call (neither a Name nor an Attribute) is
+    not a Domain construction; the resolver rejects it rather than crashing."""
+    package_dir = tmp_path / "proj" / "src" / "myproj"
+    package_dir.mkdir(parents=True)
+    (package_dir / "domain.py").write_text("app = make_factory()(name='x')\n")
 
     with pytest.raises(AddPlanError) as exc_info:
         plan_add_slice(str(tmp_path / "proj"), "aggregate", "Order")

--- a/tests/scaffold/test_add_plan.py
+++ b/tests/scaffold/test_add_plan.py
@@ -260,6 +260,20 @@ def test_unparseable_domain_py_raises(tmp_path):
     assert "domain.py" in str(exc_info.value)
 
 
+def test_domain_py_that_is_not_utf8_raises(tmp_path):
+    """A domain.py in some other encoding fails as a usage error, not a traceback."""
+    package_dir = tmp_path / "proj" / "src" / "myproj"
+    package_dir.mkdir(parents=True)
+    (package_dir / "domain.py").write_bytes(
+        'myproj = Domain(name="caf\u00e9")\n'.encode("latin-1")
+    )
+
+    with pytest.raises(AddPlanError) as exc_info:
+        plan_add_slice(str(tmp_path / "proj"), "aggregate", "Order")
+
+    assert "domain.py" in str(exc_info.value)
+
+
 def test_more_than_one_package_raises(tmp_path):
     project = _write_project(tmp_path / "proj", "alpha", "alpha")
     # A second composition root under src/ makes the target ambiguous.

--- a/tests/scaffold/test_add_plan.py
+++ b/tests/scaffold/test_add_plan.py
@@ -1,0 +1,239 @@
+"""Tests for the ``add`` planner: it plans a create-only aggregate slice and
+touches no files.
+
+The planner is pure. It resolves a project from an on-disk ``src/<package>/domain.py``
+by AST alone (no import), then returns a :class:`ChangePlan` of
+:class:`CreateFileOperation`\\ s in the ADR-0030 canonical layout.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from protean.scaffold import ChangePlan, CreateFileOperation
+from protean.scaffold.add_plan import AddPlanError, plan_add_slice
+
+pytestmark = pytest.mark.no_test_domain
+
+
+def _write_project(root: Path, package: str, domain_var: str) -> Path:
+    """Lay down the minimum of a canonical project: ``src/<package>/domain.py``
+    plus an empty ``shared/`` sibling. Returns the project root."""
+    package_dir = root / "src" / package
+    package_dir.mkdir(parents=True)
+    (package_dir / "__init__.py").write_text("")
+    (package_dir / "domain.py").write_text(
+        "from protean.domain import Domain\n\n"
+        f'{domain_var} = Domain(name="{package}")\n'
+    )
+    shared = package_dir / "shared"
+    shared.mkdir()
+    (shared / "__init__.py").write_text("")
+    return root
+
+
+def _snapshot(root: Path) -> dict[str, bytes]:
+    """Map every file under *root* to its bytes, so a before/after compare can
+    prove the planner wrote nothing."""
+    return {
+        str(path.relative_to(root)): path.read_bytes()
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+    }
+
+
+def test_plans_five_create_operations_at_canonical_paths(tmp_path):
+    project = _write_project(tmp_path / "proj", "myproj", "myproj")
+
+    plan = plan_add_slice(str(project), "aggregate", "Order")
+
+    assert isinstance(plan, ChangePlan)
+    assert len(plan.operations) > 0, "expected create operations, got none"
+    # Every op is a create; nothing edits or patches config.
+    assert all(isinstance(op, CreateFileOperation) for op in plan.operations)
+
+    paths = [op.path for op in plan.operations]
+    assert paths == [
+        "src/myproj/order/__init__.py",
+        "src/myproj/order/aggregate.py",
+        "src/myproj/order/commands.py",
+        "src/myproj/order/events.py",
+        "src/myproj/order/command_handlers.py",
+    ]
+
+
+def test_planner_writes_nothing(tmp_path):
+    project = _write_project(tmp_path / "proj", "myproj", "myproj")
+
+    before = _snapshot(project)
+    plan_add_slice(str(project), "aggregate", "Order")
+    after = _snapshot(project)
+
+    assert before == after, "the planner must not touch the filesystem"
+
+
+def test_every_planned_file_compiles(tmp_path):
+    project = _write_project(tmp_path / "proj", "myproj", "myproj")
+
+    plan = plan_add_slice(str(project), "aggregate", "Order")
+
+    assert len(plan.operations) > 0
+    for op in plan.operations:
+        assert isinstance(op, CreateFileOperation)
+        # Raises SyntaxError if the generated content is not valid Python.
+        compile(op.content, op.path, "exec")
+
+
+def test_package_init_is_side_effect_free(tmp_path):
+    """ADR-0030 rule 4: the slice's ``__init__.py`` carries a docstring only, no
+    imports. A re-export there would risk the traversal cycle from #1316."""
+    project = _write_project(tmp_path / "proj", "myproj", "myproj")
+
+    plan = plan_add_slice(str(project), "aggregate", "Order")
+    init_op = next(
+        op
+        for op in plan.operations
+        if isinstance(op, CreateFileOperation) and op.path.endswith("order/__init__.py")
+    )
+
+    for line in init_op.content.splitlines():
+        stripped = line.strip()
+        assert not stripped.startswith("import "), f"unexpected import: {line!r}"
+        assert not stripped.startswith("from "), f"unexpected import: {line!r}"
+
+
+def _content_for(plan: ChangePlan, suffix: str) -> str:
+    op = next(
+        op
+        for op in plan.operations
+        if isinstance(op, CreateFileOperation) and op.path.endswith(suffix)
+    )
+    return op.content
+
+
+def test_names_follow_the_example_slice(tmp_path):
+    project = _write_project(tmp_path / "proj", "myproj", "myproj")
+
+    plan = plan_add_slice(str(project), "aggregate", "Order")
+
+    aggregate = _content_for(plan, "aggregate.py")
+    assert "class Order:" in aggregate
+    assert "from myproj.domain import myproj" in aggregate
+    assert "@myproj.aggregate" in aggregate
+
+    assert "class CreateOrder:" in _content_for(plan, "commands.py")
+    assert "class OrderCreated:" in _content_for(plan, "events.py")
+    assert "class OrderCommandHandler:" in _content_for(plan, "command_handlers.py")
+
+
+def test_lowercase_name_still_yields_pascal_case_class_and_lowercase_slug(tmp_path):
+    """A lower-cased input name produces a PascalCase class and a lower-case dir,
+    so ``order`` and ``Order`` both land in ``order/`` with ``class Order``."""
+    project = _write_project(tmp_path / "proj", "myproj", "myproj")
+
+    plan = plan_add_slice(str(project), "aggregate", "order")
+
+    paths = [op.path for op in plan.operations]
+    assert paths[0] == "src/myproj/order/__init__.py"
+    assert "class Order:" in _content_for(plan, "aggregate.py")
+
+
+def test_domain_variable_is_read_from_domain_py_not_assumed(tmp_path):
+    """When ``domain.py`` binds a variable that is not the package name, the
+    decorators and the import use that variable. Proves the AST resolution and
+    rules out a hardcoded package-name assumption."""
+    project = _write_project(tmp_path / "proj", "orders", "subdomain")
+
+    plan = plan_add_slice(str(project), "aggregate", "Order")
+
+    aggregate = _content_for(plan, "aggregate.py")
+    assert "@subdomain.aggregate" in aggregate
+    assert "from orders.domain import subdomain" in aggregate
+    # The package directory (import root) is still `orders`, the directory name.
+    assert plan.operations[0].path.startswith("src/orders/order/")
+
+
+def test_resolves_annotated_and_attribute_form_domain_construction(tmp_path):
+    """The resolver reads ``app: Domain = protean.Domain(...)`` too: an annotated
+    assignment whose value is the attribute form ``<module>.Domain(...)``, not just
+    the bare ``app = Domain(...)`` the scaffold emits."""
+    package_dir = tmp_path / "proj" / "src" / "myproj"
+    package_dir.mkdir(parents=True)
+    (package_dir / "domain.py").write_text(
+        "import protean\nfrom protean.domain import Domain\n\n"
+        'app: Domain = protean.Domain(name="myproj")\n'
+    )
+
+    plan = plan_add_slice(str(tmp_path / "proj"), "aggregate", "Order")
+
+    assert "@app.aggregate" in _content_for(plan, "aggregate.py")
+    assert "from myproj.domain import app" in _content_for(plan, "aggregate.py")
+
+
+def test_unsupported_element_type_raises(tmp_path):
+    project = _write_project(tmp_path / "proj", "myproj", "myproj")
+
+    with pytest.raises(AddPlanError) as exc_info:
+        plan_add_slice(str(project), "widget", "Foo")
+
+    assert "aggregate" in str(exc_info.value)
+
+
+def test_invalid_name_raises(tmp_path):
+    project = _write_project(tmp_path / "proj", "myproj", "myproj")
+
+    with pytest.raises(AddPlanError):
+        plan_add_slice(str(project), "aggregate", "not a name")
+
+
+def test_no_src_directory_raises(tmp_path):
+    with pytest.raises(AddPlanError) as exc_info:
+        plan_add_slice(str(tmp_path), "aggregate", "Order")
+
+    assert "src" in str(exc_info.value)
+
+
+def test_no_domain_py_raises(tmp_path):
+    (tmp_path / "src").mkdir()
+
+    with pytest.raises(AddPlanError) as exc_info:
+        plan_add_slice(str(tmp_path), "aggregate", "Order")
+
+    assert "domain.py" in str(exc_info.value)
+
+
+def test_unparseable_domain_py_raises(tmp_path):
+    package_dir = tmp_path / "proj" / "src" / "myproj"
+    package_dir.mkdir(parents=True)
+    # A real syntax error, so ast.parse raises and the planner surfaces it.
+    (package_dir / "domain.py").write_text("def (:\n")
+
+    with pytest.raises(AddPlanError) as exc_info:
+        plan_add_slice(str(tmp_path / "proj"), "aggregate", "Order")
+
+    assert "domain.py" in str(exc_info.value)
+
+
+def test_more_than_one_package_raises(tmp_path):
+    project = _write_project(tmp_path / "proj", "alpha", "alpha")
+    # A second composition root under src/ makes the target ambiguous.
+    _write_project(project, "beta", "beta")
+
+    with pytest.raises(AddPlanError) as exc_info:
+        plan_add_slice(str(project), "aggregate", "Order")
+
+    message = str(exc_info.value)
+    assert "alpha" in message and "beta" in message
+
+
+def test_domain_py_without_domain_call_raises(tmp_path):
+    package_dir = tmp_path / "proj" / "src" / "myproj"
+    package_dir.mkdir(parents=True)
+    (package_dir / "domain.py").write_text("x = 1\n")
+
+    with pytest.raises(AddPlanError) as exc_info:
+        plan_add_slice(str(tmp_path / "proj"), "aggregate", "Order")
+
+    assert "Domain" in str(exc_info.value)


### PR DESCRIPTION
## Summary
- Adds `protean add <element-type> <name>`. It computes a create-only ChangePlan for one element slice and prints the preview. It writes nothing; applying a plan comes later.
- The only element type for now is `aggregate`, which plans a whole write-side vertical slice: the aggregate, its create command, its created event, and the command handler, at the canonical ADR-0030 paths under `src/<package>/<slug>/`.
- The planner resolves the project by AST-reading `src/<package>/domain.py`, so it picks up the real domain variable name without importing the project or its dependencies. Bad element type, bad name (including names that derive a Python keyword), and an unresolvable project all exit 2 with a message.

## Test plan
- [x] `pytest tests/scaffold/ tests/cli/test_add.py` (85 passed)
- [x] The planned slice is written to a temp project and loaded through `domain.init(traverse=True)`, checking the four elements register (`tests/cli/test_add.py:129`)
- [x] Every planned file is compiled with `compile()`, including for an awkward name (`tests/scaffold/test_add_plan.py:77,221`)
- [x] Both the planner and the CLI are checked to write nothing
- [x] `ruff check`, `ruff format --check`, `mypy --strict` clean
- [x] Patch coverage: 100% on `cli/add.py`, 99% on `scaffold/add_plan.py`

Closes #1340