### PR TITLE
Ship the versioned DX pack as package data in the protean wheel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,64 @@ jobs:
       - name: Ruff format check
         run: uv run ruff format --check
 
+  dx-pack:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    name: DX pack (clean install)
+    # Builds the wheel and installs it into a clean virtualenv that cannot see
+    # the source tree, then asserts the DX pack (src/protean/dx/pack) shipped as
+    # package data and is readable through the importlib.resources accessor. The
+    # unit suite reads the pack from the source tree; only a clean-install check
+    # proves the data survived the build into the wheel. Hatchling ships the pack
+    # with no build-config change (its packages target includes every file under
+    # src/protean), so this job guards against silent loss of that data: an
+    # uncommitted, deleted, or moved file.
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+
+      - name: Build wheel
+        run: uv build --wheel
+
+      - name: Install the wheel into a clean venv and read the pack
+        # `python -` reads the check from stdin, so sys.path[0] is the repo root,
+        # which has no top-level `protean` package to shadow the installed wheel.
+        run: |
+          python -m venv /tmp/pack-venv
+          /tmp/pack-venv/bin/pip install --upgrade pip
+          /tmp/pack-venv/bin/pip install dist/*.whl
+          # Explicit raises, not asserts: `python -O` would strip asserts, and a
+          # guard whose job is to fail loudly must not be optimizable away. The
+          # SKILL.md check covers every shipped skill, not just the first.
+          /tmp/pack-venv/bin/python - <<'PY'
+          import protean
+          from protean import dx
+
+          if dx.PACK_VERSION != protean.__version__: raise SystemExit("PACK_VERSION drifted from the framework version")
+
+          agents = dx.load_agents_source()
+          if not agents.strip(): raise SystemExit("AGENTS.md source is empty")
+
+          skills = dx.iter_skills()
+          if not skills: raise SystemExit("no skills shipped in the DX pack")
+
+          empty = [name for name in skills if not dx.read_pack_text(dx.SKILLS_DIR, name, dx.SKILL_FILE).strip()]
+          if empty: raise SystemExit(f"skills with an empty SKILL.md: {empty}")
+
+          print(f"DX pack OK: version={dx.PACK_VERSION}, skills={skills}")
+          PY
+
   # Publishes the docs via the GitHub Actions Pages pipeline (build the site,
   # then deploy the artifact) instead of `mkdocs gh-deploy` to the gh-pages
   # branch. The legacy branch-based Pages builder proved unreliable (builds

--- a/changes/1463.added.md
+++ b/changes/1463.added.md
@@ -1,0 +1,1 @@
+The `protean` wheel now bundles a versioned developer-experience pack (an AGENTS.md source and the teaching skills) as package data under `protean.dx`, read at runtime through `importlib.resources`. Because the pack ships in the same distribution, an agent always reads guidance that matches the installed framework version.

--- a/docs/adr/0039-dx-pack-ships-as-package-data.md
+++ b/docs/adr/0039-dx-pack-ships-as-package-data.md
@@ -1,0 +1,92 @@
+# ADR-0039: Ship the developer-experience pack as package data
+
+**Status:** Accepted
+
+**Date:** September 2026
+
+## Context
+
+A coding agent is only correct about Protean if it reasons about the version of
+the framework that is installed. The teaching skills and the agent instruction
+surface (AGENTS.md) describe an API that changes release to release. When that
+knowledge lives apart from the framework, the two drift: an agent reads guidance
+for one version while the code runs another, and the model reasons about an API
+that is no longer there.
+
+The developer-experience epic ships a body of agent-facing knowledge: an
+AGENTS.md source and a set of skills. It needs a home that couples it to the
+framework version by construction, a runtime read path that works whether the
+package is installed unpacked or zipped, and a guard that the data actually
+reaches the built wheel.
+
+Two existing data trees set the precedent. The `template/` copier tree and the
+IR JSON schemas under `ir/schema/` already ship as package data inside
+`protean` and are read at runtime. Hatchling includes them with no build
+configuration: its wheel target picks up every file under `src/protean/`,
+whatever its git status.
+
+## Decision
+
+We ship the pack as package data inside the `protean` wheel, under
+`src/protean/dx/pack/`. The pack travels in the same distribution as the code,
+so its version is the framework version and the two cannot drift.
+
+We read the pack through `importlib.resources`. The accessor lives in
+`protean.dx.pack` and is re-exported from `protean.dx`, so
+`protean.dx.load_agents_source()` and `protean.dx.pack_files()` reach the data.
+`importlib.resources` is the standard read path for package data and keeps
+working when `protean` is installed zipped. The accessor mirrors the shape of
+`protean.ir`: module-level constants (`PACK_VERSION`, `AGENTS_SOURCE`,
+`SKILLS_DIR`) and `load_*` helpers.
+
+We add no build configuration. Hatchling already ships every file under
+`src/protean/` through its `packages` target, proven by `template/` and
+`ir/schema/`. A CI job builds the wheel, installs it into a clean virtualenv
+that cannot see the source tree, and asserts the pack is importable and readable
+from the installed package. That job is the guard against silent loss of the
+data from the build.
+
+The pack's version is the framework version. `PACK_VERSION` resolves to
+`protean.__version__`, the framework's single version source. A consumer reads
+it to tell which framework version's guidance the pack carries, and
+`bump-my-version` moves it, so it stays in step with the content it labels. A hand-typed version
+constant would drift the day someone edits a skill and forgets to bump it.
+
+## Consequences
+
+The pack and the framework release together, so an agent reading the pack always
+sees guidance for the installed code. There is no second distribution to publish
+and no version pin between them.
+
+Reading through `importlib.resources` hands consumers a `Traversable`, which is
+the abstract resource interface rather than a filesystem `Path`. Code that needs
+a real path on disk has to materialize one. The file-projection engine that
+renders these files into a user's project (ADR-0037) reads text, so a
+`Traversable` is enough.
+
+The data files have to be committed so a clean checkout carries them. CI builds
+the wheel from a fresh checkout, which holds only committed content, so an
+uncommitted file drops out of that wheel with no error at build time. The
+clean-venv CI check catches that, and a deleted or moved file too, because it
+reads the pack from the installed wheel rather than the source tree.
+
+The wheel grows with the pack. The skills corpus is text, so the cost is small,
+and the coupling it buys is the point of the epic.
+
+## Alternatives Considered
+
+**A separate `protean-skills` distribution.** Publishing the pack as its own
+package on PyPI reintroduces the split it was meant to close: a user can install
+a skills version that does not match their framework version, and the drift is
+back. Shipping inside `protean` couples them by construction.
+
+**Reading with `Path(__file__).parent`.** The repo reads `ir/schema/` this way
+today, and it works for an unpacked install. It breaks when the package is
+installed zipped, because there is no file on disk to point `Path` at.
+`importlib.resources` covers both cases, so the DX layer adopts it and leaves the
+older read path where it is.
+
+**A `force-include` or `artifacts` entry in the build config.** Hatchling's
+default file selection already ships the pack, so an explicit build-config entry
+would add configuration that restates the default. The clean-venv check verifies
+the outcome without it.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -110,3 +110,4 @@ See `TEMPLATE.md` in the `adr/` directory for the ADR template.
 | [0036](0036-configurable-graceful-drain-window.md) | Configurable Graceful Drain Window |
 | [0037](0037-idempotent-file-projection.md) | Idempotent File Projection and the `dx` Lockfile |
 | [0038](0038-canonical-field-style-for-mypy-strict.md) | Canonical field-declaration style for mypy-strict domains |
+| [0039](0039-dx-pack-ships-as-package-data.md) | Ship the developer-experience pack as package data |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -442,6 +442,7 @@ nav:
       - adr/0036-configurable-graceful-drain-window.md
       - adr/0037-idempotent-file-projection.md
       - adr/0038-canonical-field-style-for-mypy-strict.md
+      - adr/0039-dx-pack-ships-as-package-data.md
     - Troubleshooting:
       - reference/troubleshooting.md
 

--- a/src/protean/dx/__init__.py
+++ b/src/protean/dx/__init__.py
@@ -1,15 +1,27 @@
 """Protean developer-experience (``dx``) substrate.
 
-Homes the machinery the ``protean dx`` CLI group consumes. It starts with the
-idempotent file-projection engine (:mod:`protean.dx.projection`), which writes
+Homes the machinery the ``protean dx`` CLI group consumes. The
+idempotent file-projection engine (:mod:`protean.dx.projection`) writes
 agent-facing files into a user's project and can re-write them without clobbering
-the user's own edits. This package is internal substrate for the ``dx`` command
-stage; it is side-effect free on import and adds nothing to top-level
-``protean``.
+the user's own edits. The versioned pack (:mod:`protean.dx.pack`) is the
+agent-facing knowledge those files carry, shipped as package data and read
+through ``importlib.resources``. This package is internal substrate for the
+``dx`` command stage; it is side-effect free on import and adds nothing to
+top-level ``protean``.
 """
 
 from __future__ import annotations
 
+from protean.dx.pack import (
+    AGENTS_SOURCE,
+    PACK_VERSION,
+    SKILL_FILE,
+    SKILLS_DIR,
+    iter_skills,
+    load_agents_source,
+    pack_files,
+    read_pack_text,
+)
 from protean.dx.projection import (
     LOCK_VERSION,
     ManagedRegionProjection,
@@ -28,7 +40,11 @@ from protean.dx.projection import (
 )
 
 __all__ = [
+    "AGENTS_SOURCE",
     "LOCK_VERSION",
+    "PACK_VERSION",
+    "SKILLS_DIR",
+    "SKILL_FILE",
     "ManagedRegionProjection",
     "Projection",
     "ProjectionConflict",
@@ -41,5 +57,9 @@ __all__ = [
     "StructuredJsonProjection",
     "apply_projection",
     "diff_projection",
+    "iter_skills",
+    "load_agents_source",
     "load_lock",
+    "pack_files",
+    "read_pack_text",
 ]

--- a/src/protean/dx/pack/AGENTS.md
+++ b/src/protean/dx/pack/AGENTS.md
@@ -1,0 +1,22 @@
+# Protean agent instructions
+
+This is the canonical AGENTS.md source that ships inside the `protean` package.
+It is version-coupled to the framework: a coding agent reading it always sees
+the guidance that matches the installed version.
+
+`protean dx install` renders this source into a project's `AGENTS.md`, the
+`CLAUDE.md` bridge, and the per-tool rule files. Until that command lands, the
+source is reachable through `protean.dx.load_agents_source()`.
+
+<!-- dx-pack-seed: this is a placeholder source; the full corpus lands with the
+developer-experience epic. -->
+
+## Working with Protean
+
+- Model the domain with the decorators on the `Domain` object: `@domain.aggregate`,
+  `@domain.entity`, `@domain.value_object`, `@domain.event`, `@domain.command`.
+- Keep one aggregate per transaction. Cross-aggregate consistency is eventual,
+  carried by events.
+- Put validation in the domain layer: field constraints, value-object invariants,
+  and aggregate invariants. The database stores state; it does not enforce the
+  business rules.

--- a/src/protean/dx/pack/__init__.py
+++ b/src/protean/dx/pack/__init__.py
@@ -50,9 +50,16 @@ def pack_files() -> Traversable:
 
 
 def read_pack_text(*parts: str) -> str:
-    """Read a text resource from the pack, addressed by its path parts."""
+    """Read a text resource from the pack, addressed by its path parts.
+
+    Each part is a single path segment. A segment that is empty, ``.`` or
+    ``..``, or that contains a path separator is rejected, so a caller cannot
+    read outside the pack on a filesystem install.
+    """
     resource = pack_files()
     for part in parts:
+        if not part or part in (".", "..") or "/" in part or "\\" in part:
+            raise ValueError(f"invalid pack path segment: {part!r}")
         resource = resource / part
     return resource.read_text(encoding="utf-8")
 

--- a/src/protean/dx/pack/__init__.py
+++ b/src/protean/dx/pack/__init__.py
@@ -1,0 +1,76 @@
+"""The versioned developer-experience pack, shipped as package data.
+
+The pack is the canonical, version-coupled body of agent-facing knowledge that
+travels inside the ``protean`` wheel: an AGENTS.md source and the teaching
+skills. It lives in the same distribution as the framework, so an agent always
+reads guidance that matches the installed code.
+
+Read the pack at runtime through ``importlib.resources`` so it keeps working
+when ``protean`` is installed zipped. The accessor mirrors the shape of
+:mod:`protean.ir`: module-level constants plus ``load_*`` helpers. The pack's
+data files (``AGENTS.md``, ``skills/``) sit beside this module and are reached
+through :func:`pack_files`.
+"""
+
+from __future__ import annotations
+
+from importlib import resources
+from importlib.resources.abc import Traversable
+
+import protean
+
+__all__ = [
+    "AGENTS_SOURCE",
+    "PACK_VERSION",
+    "SKILLS_DIR",
+    "SKILL_FILE",
+    "iter_skills",
+    "load_agents_source",
+    "pack_files",
+    "read_pack_text",
+]
+
+# The pack ships inside the wheel, so its version is the framework version. A
+# consumer stamps this to tell which framework version's guidance the pack
+# carries. ``protean.__version__`` is the framework's single version source,
+# moved mechanically by bump-my-version, so the stamp stays in step with the
+# content it labels.
+PACK_VERSION = protean.__version__
+
+# Well-known names within the pack: the AGENTS.md source and the skills
+# directory sit at the pack root; each skill directory holds a SKILL.md.
+AGENTS_SOURCE = "AGENTS.md"
+SKILLS_DIR = "skills"
+SKILL_FILE = "SKILL.md"
+
+
+def pack_files() -> Traversable:
+    """Return the pack root as an ``importlib.resources`` traversable."""
+    return resources.files(__name__)
+
+
+def read_pack_text(*parts: str) -> str:
+    """Read a text resource from the pack, addressed by its path parts."""
+    resource = pack_files()
+    for part in parts:
+        resource = resource / part
+    return resource.read_text(encoding="utf-8")
+
+
+def load_agents_source() -> str:
+    """Return the packaged AGENTS.md source text."""
+    return read_pack_text(AGENTS_SOURCE)
+
+
+def iter_skills() -> list[str]:
+    """Return the names of the skills bundled in the pack, sorted.
+
+    A skill is a directory under ``skills/`` that holds a ``SKILL.md``. Any
+    other entry (a stray file, or a directory without a manifest) is ignored.
+    """
+    skills_root = pack_files() / SKILLS_DIR
+    return sorted(
+        child.name
+        for child in skills_root.iterdir()
+        if child.is_dir() and (child / SKILL_FILE).is_file()
+    )

--- a/src/protean/dx/pack/skills/protean-overview/SKILL.md
+++ b/src/protean/dx/pack/skills/protean-overview/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: protean-overview
+description: Orient a coding agent to a Protean domain before it writes code. Explains the core building blocks (aggregates, entities, value objects, events, commands, handlers) and the rules that hold across them. Use when starting work in a Protean project, when unsure which element to reach for, or when the user asks "how is a Protean domain put together".
+license: Apache-2.0
+compatibility: Requires Python 3.11+, protean framework
+metadata:
+  author: proteanhq
+  version: "0.1"
+  category: orientation
+---
+
+# Protean overview
+
+<!-- dx-pack-seed: minimal seed skill; the full teaching corpus lands with the
+developer-experience epic. -->
+
+Protean is a domain-driven framework. A domain is a registry of elements you
+declare with decorators on a `Domain` object.
+
+## Building blocks
+
+- **Aggregate** (`@domain.aggregate`): the root entity of a consistency
+  boundary. It owns its child entities and value objects and enforces the
+  invariants that must hold whenever it changes.
+- **Entity** (`@domain.entity`): an object with identity that lives inside an
+  aggregate and is reached through it.
+- **Value object** (`@domain.value_object`): an immutable value with no
+  identity, compared by its attributes.
+- **Event** (`@domain.event`): a record of something that happened. An
+  aggregate raises one with `self.raise_(...)`.
+- **Command** (`@domain.command`): an intent to change state, processed by a
+  command handler.
+- **Handlers** (`@domain.command_handler`, `@domain.event_handler`): load an
+  aggregate, invoke a method on it, and persist the result.
+
+## Rules that hold across elements
+
+- One aggregate changes per transaction. Consistency between aggregates is
+  eventual, carried by events.
+- Business rules live in the domain layer: field constraints, value-object
+  invariants, and aggregate invariants.
+- An aggregate has a single identity. Composite keys have no place in the model.

--- a/tests/dx/test_pack.py
+++ b/tests/dx/test_pack.py
@@ -1,0 +1,59 @@
+"""Tests for the DX pack accessor (``protean.dx``).
+
+These read the pack from the source tree. The clean-venv wheel check in CI
+proves the same resources survive the build into an installed wheel.
+"""
+
+import protean
+from protean import dx
+from protean.dx import pack
+
+
+def test_pack_version_is_the_framework_version():
+    # The pack ships inside the wheel, so its version is the framework version.
+    assert protean.__version__ == dx.PACK_VERSION
+    assert dx.PACK_VERSION
+
+
+def test_pack_files_returns_the_pack_root():
+    root = dx.pack_files()
+
+    assert (root / dx.AGENTS_SOURCE).is_file()
+    assert (root / dx.SKILLS_DIR).is_dir()
+
+
+def test_load_agents_source_returns_seed_content():
+    text = dx.load_agents_source()
+
+    assert "Protean agent instructions" in text
+    assert "dx-pack-seed" in text
+
+
+def test_read_pack_text_reads_a_nested_resource():
+    text = dx.read_pack_text(dx.SKILLS_DIR, "protean-overview", dx.SKILL_FILE)
+
+    assert "name: protean-overview" in text
+
+
+def test_iter_skills_lists_the_seed_skill():
+    skills = dx.iter_skills()
+
+    assert len(skills) > 0, "Expected at least the seed skill in the DX pack"
+    assert "protean-overview" in skills
+
+
+def test_iter_skills_lists_skill_dirs_only_and_sorts(tmp_path, monkeypatch):
+    # The seed pack has a single valid skill, so it cannot exercise the filter
+    # or the sort. Point the accessor at a fake pack root with two skills
+    # (created out of alphabetical order), a stray file, and a stray directory
+    # with no SKILL.md; only the two skills count, and they come back sorted.
+    skills_root = tmp_path / pack.SKILLS_DIR
+    for name in ("beta", "alpha"):
+        (skills_root / name).mkdir(parents=True)
+        (skills_root / name / pack.SKILL_FILE).write_text("# skill", encoding="utf-8")
+    (skills_root / "README.md").write_text("not a skill", encoding="utf-8")
+    (skills_root / "__pycache__").mkdir()  # a directory, but no SKILL.md
+
+    monkeypatch.setattr(pack, "pack_files", lambda: tmp_path)
+
+    assert pack.iter_skills() == ["alpha", "beta"]

--- a/tests/dx/test_pack.py
+++ b/tests/dx/test_pack.py
@@ -4,9 +4,15 @@ These read the pack from the source tree. The clean-venv wheel check in CI
 proves the same resources survive the build into an installed wheel.
 """
 
+import pytest
+
 import protean
 from protean import dx
 from protean.dx import pack
+
+# These tests read package data; they never touch a Domain, so skip the autouse
+# test_domain fixture and its initialization cost.
+pytestmark = pytest.mark.no_test_domain
 
 
 def test_pack_version_is_the_framework_version():
@@ -33,6 +39,13 @@ def test_read_pack_text_reads_a_nested_resource():
     text = dx.read_pack_text(dx.SKILLS_DIR, "protean-overview", dx.SKILL_FILE)
 
     assert "name: protean-overview" in text
+
+
+@pytest.mark.parametrize("bad", ["..", ".", "", "a/b", "a\\b"])
+def test_read_pack_text_rejects_path_traversal(bad):
+    # A caller must not be able to escape the pack with `..` or a separator.
+    with pytest.raises(ValueError):
+        dx.read_pack_text(dx.SKILLS_DIR, bad)
 
 
 def test_iter_skills_lists_the_seed_skill():


### PR DESCRIPTION
## Summary

Ships the seed of the developer-experience pack (epic #1460) as package data inside the `protean` wheel.

- New `src/protean/dx/pack/`: a versioned pack (an `AGENTS.md` source and one seed skill) read at runtime through `importlib.resources`. The accessor lives in `protean.dx.pack` and is re-exported from `protean.dx`, so an agent always reads guidance that matches the installed framework version.
- Accessor API: `PACK_VERSION` (resolves to `protean.__version__`), `load_agents_source()`, `read_pack_text()`, `iter_skills()`, `pack_files()`, plus the `AGENTS_SOURCE` / `SKILLS_DIR` / `SKILL_FILE` name constants.
- Seed content: a placeholder `AGENTS.md` source and one seed skill (`protean-overview`), authored here under Apache-2.0. The full corpus lands with later epic sub-issues (and the teaching skills are still blocked on relicensing).
- New CI job `dx-pack`: builds the wheel, installs it into a clean virtualenv that cannot see the source tree, and asserts the pack is importable and readable. Hatchling ships the data with no build-config change; this job guards against silent loss of it (an uncommitted, deleted, or moved file). The check uses explicit `raise SystemExit` (not `assert`, which `python -O` strips) and validates every shipped skill.
- ADR-0039 records the decision (package data + `importlib.resources`, version-coupled by shared distribution).

The `dx/` package already held the projection engine (ADR-0037); this adds the pack it renders as a `dx/pack/` subpackage rather than a fresh `dx/__init__.py` accessor as the issue text (written before that engine landed) suggested.

## Notes

- `iter_skills()` counts a skill as a directory holding a `SKILL.md`, so a stray directory (`__pycache__`, etc.) never leaks into the list.
- `PACK_VERSION` derives from `protean.__version__` rather than a hand-typed constant, so it can't drift when the pack content changes.

## Test plan

- [x] Core tests pass (`protean test`: 12963 passed)
- [x] `tests/dx/test_pack.py` (accessor behavior, incl. the `SKILL.md` filter and sort)
- [x] Clean-venv wheel install reads the pack (the `dx-pack` job, reproduced locally on the tracked-only tree)
- [x] 100% patch coverage
- [x] Full adapter suite (`Python 3.14 Full` leg) — no adapter/field surface in this change; runs in CI

Closes #1463
