### PR TITLE
Point the README and docs at the reference app and Shopstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,16 @@ if __name__ == "__main__":
             print(f"  - {entry.title}")
 ```
 
+## Reference application
+
+For a fuller picture, [`examples/reference_app/`](examples/reference_app/) runs
+the same blog domain behind a FastAPI app, with its own README covering setup
+and the routes it exposes.
+
+For a larger, multi-context example, see
+[proteanhq/shopstream](https://github.com/proteanhq/shopstream), a shopping
+platform built with Protean.
+
 ## Documentation
 
 Online docs are available at [https://docs.proteanhq.com](https://docs.proteanhq.com).

--- a/README.md
+++ b/README.md
@@ -117,8 +117,9 @@ if __name__ == "__main__":
 ## Reference application
 
 For a fuller picture, [`examples/reference_app/`](examples/reference_app/) runs
-the same blog domain behind a FastAPI app, with its own README covering setup
-and the routes it exposes.
+the same blog domain behind a FastAPI app. See
+[`app/README.md`](examples/reference_app/app/README.md) for setup and the
+routes it exposes.
 
 For a larger, multi-context example, see
 [proteanhq/shopstream](https://github.com/proteanhq/shopstream), a shopping

--- a/changes/1487.changed.md
+++ b/changes/1487.changed.md
@@ -1,0 +1,1 @@
+Pointed the README and docs at the runnable reference application and the Shopstream example. The README carries a "Reference application" section after Quick Start, and `docs/guides/getting-started/quickstart.md` and `docs/guides/index.md` both link to `examples/reference_app/` and `proteanhq/shopstream`, reference app first.

--- a/docs/guides/getting-started/quickstart.md
+++ b/docs/guides/getting-started/quickstart.md
@@ -156,6 +156,11 @@ Here is the complete example in a single file:
 
 ## Where to go next
 
+- [Reference application](https://github.com/proteanhq/protean/tree/main/examples/reference_app):
+  the same blog domain running behind a FastAPI app. Clone it and run it to
+  see the pieces wired together.
+- [Shopstream](https://github.com/proteanhq/shopstream): a larger, multi-context
+  example built with Protean.
 - [Set Up the Domain](../compose-a-domain/index.md): Learn about domain
   registration, initialization, and activation in depth.
 - [Define Domain Elements](../domain-definition/index.md): Explore aggregates,

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -76,6 +76,16 @@ with DDD and evolve later.
 
 </div>
 
+## Reference Application
+
+Want to see a complete application instead of isolated snippets?
+
+- [Reference application](https://github.com/proteanhq/protean/tree/main/examples/reference_app):
+  the blog domain from the [Quickstart](./getting-started/quickstart.md), running
+  behind a FastAPI app.
+- [Shopstream](https://github.com/proteanhq/shopstream): a larger, multi-context
+  example built with Protean.
+
 ## How Do I...?
 
 For the full task index, see [How Do I...?](../how-do-i.md).


### PR DESCRIPTION
## Summary
- README gets a "Reference application" section right after Quick Start, linking to `examples/reference_app/` and its `app/README.md`, then to `proteanhq/shopstream` as the larger multi-context example.
- `docs/guides/getting-started/quickstart.md` "Where to go next" and `docs/guides/index.md` both link to the reference app first, Shopstream second.
- Docs only. No code or API changes.

## Test plan
- [x] `uv run mkdocs build --strict` builds clean, so every new link resolves
- [x] `tests/examples/test_readme_quickstart_matches_source.py` and `test_docs_quickstart_matches_source.py` pass (23 passed) - the new README section sits outside the guarded Quick Start block
- [x] `examples/reference_app/app/README.md` exists and `proteanhq/shopstream` is public

Closes #1487